### PR TITLE
Add 58 Portuguese breweries

### DIFF
--- a/data/portugal/acores.csv
+++ b/data/portugal/acores.csv
@@ -1,0 +1,2 @@
+id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Bela,micro,Rua Dr. José Bruno Carreiro 28,,,Angra do Heroísmo,Açores,9700-109,Portugal,,http://www.belacerveja.com,-27.2059155,38.6580373

--- a/data/portugal/aveiro.csv
+++ b/data/portugal/aveiro.csv
@@ -1,3 +1,10 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,12 Marias,micro,EN109 74,Fermelã,,Estarreja,Aveiro,3865-127,Portugal,,https://12marias.pt/,,
 863f291f-32aa-40df-8810-f37911e4ae6a,Cinco Chagas,micro,Rua das Cavadas N8,Vale do Boi,Moita,Anadia,Aveiro,3780-482,Portugal,,https://cincochagas.pt,,
+,Esperança,micro,R. Ten. Morais Sarmento 4,Antes,,Mealhada,Aveiro,3050-032,Portugal,,,-8.4712004,40.3831852
+,Lovecraft,brewpub,Rua das Fogaceiras 21,,,Aveiro,Aveiro,4520-200,Portugal,,,-8.5801323,40.9190867
+,Maldita,brewpub,Arco do Comércio 5,,,Aveiro,Aveiro,3800-213,Portugal,,,-8.6519605,40.6424514
+,Odemel,micro,Rua do Barão Nº 1580,,,Oliveira de Azeméis,Aveiro,3720-051,Portugal,,http://odemel.com,-8.5303189,40.8107508
+,Quatro Torres,micro,Pç Prof. Leão 13,,,Santa Maria da Feira,Aveiro,4520-173,Portugal,,https://quatrotorres.pt/,-8.5445296,40.9269082
+,Tough Love,brewpub,R. Guilherme Gomes Fernandes 5,,,Esmoriz,Aveiro,3800-197,Portugal,,http://www.toughlove.pt,-8.6506648,40.6431514
 bcc9f869-4952-4137-a502-5ac716b0a360,Vadia,brewpub,Rua Comendador Artur J. G. Barbosa nº576,,,Oliveira de Azemeis,Aveiro,3720-005,Portugal,+351 256 482 151,https://www.cervejavadia.pt,40.84133461624508,-8.434270976824363

--- a/data/portugal/braga.csv
+++ b/data/portugal/braga.csv
@@ -1,0 +1,4 @@
+id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Duura,micro,AVENIDA PROFESSOR MACHADO VILELA 14,,,Vila Verde,Braga,4730-721,Portugal,,https://duura.pt/,-8.4377666,41.6505417
+,Letra,brewpub,R. Dom Gonçalo Pereira 35,,,Vila Verde,Braga,4700-426,Portugal,,https://www.cervejaletra.pt,,
+,Marrafa,brewpub,R. Padre Domingos Alves Pereira 20,Jesufrei,,Vila Nova de Famalicão,Braga,4770-160,Portugal,,https://www.marrafa.pt/,-8.5068504,41.4572604

--- a/data/portugal/coimbra.csv
+++ b/data/portugal/coimbra.csv
@@ -1,2 +1,5 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Açor,micro,estrada nacional 17 n 620,Ramal Pombeiro,,Coimbra,Coimbra,3300-364,Portugal,,,,
+,Boazona,micro,Estrada Nacional N 2 801,Ventosa,,Coimbra,Coimbra,3350-029,Portugal,,,,
+,Epicura,micro,Av. João das Regras 46,Santa Clara,,Coimbra,Coimbra,3040-256,Portugal,,https://epicuracraftbeerhouse.eatbu.com/,-8.4328338,40.2041259
 58336544-2f7c-4a30-8e39-d796906b3055,Praxis,brewpub,Urbanização Quinta da Várzea,Lote 29,,Santa Clara,Coimbra,3040-320,Portugal,+351 911 922 162,https://www.beerpraxis.com,-8.432719275035133,40.1947511039474

--- a/data/portugal/faro.csv
+++ b/data/portugal/faro.csv
@@ -1,2 +1,7 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Al'Drabona,micro,Venda Nova,,,Silves,Faro,8300-054,Portugal,,,-8.4315428,37.1488678
 9da0a260-5b85-4490-824a-a397446c17dc,Algarve Rock Brewery,micro,Unidade 2B,Parque Vale da Venda,,Faro,Faro,8005-412,Portugal,+ 351 289 815 218,https://algarverock.com/,-7.972956207903116,37.06560087144406
+,Mania,micro,sítio da ameijeirinha,R. da Atalaia,,Lagos,Faro,8600-641,Portugal,,http://www.mania.beer/,,
+,Marafada,micro,Quinta dos Avós,,,Algoz,Faro,8365-083,Portugal,,,,
+,Nova Vida,brewpub,R. Frei Joaquim de Loulé n° 52 RC direita,,,Loulé,Faro,8100-579,Portugal,,http://novavida.pt,,
+,Novo Sul,micro,R. Estácio da Veiga 67,,,Albufeira,Faro,8200-668,Portugal,,http://www.novosul-brewing.pt,-8.2252961,37.1037312

--- a/data/portugal/lisboa.csv
+++ b/data/portugal/lisboa.csv
@@ -1,6 +1,19 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,A.M.O.,brewpub,R. Bernardim Ribeiro 53,,,Lisboa,Lisboa,1150-069,Portugal,,https://www.amobrewery.com/,-9.1731814,38.7965334
+,Aguarela,brewpub,R. Angelina Vidal 23,,,Lisboa,Lisboa,1170-017,Portugal,,,-9.130962,38.7222444
+,Bah!,brewpub,Tv. Afonso Sanches R. Afonso Sanches 6D,,,Cascais,Lisboa,2750-427,Portugal,,https://www.bahcraftbeer.com,,
+,Canil,brewpub,R. dos Douradores 133,,,Lisboa,Lisboa,1100-213,Portugal,,https://www.cervejacanil.com,-9.1371185,38.7123695
 e2610530-7819-4b89-80e6-86ea6fd7ff44,Deck Beer Garden,brewpub,Av. Aida 63,,,Estoril,Lisboa,2765-187,Portugal,+351 21 468 2661,https://www.facebook.com/deckbeerlab,-9.399351099325555,38.70428229725156
 27d18114-31bb-4baf-b330-71bcba80cc8a,"Dois Corvos Cervejeira, Lda.",micro,"Rua Capitão Leitão, 94",,,Lisboa,Lisboa,1950-052,Portugal,+351 211 331 093,https://www.doiscorvos.pt,-9.105483084696079,38.73826742792099
 2b5d9ce9-b8bd-4ece-98af-9d3eb6f5896f,Duque Brewpub,brewpub,Calçada do Duque nº49-51,,,Lisboa,Lisboa,1200-156,Portugal,,https://www.duquebrewpub.com,-9.142480929038104,38.713453267381496
+,Fermentage,brewpub,R. Cap. Leitão 1B,,,Lisboa,Lisboa,1950-049,Portugal,,https://www.fermentage.com,-9.1042905,38.73893
+,Hopsin,brewpub,Av. do Atlântico 1,,,Colares,Lisboa,2705-231,Portugal,,https://hopsin.pt,-9.4503945,38.8060541
+,Lispoa,brewpub,R. Nova do Desterro 29D,,,Lisboa,Lisboa,1150-241,Portugal,,http://www.lispoa.com,-9.1368856,38.7196469
 8f0626fd-2bfe-4f6f-a8eb-42dbe0a3984b,Mean Sardine,micro,58 Surf Building,Av. São Sebastião 36b,,Ericeira,Lisboa,2655-483,Portugal,,https://meansardine.pt,-9.417647159720808,38.98126500163354
+,Musa,brewpub,R. do Vale Formoso 9,,,Lisboa,Lisboa,1950-277,Portugal,,https://cervejamusa.com,-9.1015883,38.7448788
+,Oitava Colina,brewpub,R. Damasceno Monteiro 8A,,,Lisboa,Lisboa,1170-112,Portugal,,http://www.oitavacolina.pt,-9.1320184,38.7184372
+,Outro Lado,brewpub,Beco do Arco Escuro 1,,,Lisboa,Lisboa,1100-585,Portugal,,,-9.1340014,38.7093753
 0afdca59-0ed4-44dc-80d8-7a952e1924f6,Pato Brewing,micro,Centro Empresarial Sintra-Estoril I,Av. Pedro Álvares Cabral 177 ARMAZÉM G,Beloura,Sintra,Lisboa,2710-144,Portugal,+351 96 280 0847,http://www.patobrewing.com,-9.374911626904721,38.7592461545261
+,Piratas Cervejeiros,micro,Av. da República 101,,,Queluz,Lisboa,2745-209,Portugal,,,-9.2560215,38.7538661
+,Rafeira,micro,R. da Cordoaria 17,,,Sintra,Lisboa,2900-558,Portugal,,http://www.cervejarafeira.com,-8.9011375,38.5206705
+,Seleção 1927 / Browers,brewpub,Tv. Grilo 1,,,Lisboa,Lisboa,1950-145,Portugal,,https://www.superbockgroup.com/,-9.1061754,38.7321139

--- a/data/portugal/portalegre.csv
+++ b/data/portugal/portalegre.csv
@@ -1,2 +1,4 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
 11903890-96c3-4019-b526-6bb0eea6c08c,Barona Brewing Company,micro,EM1036-1 2,,,Santo António das Areias,Portalegre,7330-215,Portugal,+351 21 468 2661,https://www.cervejabarona.pt/,-7.337693604727156,39.43767892561163
+,Casa Do Penedo,micro,Rua Do Cimo Da Vinha 8,,,Portalegre,Portalegre,7300-658,Portugal,,,-7.4970149,39.3288067
+,Censurada,micro,R. do Cimo da Vinha 6,Fortios,,Portalegre,Portalegre,7300-658,Portugal,,http://www.cervejacensurada.com,-7.4970149,39.3288067

--- a/data/portugal/porto.csv
+++ b/data/portugal/porto.csv
@@ -1,3 +1,19 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Biltre,micro,Rua Trás do Maninho N.º 521,,,Porto,Porto,4405-794,Portugal,,,,
+,Burguesa,micro,R. Luís de Camões 36,,,Vila Nova de Gaia,Porto,4400-205,Portugal,,https://www.burguesa.pt,-8.6086058,41.1344857
+,Catraio,brewpub,R. de Cedofeita 256,,,Porto,Porto,4050-174,Portugal,,https://catraio.pt/,-8.6172992,41.1511077
+,Celta Endóvelico,brewpub,Rua dos Mártires da Liberdade 29,,,Porto,Porto,4050-360,Portugal,,,-8.6136704,41.1525056
+,Deuses do Malte,micro,R. de Soares dos Reis 1324,,,Vila Nova de Gaia,Porto,4430-240,Portugal,,,,
+,Dos Diabos,brewpub,R. de Pinto Bessa 122 Armazém 2,,,Porto,Porto,4300-427,Portugal,,http://www.dosdiabos.pt,-8.5887484,41.1498709
+,Fábrica da Picaria,micro,Rua da Picaria 72,,,Porto,Porto,4050-477,Portugal,,https://afabricadapicaria.pt,-8.6129025,41.1495339
+,FDS!,micro,R. Campo do Monte 218,,,Vila Nova de Gaia,Porto,4400-398,Portugal,,http://www.fds.beer,-8.5951599,41.0965752
+,Fidélis,micro,Av. Pedro Guedes 61,,,Penafiel,Porto,4560-452,Portugal,,,,
+,Gémea,micro,Av. Vasco da Gama 774,,,Vila Nova de Gaia,Porto,4430-247,Portugal,,,-8.5994732,41.1190341
+,Going Gremlin,micro,R. de Azevedo Coutinho 39,,,Porto,Porto,4100-100,Portugal,,https://www.going-gremlin.pt,-8.6467301,41.1613734
+,HopTrip,brewpub,R. Heróis de França 617,,,Matosinhos,Porto,4450-159,Portugal,,https://www.hoptrip.pt/,-8.6927612,41.1809124
+,Lupum,micro,R. Fontiela 207,,,Vila Nova de Gaia,Porto,4430-833,Portugal,,,-8.5455314,41.1068139
+,Madam Lindinha Lucas,micro,R. Henrique Bravo 7206,,,Porto,Porto,4465-165,Portugal,,,-8.6000588,41.1982569
 1c3768b5-cdcf-4b42-915a-0f99ad191b87,Nortada,brewpub,R. de Sá da Bandeira 210,,,Porto,Porto,4000-427,Portugal,+351 22 018 1000,https://cervejanortada.pt,-8.608164266696724,41.148109589962274
+,Pobeira,micro,RUA DE DONA MARIA I 426,,,Póvoa de Varzim,Porto,4490-538,Portugal,,http://www.cervejapobeira.pt,,
+,Post Scriptum,micro,R. Sra. da Alegria 10,,,Trofa,Porto,4745-033,Portugal,,http://www.postscriptumbrewery.com/,,
 3cec9f9a-adef-4536-9107-fb1f8324a088,"Sovina, Lda.",micro,"Rua Manuel Pinto de Azevedo, 65",Armazém 4 e 5,,Porto,Porto,4100-321,Portugal,+351 22 600 69 36,https://sovina.pt/,-8.645222959665363,41.17075782152705

--- a/data/portugal/santarem.csv
+++ b/data/portugal/santarem.csv
@@ -1,0 +1,4 @@
+id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Gloriana,micro,Rua Capitão Salgueiro Maia Nº 239,,,Santarém,Santarém,2120-230,Portugal,,,-8.691238,39.2553487
+,Rima,micro,R. Fonte da Igreja 34,São João da Ribeira,,Rio Maior,Santarém,2040-460,Portugal,,http://www.cervejarima.com,-8.8475133,39.2809754
+,Zidra,micro,Rua do Centro Industrial Tojal 205,,,Ferreira do Zêzere,Santarém,2240-135,Portugal,,https://zidra.pt/,,

--- a/data/portugal/setubal.csv
+++ b/data/portugal/setubal.csv
@@ -1,0 +1,3 @@
+id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Aldeana,micro,RUA BENTO DE JESUS CARAÇA 315 1º ESQ,,,Montijo,Setúbal,2870-134,Portugal,,,-8.9835395,38.7083159
+,Ophiussa,micro,Parque Industrial Sado Internacional,Pavilhão C 14,,Setúbal,Setúbal,2910-130,Portugal,,https://ophiussabrewing.com,-8.8162029,38.5419436

--- a/data/portugal/vila-real.csv
+++ b/data/portugal/vila-real.csv
@@ -1,0 +1,2 @@
+id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Cerveja Bila,micro,Pavilhão n.º5 do Lote n.º 158,Zona Industrial de Vila Real,,Vila Real,Vila Real,5000-082,Portugal,,http://www.cervejabila.pt,-7.7089429,41.2777911

--- a/data/portugal/viseu.csv
+++ b/data/portugal/viseu.csv
@@ -1,0 +1,3 @@
+id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
+,Mickas Craft Beer,micro,R. Conselheiro Morais Carvalho 43-45,,,Vouzela,Viseu,3670-261,Portugal,,,-8.1118229,40.7232347
+,OldFox,brewpub,R. Escura 46,,,Viseu,Viseu,3500-219,Portugal,,https://oldfoxcervejaria.pt/,-7.9101398,40.660136


### PR DESCRIPTION
Adds 58 breweries in Portugal, sourced from a dataset I maintain at
beerevents.pt and verified by hand.

### What's included
- **58 new breweries** across 12 districts
- **6 new district files:** `acores`, `braga`, `santarem`, `setubal`,
  `vila-real`, `viseu`
- **6 existing files extended:** `aveiro`, `coimbra`, `faro`, `lisboa`,
  `portalegre`, `porto`

### Data quality
- Every row has `name`, `brewery_type`, `address_1`, `city`,
  `state_province`, `postal_code` and `country`; all postal codes match
  the Portuguese `NNNN-NNN` format.
- `state_province` uses Portuguese district names, consistent with the
  existing files (e.g. `Lisboa`, not `Lisbon`).
- Breweries already in the dataset (Algarve Rock, Barona, Dois Corvos,
  Mean Sardine, Nortada, Praxis, Sovina, Vadia) were **excluded** to
  avoid duplicates.
- All `website_url` values were checked for reachability; dead domains
  were left blank rather than recorded.
- Coordinates for 44 of the 58 were geocoded from the full street
  address and postal code, then bounds-checked against the expected
  district. The remaining 14 are left blank rather than approximated.
- `id` is left blank for the maintainer workflow to populate.