### PR TITLE
Include France csv for department Bouche du Rhone

### DIFF
--- a/data/france/bouche-du-rhone.csv
+++ b/data/france/bouche-du-rhone.csv
@@ -1,0 +1,4 @@
+obdb_id,name,brewery_type,street,address_2,address_3,city,state,county_province,postal_code,website_url,phone,country,longitude,latitude,tags
+biere-de-la-plaine-marseille,Bière de la Plaine,micro,16 Rue Saint Pierre,,,Marseille,Bouche du Rhône,,13006,https://brasseriedelaplaine.fr/,0491473254,France,5.387671540113359,43.293661922761046,
+la-minotte-marseille,La Minotte,micro,14 Blvd de l'Europe,,,Vitrolles,Bouche du Rhône,,13127,https://www.minot-brasserie.fr/,0465948644,France,5.24158474011782,43.4396502637125,
+zoumai-marseille,Zoumaï,micro,7 Cours Gouffé,,,Marseille,Bouche du Rhône,,13005,https://www.brasseriezoumai.fr/,0953870379,France,5.386584040113172,43.286428877281104,


### PR DESCRIPTION
France is a country with so-called 'Départements', which are the equivalent of states. Thus, this convention was chosen, and new CSV files could be created for different départements, as it is done for the US with states.