### PR TITLE
Remove duplicate data file. Confirmed with md5sum

### DIFF
--- a/data/Isle-of-man/middle.csv
+++ b/data/Isle-of-man/middle.csv
@@ -1,3 +1,0 @@
-id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-86531644-17de-4385-af71-82574666baa6,Bushy’s Brewery Ltd,micro,Mount Murray,,,Braddan,Middle,IM4 1JE,Isle of Man,+441624611101,https://www.bushys.com/,-4.55793831939852,54.1361028652688
-81916cf6-f84e-4480-a48c-93ff1e1322ad,Okell & Sons Ltd,micro,Old Castletown Road,,,Kewaigue,Middle,IM2 1QG,Isle of Man,+441624699400,https://www.okells.co.uk/,-4.506495,54.143623


### PR DESCRIPTION
I was cloning the main repository and received the following error:

```
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  'data/Isle-of-man/middle.csv'
  'data/isle-of-man/middle.csv'
```

Checking with md5sum showed the middle.csv file was identical so I suggest to remove the one with the capital "Isle" as it's not consistent with the other country names.