### PR TITLE
Update Elk Horn Brewery URL

### DIFF
--- a/data/united-states/oregon.csv
+++ b/data/united-states/oregon.csv
@@ -96,7 +96,7 @@ b5449cda-10d5-4356-a60e-aca42e338b18,Dirt Road Brewing,planning,1301 Main St,,,P
 0fde773c-3201-4be7-b3ba-caf278efa4d3,Draper Brewing,micro,640 SE Jackson St,,,Roseburg,Oregon,97470,United States,5415805585,http://www.draperbrewing.com,-123.3445979,43.2084738
 fa16f1e8-3ee9-46e8-8c40-64a05947f6a2,Drinking Horse Brewing Company,micro,11517 SE Highway 212,,,Clackamas,Oregon,97015-9053,United States,5035648165,http://www.drinkinghorsebeer.com,-122.378124,45.4288733
 5e07c2a9-63b7-4c82-8167-13f350b811a6,Ecliptic Brewing,micro,825 N Cook St,,,Portland,Oregon,97227-1503,United States,5032658002,http://www.eclipticbrewing.com,-122.6751185,45.54737005
-1f6f2780-aea7-4d70-ae11-73f99ff0f760,Elk Horn Brewery,brewpub,686 E Broadway,,,Eugene,Oregon,97401-3340,United States,5415058356,http://www.elkhornbrewery.com,-123.0824349,44.04979409
+1f6f2780-aea7-4d70-ae11-73f99ff0f760,Elk Horn Brewery,brewpub,686 E Broadway,,,Eugene,Oregon,97401-3340,United States,5415058356,http://elkbeerhouse.com-us.com,-123.0824349,44.04979409
 d656f484-6477-4d44-8c47-7bf1bf309363,Evasion Brewing - Production Facility,micro,4230 NE Riverside Dr,,,McMinnville,Oregon,97128-8403,United States,5038355322,http://www.evasionbrewing.com,-123.1519619,45.22899995
 4a2c515d-7384-4406-8751-31133687eac1,Ex Novo Brewing Co,micro,2326 N Flint Ave,,,Portland,Oregon,97227-1905,United States,5038948251,http://www.exnovobrew.com,-122.6684147,45.54002045
 3cffc2c8-fe86-46cd-836b-55f860daa1d9,Falling Sky Brewing,brewpub,1334 Oak Aly,,,Eugene,Oregon,97401-3190,United States,5415057096,http://www.fallingskybrewing.com,-123.0921962,44.04539623


### PR DESCRIPTION
Per email, and did verify that the existing URL is spam and new URL is good:

Dear partner openbrewerydb.org,

It has come to our attention that your site still contains a hyperlink to our former domain. This domain is no longer managed by our organization and now carries content that could be misconstrued as affiliated with us, potentially leading to misinformation.

Please replace this outdated link with our official and active website:

Old URL: elkhornbrewery. com
New URL: elkbeerhouse.com-us.com

The old link appears in: https://openbrewerydb.org/breweries/United%20States/Oregon/Eugene

We appreciate your cooperation in promptly correcting this matter to maintain editorial accuracy.

Best regards,

Content & Communications Manager

Elk Beer House Group