### PR TITLE
Add The Uncharted Brewing Company in Skåne, Sweden

### DIFF
--- a/data/sweden/skane.csv
+++ b/data/sweden/skane.csv
@@ -1,0 +1,2 @@
+name,brewery_type,address_1,city,state_province,postal_code,country,phone,website_url
+The Uncharted Brewing Company,micro,Bruksgatan 1,Eslöv,Skåne,241 39,Sweden,+46 (0) 76 788 6275,https://www.uncharted-brewing.com


### PR DESCRIPTION
This pull request adds The Uncharted Brewing Company located in Skåne, Sweden to the brewery database. The addition includes all relevant details and ensures the data is structured correctly.