### PR TITLE
Normalize addresses data in Germany

### DIFF
--- a/data/germany/baden-wurttemberg.csv
+++ b/data/germany/baden-wurttemberg.csv
@@ -6,7 +6,7 @@ id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_co
 f83d4bed-0760-4802-900e-c2ed6e874968,Adlerbrauerei Schmetzer,brewpub,3 Reubacher Straße,,,Wallhausen,Baden-Württemberg,74599,Germany,+49 7955 2234,https://adlerbrauerei-schmetzer.de/,10.11867,49.2347
 26147e1c-c0f7-40ae-8572-df23afe8e266,Albquell Bräuhaus,brewpub,6 Lindenplatz,,,Trochtelfingen,Baden-Württemberg,72818,Germany,+49 7124 733,http://www.albquell-brauhaus.de,9.2455955,48.3081319
 3345a490-cc70-449e-b037-939398bd0f25,Alpirsbacher Klosterbräu,brewpub,1 Marktplatz,,,Alpirsbach,Baden-Württemberg,72275,Germany,+49 7444 670,http://www.alpirsbacher.de,8.40305,48.34566
-ddd11477-dab1-4aae-a129-5b1a6248c3a9,Alte Werkstatt,brewpub,Luetzestr. 93,,,Weingarten (Baden),Baden-Württemberg,76356,Germany,+49 7244 8261,http://www.alte-werkstatt-bier.de,8.5313723,49.0533742
+ddd11477-dab1-4aae-a129-5b1a6248c3a9,Alte Werkstatt,brewpub,Luetzestraße 93,,,Weingarten (Baden),Baden-Württemberg,76356,Germany,+49 7244 8261,http://www.alte-werkstatt-bier.de,8.5313723,49.0533742
 6df21f70-1f25-460c-956a-f98a9576d82c,Alter Bahnhof,brewpub,2 Bahnhofstraße,,,Malsch,Baden-Württemberg,76316,Germany,+49 7246 305944,http://www.alterbahnhofmalsch.de,8.3238889,48.8894444
 51bc8efd-7da5-437c-b95d-af24c8120ff9,Andreasbr,brewpub,71A Donauring,,,Eggenstein-Leopoldshafen,Baden-Württemberg,76344,Germany,+49 7247 963200,http://www.andreasbraeu.de,8.398706899999999,49.0903862
 9885ebba-4e94-42ec-bae9-9301d1b05183,Badenstuff,brewpub,25 Krokusweg,,,Offenburg,Baden-Württemberg,77656,Germany,+49 781 76665,http://www.badenstuff.com,7.92048,48.45587
@@ -28,7 +28,7 @@ bc4933ef-ccf6-44f6-a48f-d32348d2ae80,Bräuhaus Ummendorf,brewpub,10 Bachstraße,
 e8daf982-a06a-44a9-8310-b6ce8fb5639b,Brauwerk Baden,brewpub,3 Gutenbergstraße,,,Offenburg,Baden-Württemberg,77654,Germany,,http://www.kronen-brauhaus.de,7.956585599999999,48.4882827
 45d5bf76-af10-43b0-9195-c3b5f8829dc4,Brauwerk Salvermoser,closed,14 Am Mühlberg,,,Tuttlingen,Baden-Württemberg,78532,Germany,+49 7462 7986,http://www.brauwerk-salvermoser.de,8.7699,47.96017
 c423766b-b61c-443d-82db-6c0afca23ef2,Brauzentrum Blaubeuren,brewpub,6 Auf dem Graben,,,Blaubeuren,Baden-Württemberg,89143,Germany,+49 175 9280239,http://www.pumator.de,9.7865239,48.4122368
-92d42647-418c-42c1-bec1-495da2c78083,Brewmaltster / Braxar,micro,Hauptstr. 9,,,Buehlertann,Baden-Württemberg,74424,Germany,,http://www.brewmaltster.de,,
+92d42647-418c-42c1-bec1-495da2c78083,Brewmaltster / Braxar,micro,Hauptstraße 9,,,Buehlertann,Baden-Württemberg,74424,Germany,,http://www.brewmaltster.de,,
 a3c7f51e-c71f-4e38-a109-dcc13bef3756,Bulzinger,brewpub,3 Schillerstraße,,,Rietheim-Weilheim,Baden-Württemberg,78604,Germany,+49 7461 73822,https://www.lammbrauerei-weilheim.de/index.php/ueber-uns,8.773282799999999,48.0255894
 27b65e46-3c13-47fa-a882-c93473c6ab35,Bürgerstüble,brewpub,2 Anwandstraße,,,Sulz am Neckar,Baden-Württemberg,72172,Germany,+49 7454 4329,http://buergerstueble-sigmarswangen.de/,8.61486,48.3295
 801af57f-d3d9-46d9-844f-dfc6fef13543,Café Mundart,brewpub,24 Balinger Straße,,,Meßstetten,Baden-Württemberg,72469,Germany,+49 7436 910958,http://www.cafe-mundart.de,8.872172599999999,48.2002834

--- a/data/germany/baden-wurttemberg.csv
+++ b/data/germany/baden-wurttemberg.csv
@@ -1,196 +1,196 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-1a743eec-cc52-4f5e-876b-ef3bcd924e84,Aalener Löwenbrauerei,brewpub,8 Galgenbergstraße,,,Aalen,Baden-Württemberg,73431,Germany,+49 7361 32597,http://www.bestesbier.de,10.0985681,48.8384864
-7f104ccf-6720-48ff-a2cf-5c05dd88aaf1,Adler,brewpub,38 Lindenstraße,,,Wiernsheim,Baden-Württemberg,75446,Germany,+49 7044 920778,http://www.adlerbraeu.de,8.8511433,48.8879519
-5b99dc11-165e-4cf0-873d-1a7bd1ded0a9,Adler-Bräu,brewpub,17 Biberacher Straße,,,Oberstadion,Baden-Württemberg,89613,Germany,+49 7357 921990,http://www.brauereigasthof-moosbeuren.de,9.724819,48.1795445
-1b7ff36c-d91b-4f04-9ee0-48622eac5aa9,Adlerbrauerei,brewpub,2 Adlergasse,,,Erbach,Baden-Württemberg,89155,Germany,+49 7305 7342,http://www.adler-dellmensingen.de,9.900200199999999,48.3026079
-f83d4bed-0760-4802-900e-c2ed6e874968,Adlerbrauerei Schmetzer,brewpub,3 Reubacher Straße,,,Wallhausen,Baden-Württemberg,74599,Germany,+49 7955 2234,https://adlerbrauerei-schmetzer.de/,10.11867,49.2347
-26147e1c-c0f7-40ae-8572-df23afe8e266,Albquell Bräuhaus,brewpub,6 Lindenplatz,,,Trochtelfingen,Baden-Württemberg,72818,Germany,+49 7124 733,http://www.albquell-brauhaus.de,9.2455955,48.3081319
-3345a490-cc70-449e-b037-939398bd0f25,Alpirsbacher Klosterbräu,brewpub,1 Marktplatz,,,Alpirsbach,Baden-Württemberg,72275,Germany,+49 7444 670,http://www.alpirsbacher.de,8.40305,48.34566
+1a743eec-cc52-4f5e-876b-ef3bcd924e84,Aalener Löwenbrauerei,brewpub,Galgenbergstraße 8,,,Aalen,Baden-Württemberg,73431,Germany,+49 7361 32597,http://www.bestesbier.de,10.0985681,48.8384864
+7f104ccf-6720-48ff-a2cf-5c05dd88aaf1,Adler,brewpub,Lindenstraße 38,,,Wiernsheim,Baden-Württemberg,75446,Germany,+49 7044 920778,http://www.adlerbraeu.de,8.8511433,48.8879519
+5b99dc11-165e-4cf0-873d-1a7bd1ded0a9,Adler-Bräu,brewpub,Biberacher Straße 17,,,Oberstadion,Baden-Württemberg,89613,Germany,+49 7357 921990,http://www.brauereigasthof-moosbeuren.de,9.724819,48.1795445
+1b7ff36c-d91b-4f04-9ee0-48622eac5aa9,Adlerbrauerei,brewpub,Adlergasse 2,,,Erbach,Baden-Württemberg,89155,Germany,+49 7305 7342,http://www.adler-dellmensingen.de,9.900200199999999,48.3026079
+f83d4bed-0760-4802-900e-c2ed6e874968,Adlerbrauerei Schmetzer,brewpub,Reubacher Straße 3,,,Wallhausen,Baden-Württemberg,74599,Germany,+49 7955 2234,https://adlerbrauerei-schmetzer.de/,10.11867,49.2347
+26147e1c-c0f7-40ae-8572-df23afe8e266,Albquell Bräuhaus,brewpub,Lindenplatz 6,,,Trochtelfingen,Baden-Württemberg,72818,Germany,+49 7124 733,http://www.albquell-brauhaus.de,9.2455955,48.3081319
+3345a490-cc70-449e-b037-939398bd0f25,Alpirsbacher Klosterbräu,brewpub,Marktplatz 1,,,Alpirsbach,Baden-Württemberg,72275,Germany,+49 7444 670,http://www.alpirsbacher.de,8.40305,48.34566
 ddd11477-dab1-4aae-a129-5b1a6248c3a9,Alte Werkstatt,brewpub,Luetzestraße 93,,,Weingarten (Baden),Baden-Württemberg,76356,Germany,+49 7244 8261,http://www.alte-werkstatt-bier.de,8.5313723,49.0533742
-6df21f70-1f25-460c-956a-f98a9576d82c,Alter Bahnhof,brewpub,2 Bahnhofstraße,,,Malsch,Baden-Württemberg,76316,Germany,+49 7246 305944,http://www.alterbahnhofmalsch.de,8.3238889,48.8894444
-51bc8efd-7da5-437c-b95d-af24c8120ff9,Andreasbr,brewpub,71A Donauring,,,Eggenstein-Leopoldshafen,Baden-Württemberg,76344,Germany,+49 7247 963200,http://www.andreasbraeu.de,8.398706899999999,49.0903862
-9885ebba-4e94-42ec-bae9-9301d1b05183,Badenstuff,brewpub,25 Krokusweg,,,Offenburg,Baden-Württemberg,77656,Germany,+49 781 76665,http://www.badenstuff.com,7.92048,48.45587
-3805c592-5427-49e1-8609-a56fdf01fe66,Badisch Brauhaus,brewpub,38-40 Stephanienstraße,,,Karlsruhe,Baden-Württemberg,76133,Germany,+49 721 1444400,http://www.badisch-brauhaus.de,8.3938044,49.0118167
-d08767b4-f8a5-4124-a029-c38b29a3a6e3,Baisinger BierManufaktur,brewpub,13 Ergenzinger Straße,,,Rottenburg am Neckar,Baden-Württemberg,72108,Germany,+49 7457 94300,http://www.baisinger.de,8.7782754,48.5046712
-3fcac8d1-1091-4c9a-a244-dcf772a4ca14,Barfüßer,brewpub,2 Franz-Xaver-Heilig-Straße,,,Pfullendorf,Baden-Württemberg,88630,Germany,+49 7552 9280815,http://www.barfuesser-brauhaus/pfullendorf/,9.250859,47.92402209999999
-81010e86-c5d0-4c04-bbef-4e6fbb77f4ee,Bauhöfer,brewpub,12 Ullenburg Straße,,,Renchen,Baden-Württemberg,77871,Germany,+49 7843 94740,http://www.ulmer-bier.de,8.049072599999999,48.58008599999999
-54ada3c7-fba6-46dd-88e6-fa786dcd394d,Bayerisches Brauhaus,brewpub,12 St.Georgen Steige,,,Pforzheim,Baden-Württemberg,75175,Germany,+49 7231 60080,http://www.brauhaus-pforzheim.de,8.704553299999999,48.886618
-a4462335-d4e7-4e4d-b306-703aa8b37927,Berg,brewpub,2 Brauhausstraße,,,Ehingen (Donau),Baden-Württemberg,89584,Germany,+49 7391 771710,http://www.bergbier.de,9.735312799999999,48.2623255
+6df21f70-1f25-460c-956a-f98a9576d82c,Alter Bahnhof,brewpub,Bahnhofstraße 2,,,Malsch,Baden-Württemberg,76316,Germany,+49 7246 305944,http://www.alterbahnhofmalsch.de,8.3238889,48.8894444
+51bc8efd-7da5-437c-b95d-af24c8120ff9,Andreasbr,brewpub,Donauring 71A,,,Eggenstein-Leopoldshafen,Baden-Württemberg,76344,Germany,+49 7247 963200,http://www.andreasbraeu.de,8.398706899999999,49.0903862
+9885ebba-4e94-42ec-bae9-9301d1b05183,Badenstuff,brewpub,Krokusweg 25,,,Offenburg,Baden-Württemberg,77656,Germany,+49 781 76665,http://www.badenstuff.com,7.92048,48.45587
+3805c592-5427-49e1-8609-a56fdf01fe66,Badisch Brauhaus,brewpub,Stephanienstraße 38-40,,,Karlsruhe,Baden-Württemberg,76133,Germany,+49 721 1444400,http://www.badisch-brauhaus.de,8.3938044,49.0118167
+d08767b4-f8a5-4124-a029-c38b29a3a6e3,Baisinger BierManufaktur,brewpub,Ergenzinger Straße 13,,,Rottenburg am Neckar,Baden-Württemberg,72108,Germany,+49 7457 94300,http://www.baisinger.de,8.7782754,48.5046712
+3fcac8d1-1091-4c9a-a244-dcf772a4ca14,Barfüßer,brewpub,Franz-Xaver-Heilig-Straße 2,,,Pfullendorf,Baden-Württemberg,88630,Germany,+49 7552 9280815,http://www.barfuesser-brauhaus/pfullendorf/,9.250859,47.92402209999999
+81010e86-c5d0-4c04-bbef-4e6fbb77f4ee,Bauhöfer,brewpub,Ullenburg Straße 12,,,Renchen,Baden-Württemberg,77871,Germany,+49 7843 94740,http://www.ulmer-bier.de,8.049072599999999,48.58008599999999
+54ada3c7-fba6-46dd-88e6-fa786dcd394d,Bayerisches Brauhaus,brewpub,St.Georgen Steige 12,,,Pforzheim,Baden-Württemberg,75175,Germany,+49 7231 60080,http://www.brauhaus-pforzheim.de,8.704553299999999,48.886618
+a4462335-d4e7-4e4d-b306-703aa8b37927,Berg,brewpub,Brauhausstraße 2,,,Ehingen (Donau),Baden-Württemberg,89584,Germany,+49 7391 771710,http://www.bergbier.de,9.735312799999999,48.2623255
 420a01c4-0936-4181-8703-e51b6903e24c,Beurener Fels Brauerei,micro,Weiler Steige,,,Beuren,Baden-Württemberg,72660,Germany,,http://www.beurenerfelsbrauerei.de,9.4187429,48.5706148
-7ff4982b-11b8-48f7-8faa-f85505caed1e,BIERkulturGUT,brewpub,2 Weiße-Tor-Straße,,,Philippsburg,Baden-Württemberg,76661,Germany,+49 179 2123094,http://www.bierkulturgut.com,8.4536201,49.2366581
-0a857d52-3744-4f42-ab40-5598ea2dcff5,Bierwerk Gerstenfux,closed,40 Oberensinger Straße,,,Nürtingen,Baden-Württemberg,72622,Germany,+49 7022 7864015,http://www.bierwerkgerstenfux.de,9.345667899999999,48.6405257
-c3f69105-f68c-412c-b8b0-9fce73266314,Blank,brewpub,19 Von-Speth-Straße,,,Riedlingen,Baden-Württemberg,88499,Germany,+49 7373 643,http://www.brauerei-blank.de,9.516753999999999,48.214986
-87b23d97-d1c3-4583-9ccd-3074dd7d8117,Brauhaus 2.0,closed,8 Egon-Eiermann-Allee,,,Karlsruhe,Baden-Württemberg,76187,Germany,+49 721 47050220,http://www.brauhaus-zweipunktnull.de,8.3502092,49.03681659999999
-67fc21da-e09e-450e-a53c-65eedf6e7af9,Brauhaus am Schlößle,brewpub,78/2 Backnanger Straße,,,Sulzbach an der Murr,Baden-Württemberg,71560,Germany,+49 176 22922941,http://www.brauhaus-am-schloessle.de,9.49669,49.00412
-bb674664-d831-4c4b-8b0e-ba99526e5155,Brauhaus Meier,brewpub,10 Brunnmattstraße,,,Wehr,Baden-Württemberg,79664,Germany,+49 7762 8062509,http://www.brauhaus-meier.de,7.907375800000001,47.6130956
-bc4933ef-ccf6-44f6-a48f-d32348d2ae80,Bräuhaus Ummendorf,brewpub,10 Bachstraße,,,Ummendorf,Baden-Württemberg,88444,Germany,+49 7351 44430,http://www.braeuhaus.de,9.832749999999999,48.06364
-2d033740-c6f6-45db-aaac-84e5a20d5571,Brauhaus Zollernalb,brewpub,4 Bahnhof,,,Albstadt,Baden-Württemberg,72458,Germany,+49 7431 9482941,http://www.brauhaus-zollernalb.de,9.0255824,48.2105719
-e8daf982-a06a-44a9-8310-b6ce8fb5639b,Brauwerk Baden,brewpub,3 Gutenbergstraße,,,Offenburg,Baden-Württemberg,77654,Germany,,http://www.kronen-brauhaus.de,7.956585599999999,48.4882827
-45d5bf76-af10-43b0-9195-c3b5f8829dc4,Brauwerk Salvermoser,closed,14 Am Mühlberg,,,Tuttlingen,Baden-Württemberg,78532,Germany,+49 7462 7986,http://www.brauwerk-salvermoser.de,8.7699,47.96017
-c423766b-b61c-443d-82db-6c0afca23ef2,Brauzentrum Blaubeuren,brewpub,6 Auf dem Graben,,,Blaubeuren,Baden-Württemberg,89143,Germany,+49 175 9280239,http://www.pumator.de,9.7865239,48.4122368
+7ff4982b-11b8-48f7-8faa-f85505caed1e,BIERkulturGUT,brewpub,Weiße-Tor-Straße 2,,,Philippsburg,Baden-Württemberg,76661,Germany,+49 179 2123094,http://www.bierkulturgut.com,8.4536201,49.2366581
+0a857d52-3744-4f42-ab40-5598ea2dcff5,Bierwerk Gerstenfux,closed,Oberensinger Straße 40,,,Nürtingen,Baden-Württemberg,72622,Germany,+49 7022 7864015,http://www.bierwerkgerstenfux.de,9.345667899999999,48.6405257
+c3f69105-f68c-412c-b8b0-9fce73266314,Blank,brewpub,Von-Speth-Straße 19,,,Riedlingen,Baden-Württemberg,88499,Germany,+49 7373 643,http://www.brauerei-blank.de,9.516753999999999,48.214986
+87b23d97-d1c3-4583-9ccd-3074dd7d8117,Brauhaus 2.0,closed,Egon-Eiermann-Allee 8,,,Karlsruhe,Baden-Württemberg,76187,Germany,+49 721 47050220,http://www.brauhaus-zweipunktnull.de,8.3502092,49.03681659999999
+67fc21da-e09e-450e-a53c-65eedf6e7af9,Brauhaus am Schlößle,brewpub,Backnanger Straße 78/2,,,Sulzbach an der Murr,Baden-Württemberg,71560,Germany,+49 176 22922941,http://www.brauhaus-am-schloessle.de,9.49669,49.00412
+bb674664-d831-4c4b-8b0e-ba99526e5155,Brauhaus Meier,brewpub,Brunnmattstraße 10,,,Wehr,Baden-Württemberg,79664,Germany,+49 7762 8062509,http://www.brauhaus-meier.de,7.907375800000001,47.6130956
+bc4933ef-ccf6-44f6-a48f-d32348d2ae80,Bräuhaus Ummendorf,brewpub,Bachstraße 10,,,Ummendorf,Baden-Württemberg,88444,Germany,+49 7351 44430,http://www.braeuhaus.de,9.832749999999999,48.06364
+2d033740-c6f6-45db-aaac-84e5a20d5571,Brauhaus Zollernalb,brewpub,Bahnhof 4,,,Albstadt,Baden-Württemberg,72458,Germany,+49 7431 9482941,http://www.brauhaus-zollernalb.de,9.0255824,48.2105719
+e8daf982-a06a-44a9-8310-b6ce8fb5639b,Brauwerk Baden,brewpub,Gutenbergstraße 3,,,Offenburg,Baden-Württemberg,77654,Germany,,http://www.kronen-brauhaus.de,7.956585599999999,48.4882827
+45d5bf76-af10-43b0-9195-c3b5f8829dc4,Brauwerk Salvermoser,closed,Am Mühlberg 14,,,Tuttlingen,Baden-Württemberg,78532,Germany,+49 7462 7986,http://www.brauwerk-salvermoser.de,8.7699,47.96017
+c423766b-b61c-443d-82db-6c0afca23ef2,Brauzentrum Blaubeuren,brewpub,Auf dem Graben 6,,,Blaubeuren,Baden-Württemberg,89143,Germany,+49 175 9280239,http://www.pumator.de,9.7865239,48.4122368
 92d42647-418c-42c1-bec1-495da2c78083,Brewmaltster / Braxar,micro,Hauptstraße 9,,,Buehlertann,Baden-Württemberg,74424,Germany,,http://www.brewmaltster.de,,
-a3c7f51e-c71f-4e38-a109-dcc13bef3756,Bulzinger,brewpub,3 Schillerstraße,,,Rietheim-Weilheim,Baden-Württemberg,78604,Germany,+49 7461 73822,https://www.lammbrauerei-weilheim.de/index.php/ueber-uns,8.773282799999999,48.0255894
-27b65e46-3c13-47fa-a882-c93473c6ab35,Bürgerstüble,brewpub,2 Anwandstraße,,,Sulz am Neckar,Baden-Württemberg,72172,Germany,+49 7454 4329,http://buergerstueble-sigmarswangen.de/,8.61486,48.3295
-801af57f-d3d9-46d9-844f-dfc6fef13543,Café Mundart,brewpub,24 Balinger Straße,,,Meßstetten,Baden-Württemberg,72469,Germany,+49 7436 910958,http://www.cafe-mundart.de,8.872172599999999,48.2002834
-4ba3268a-e6f0-4e1d-99bc-096c101c0c08,Café Weichhardt,brewpub,1 Wielandstraße,,,Biberach an der Riß,Baden-Württemberg,88400,Germany,+49 7351 828925,http://www.cafe-weichhardt.de,9.7868023,48.0990354
-df785b94-c91c-4407-a856-4814e2ad5cca,Calwer-Eck-Bräu,brewpub,10 Bolzstraße,,,Stuttgart,Baden-Württemberg,70173,Germany,+49 711 72230930,http://www.calwereck.de,9.177834899999999,48.7803028
-35167753-ea8b-4491-ad04-9ef049f3787c,Cast,closed,144 Siemensstraße,,,Stuttgart,Baden-Württemberg,70469,Germany,+49 711 50482973,http://www.cast-brauerei.com,9.1698415,48.81883149999999
-96d75b7b-a4f3-4c2a-a9e3-d5c6451cbcee,Christoph-Bräu,brewpub,3 Alois-Degler-Straße,,,Gaggenau,Baden-Württemberg,76571,Germany,+49 7225 70393,http://www.christophbraeu.de,8.3164569,48.8045115
-286c6b46-c319-47c9-aed6-9c114bd6ce23,Craftcell,brewpub,13 Langenzell,,,Wiesenbach,Baden-Württemberg,69257,Germany,,http://www.craftcell.de,8.8388692,49.36403989999999
-d015910a-688b-4f98-9710-39d29fe8ec6f,Dachsenfranz Biermanufaktur,brewpub,1 Hoffenheimer Straße,,,Zuzenhausen,Baden-Württemberg,74939,Germany,+49 6226 939020,http://www.dachsenfranz.de,8.8243279,49.29572839999999
-95e8d795-5478-420e-9ff5-cc23f5d1b300,Dammenmühle,brewpub,1 Dammenmühle,,,Lahr/Schwarzwald,Baden-Württemberg,77933,Germany,+49 7821 93930,http://www.hoteldammenmuehle.de,7.860662899999999,48.3249589
-7505214f-492b-4cb9-be0b-d122fee36bf0,Dinkelacker-Schwaben,brewpub,46 Tübinger Straße,,,Stuttgart,Baden-Württemberg,70178,Germany,+49 711 64810,http://www.ds-kg.de,9.1699231,48.767743
-8f0fbb0a-9b6e-4802-9836-6eda6a6cc5a1,Distelhäuser,brewpub,3 Grünsfelder Straße,,,Tauberbischofsheim,Baden-Württemberg,97941,Germany,+49 9341 805820,http://www.distelhaeuser.de,9.6939324,49.5988339
-926543c9-5efe-4ccb-a963-b54500357c89,Doc's Bier,brewpub,11 Schönhardtshöhe,,,Rottenburg am Neckar,Baden-Württemberg,72108,Germany,+49 7472 42936,http://www.docsbier.de,8.8768814,48.4519269
-ec87ea83-d563-41a7-aea8-e64eca72dfa0,Domänen Bräu,brewpub,1 Brielhof,,,Hechingen,Baden-Württemberg,72379,Germany,+49 7471 96019210,http://www.hofgut-domaene.de,8.950374199999999,48.336022
-a1a0da47-b937-4e51-aa96-ecfbd2a797b2,Dorfbräu,brewpub,28 Elzstraße,,,Teningen,Baden-Württemberg,79331,Germany,,,7.801050000000001,48.1366526
-40dc50e3-00e4-462d-b329-a6cd5ffe04de,Dörzbacher,brewpub,53 Lange Straße,,,Ahorn,Baden-Württemberg,74744,Germany,+49 7930 374,http://www.doerzbacher-brauerei.de,9.574402,49.46039810000001
-b5ebb54d-b2e5-42f4-9ea2-80fc3556afaa,Echterdinger Brauhaus,brewpub,2 Filderbahnstraße,,,Leinfelden-Echterdingen,Baden-Württemberg,70771,Germany,+49 711 633440,http://www.parkhotel-stuttgart.de,9.1676372,48.6915299
-e93f65e6-7b87-41e3-afab-edbb86dfe9d5,Edelweissbrauerei Farny,brewpub,5 Dürren,,,Kißlegg,Baden-Württemberg,88353,Germany,+49 7522 97880,http://www.farny.de,9.8726253,47.728673
-22ad8760-8c58-4d01-813c-3a6c480cb8ba,Egolf,brewpub,1 Hintere Klinge,,,Schefflenz,Baden-Württemberg,74850,Germany,+49 6293 488,http://www.brauerei-egolf.de,9.26576,49.39039
-61422757-bd0f-42f3-8377-eae322c29eae,Eichbaum,brewpub,170 Käfertaler Straße,,,Mannheim,Baden-Württemberg,68167,Germany,+49 621 33700,http://www.eichbaum.de,8.4902918,49.4960675
-68a34182-7f19-4579-a932-36d008e776f6,Engel,brewpub,29 Haller Straße,,,Crailsheim,Baden-Württemberg,74564,Germany,+49 7951 91930,http://www.engelbier.de,10.0579495,49.1414925
-36a73213-04fe-4481-84a9-e9a3c4b69b76,Enkendörfle Hausbräu,brewpub,1 Glattackerweg,,,Wehr,Baden-Württemberg,79664,Germany,,http://www.enkendoerfler.de,7.9015795,47.6180058
-6b632d9c-be2f-4150-b25f-162252ffb4ef,Feierling,brewpub,46 Gerberau,,,Freiburg im Breisgau,Baden-Württemberg,79098,Germany,,http://www.feierling.de,7.8527257,47.9933106
-0218e79c-a268-47f2-ba82-bf7a9a9ca692,Fischer's Brauhaus,brewpub,30 Auf der Lehr,,,Mössingen,Baden-Württemberg,72116,Germany,+49 7473 954443,http://www.brauhaus-moessingen.de,9.0657474,48.40880629999999
-5a234e56-d283-4437-82fe-f53bceca24c5,Franken Bräu,brewpub,4 Heuchlinger Weg,,,Schrozberg,Baden-Württemberg,74575,Germany,+49 7936 261,http://www.franken-braeu.de,9.9162401,49.34956039999999
-25ec4e2d-1ced-49e6-a949-b163b65459e4,Franz,brewpub,4 Rauentaler Straße,,,Rastatt,Baden-Württemberg,76437,Germany,+49 7222 97370,http://www.brauerei-franz.de,8.2090975,48.8571232
-0026c4de-2047-4aec-8bd5-85619e5be850,Friedrich Bier,brewpub,34 Friedrichstraße,,,Offenburg,Baden-Württemberg,77654,Germany,+49 781 12555560,http://www.friedrichbier.de,7.9496305,48.4700684
-a50f5d36-92f6-45e9-8bbe-932971102777,Fürstenberg,brewpub,1-4 Postplatz,,,Donaueschingen,Baden-Württemberg,78166,Germany,+49 771 860,http://www.fuerstenberg.de,8.4984216,47.9517707
-e99c167f-f2ac-4fc5-8416-f3ac19502f58,Fux Bier,closed,67 Filderstraße,,,Leinfelden-Echterdingen,Baden-Württemberg,70771,Germany,+49 177 2923241,http://www.fux-bier.de,9.1240161,48.6921326
-78cb5232-6114-4d8e-a45e-030c7621f5a0,Ganter,brewpub,43 Schwarzwaldstraße,,,Freiburg im Breisgau,Baden-Württemberg,79117,Germany,+49 761 21850,http://www.ganter.com,7.8598599,47.9898605
-cd03a4be-d897-467b-95fc-fe621195e404,Gasthaus Traube / Seebräu,brewpub,2 Radolfzeller Straße,,,Bodman-Ludwigshafen,Baden-Württemberg,78351,Germany,+49 7773 938303,http://www.traube-bodensee.de,9.056098400000002,47.8170457
-76a0edb8-fd5f-4fee-a3e1-c24d5d2f39b8,Geiger,micro,1 Eschenbacher Straße,,,Schlat,Baden-Württemberg,73114,Germany,+49 7161 9990224,http://www.manufaktur-joerg-geiger.de/,9.7049199,48.6524936
-882e99fb-5914-444b-9947-8e966f729fd7,Gerber Bräu,brewpub,47 Kanalstraße,,,Uhingen,Baden-Württemberg,73066,Germany,+49 7161 946970,http://www.gerberbraeu.de,9.5760595,48.7078316
-778e7dc3-5814-4e6b-b4fa-a20acb1ce262,Gold Ochsen,brewpub,3-8 Veitsbrunnenweg,,,Ulm,Baden-Württemberg,89073,Germany,+49 731 1640,http://www.goldochsen.de,9.9906291,48.4065628
-ee61a3b4-a2d9-4cf5-8cb7-99ec628ec0ce,Gold-Ochsenbrauerei,brewpub,19 Spielbach,,,Schrozberg,Baden-Württemberg,74575,Germany,+49 7939 461,https://www.facebook.com/pages/Goldochsen-Brauerei/216104248413407,10.0676001,49.3854822
+a3c7f51e-c71f-4e38-a109-dcc13bef3756,Bulzinger,brewpub,Schillerstraße 3,,,Rietheim-Weilheim,Baden-Württemberg,78604,Germany,+49 7461 73822,https://www.lammbrauerei-weilheim.de/index.php/ueber-uns,8.773282799999999,48.0255894
+27b65e46-3c13-47fa-a882-c93473c6ab35,Bürgerstüble,brewpub,Anwandstraße 2,,,Sulz am Neckar,Baden-Württemberg,72172,Germany,+49 7454 4329,http://buergerstueble-sigmarswangen.de/,8.61486,48.3295
+801af57f-d3d9-46d9-844f-dfc6fef13543,Café Mundart,brewpub,Balinger Straße 24,,,Meßstetten,Baden-Württemberg,72469,Germany,+49 7436 910958,http://www.cafe-mundart.de,8.872172599999999,48.2002834
+4ba3268a-e6f0-4e1d-99bc-096c101c0c08,Café Weichhardt,brewpub,Wielandstraße 1,,,Biberach an der Riß,Baden-Württemberg,88400,Germany,+49 7351 828925,http://www.cafe-weichhardt.de,9.7868023,48.0990354
+df785b94-c91c-4407-a856-4814e2ad5cca,Calwer-Eck-Bräu,brewpub,Bolzstraße 10,,,Stuttgart,Baden-Württemberg,70173,Germany,+49 711 72230930,http://www.calwereck.de,9.177834899999999,48.7803028
+35167753-ea8b-4491-ad04-9ef049f3787c,Cast,closed,Siemensstraße 144,,,Stuttgart,Baden-Württemberg,70469,Germany,+49 711 50482973,http://www.cast-brauerei.com,9.1698415,48.81883149999999
+96d75b7b-a4f3-4c2a-a9e3-d5c6451cbcee,Christoph-Bräu,brewpub,Alois-Degler-Straße 3,,,Gaggenau,Baden-Württemberg,76571,Germany,+49 7225 70393,http://www.christophbraeu.de,8.3164569,48.8045115
+286c6b46-c319-47c9-aed6-9c114bd6ce23,Craftcell,brewpub,Langenzell 13,,,Wiesenbach,Baden-Württemberg,69257,Germany,,http://www.craftcell.de,8.8388692,49.36403989999999
+d015910a-688b-4f98-9710-39d29fe8ec6f,Dachsenfranz Biermanufaktur,brewpub,Hoffenheimer Straße 1,,,Zuzenhausen,Baden-Württemberg,74939,Germany,+49 6226 939020,http://www.dachsenfranz.de,8.8243279,49.29572839999999
+95e8d795-5478-420e-9ff5-cc23f5d1b300,Dammenmühle,brewpub,Dammenmühle 1,,,Lahr/Schwarzwald,Baden-Württemberg,77933,Germany,+49 7821 93930,http://www.hoteldammenmuehle.de,7.860662899999999,48.3249589
+7505214f-492b-4cb9-be0b-d122fee36bf0,Dinkelacker-Schwaben,brewpub,Tübinger Straße 46,,,Stuttgart,Baden-Württemberg,70178,Germany,+49 711 64810,http://www.ds-kg.de,9.1699231,48.767743
+8f0fbb0a-9b6e-4802-9836-6eda6a6cc5a1,Distelhäuser,brewpub,Grünsfelder Straße 3,,,Tauberbischofsheim,Baden-Württemberg,97941,Germany,+49 9341 805820,http://www.distelhaeuser.de,9.6939324,49.5988339
+926543c9-5efe-4ccb-a963-b54500357c89,Doc's Bier,brewpub,Schönhardtshöhe 11,,,Rottenburg am Neckar,Baden-Württemberg,72108,Germany,+49 7472 42936,http://www.docsbier.de,8.8768814,48.4519269
+ec87ea83-d563-41a7-aea8-e64eca72dfa0,Domänen Bräu,brewpub,Brielhof 1,,,Hechingen,Baden-Württemberg,72379,Germany,+49 7471 96019210,http://www.hofgut-domaene.de,8.950374199999999,48.336022
+a1a0da47-b937-4e51-aa96-ecfbd2a797b2,Dorfbräu,brewpub,Elzstraße 28,,,Teningen,Baden-Württemberg,79331,Germany,,,7.801050000000001,48.1366526
+40dc50e3-00e4-462d-b329-a6cd5ffe04de,Dörzbacher,brewpub,Lange Straße 53,,,Ahorn,Baden-Württemberg,74744,Germany,+49 7930 374,http://www.doerzbacher-brauerei.de,9.574402,49.46039810000001
+b5ebb54d-b2e5-42f4-9ea2-80fc3556afaa,Echterdinger Brauhaus,brewpub,Filderbahnstraße 2,,,Leinfelden-Echterdingen,Baden-Württemberg,70771,Germany,+49 711 633440,http://www.parkhotel-stuttgart.de,9.1676372,48.6915299
+e93f65e6-7b87-41e3-afab-edbb86dfe9d5,Edelweissbrauerei Farny,brewpub,Dürren 5,,,Kißlegg,Baden-Württemberg,88353,Germany,+49 7522 97880,http://www.farny.de,9.8726253,47.728673
+22ad8760-8c58-4d01-813c-3a6c480cb8ba,Egolf,brewpub,Hintere Klinge 1,,,Schefflenz,Baden-Württemberg,74850,Germany,+49 6293 488,http://www.brauerei-egolf.de,9.26576,49.39039
+61422757-bd0f-42f3-8377-eae322c29eae,Eichbaum,brewpub,Käfertaler Straße 170,,,Mannheim,Baden-Württemberg,68167,Germany,+49 621 33700,http://www.eichbaum.de,8.4902918,49.4960675
+68a34182-7f19-4579-a932-36d008e776f6,Engel,brewpub,Haller Straße 29,,,Crailsheim,Baden-Württemberg,74564,Germany,+49 7951 91930,http://www.engelbier.de,10.0579495,49.1414925
+36a73213-04fe-4481-84a9-e9a3c4b69b76,Enkendörfle Hausbräu,brewpub,Glattackerweg 1,,,Wehr,Baden-Württemberg,79664,Germany,,http://www.enkendoerfler.de,7.9015795,47.6180058
+6b632d9c-be2f-4150-b25f-162252ffb4ef,Feierling,brewpub,Gerberau 46,,,Freiburg im Breisgau,Baden-Württemberg,79098,Germany,,http://www.feierling.de,7.8527257,47.9933106
+0218e79c-a268-47f2-ba82-bf7a9a9ca692,Fischer's Brauhaus,brewpub,Auf der Lehr 30,,,Mössingen,Baden-Württemberg,72116,Germany,+49 7473 954443,http://www.brauhaus-moessingen.de,9.0657474,48.40880629999999
+5a234e56-d283-4437-82fe-f53bceca24c5,Franken Bräu,brewpub,Heuchlinger Weg 4,,,Schrozberg,Baden-Württemberg,74575,Germany,+49 7936 261,http://www.franken-braeu.de,9.9162401,49.34956039999999
+25ec4e2d-1ced-49e6-a949-b163b65459e4,Franz,brewpub,Rauentaler Straße 4,,,Rastatt,Baden-Württemberg,76437,Germany,+49 7222 97370,http://www.brauerei-franz.de,8.2090975,48.8571232
+0026c4de-2047-4aec-8bd5-85619e5be850,Friedrich Bier,brewpub,Friedrichstraße 34,,,Offenburg,Baden-Württemberg,77654,Germany,+49 781 12555560,http://www.friedrichbier.de,7.9496305,48.4700684
+a50f5d36-92f6-45e9-8bbe-932971102777,Fürstenberg,brewpub,Postplatz 1-4,,,Donaueschingen,Baden-Württemberg,78166,Germany,+49 771 860,http://www.fuerstenberg.de,8.4984216,47.9517707
+e99c167f-f2ac-4fc5-8416-f3ac19502f58,Fux Bier,closed,Filderstraße 67,,,Leinfelden-Echterdingen,Baden-Württemberg,70771,Germany,+49 177 2923241,http://www.fux-bier.de,9.1240161,48.6921326
+78cb5232-6114-4d8e-a45e-030c7621f5a0,Ganter,brewpub,Schwarzwaldstraße 43,,,Freiburg im Breisgau,Baden-Württemberg,79117,Germany,+49 761 21850,http://www.ganter.com,7.8598599,47.9898605
+cd03a4be-d897-467b-95fc-fe621195e404,Gasthaus Traube / Seebräu,brewpub,Radolfzeller Straße 2,,,Bodman-Ludwigshafen,Baden-Württemberg,78351,Germany,+49 7773 938303,http://www.traube-bodensee.de,9.056098400000002,47.8170457
+76a0edb8-fd5f-4fee-a3e1-c24d5d2f39b8,Geiger,micro,Eschenbacher Straße 1,,,Schlat,Baden-Württemberg,73114,Germany,+49 7161 9990224,http://www.manufaktur-joerg-geiger.de/,9.7049199,48.6524936
+882e99fb-5914-444b-9947-8e966f729fd7,Gerber Bräu,brewpub,Kanalstraße 47,,,Uhingen,Baden-Württemberg,73066,Germany,+49 7161 946970,http://www.gerberbraeu.de,9.5760595,48.7078316
+778e7dc3-5814-4e6b-b4fa-a20acb1ce262,Gold Ochsen,brewpub,Veitsbrunnenweg 3-8,,,Ulm,Baden-Württemberg,89073,Germany,+49 731 1640,http://www.goldochsen.de,9.9906291,48.4065628
+ee61a3b4-a2d9-4cf5-8cb7-99ec628ec0ce,Gold-Ochsenbrauerei,brewpub,Spielbach 19,,,Schrozberg,Baden-Württemberg,74575,Germany,+49 7939 461,https://www.facebook.com/pages/Goldochsen-Brauerei/216104248413407,10.0676001,49.3854822
 077f9fc7-24ce-4ce8-9984-92ac8c2fa5f1,Grüner Baum,closed,Bachstraße,,,Fleischwangen,Baden-Württemberg,88373,Germany,+49 7505 347,http://landgasthof.cwsurf.de,9.4817193,47.8778
-9c64e21e-be0d-4805-a31e-d9f933c06cda,Häberlen,brewpub,66 Karlstraße,,,Gaildorf,Baden-Württemberg,74405,Germany,+49 7971 6250,http://www.brauerei-haeberlen.de,9.772335,48.99837489999999
-9f9ef817-e0a4-44f5-b454-6460f5732e9a,Hader Karle,brewpub,3 Längentalstraße,,,Villingen-Schwenningen,Baden-Württemberg,78052,Germany,+49 7721 63591,http://www.hader-karle.de,8.501249099999999,48.09449799999999
-e591bd3e-352b-43d6-9783-5de9556f7d4a,Häffner,brewpub,24 Salinenstraße,,,Bad Rappenau,Baden-Württemberg,74906,Germany,+49 7264 8050,http://www.haeffner-braeu.de,9.112063000000001,49.238093
-1187d3e8-4d29-43c0-8ea0-ea6757ab4dc4,Haller Löwenbräu,brewpub,6 Ritterstraße,,,Schwäbisch Hall,Baden-Württemberg,74523,Germany,+49 791 50901,http://www.haller-loewenbraeu.de,9.733312699999999,49.1060052
-5ae2d546-fb98-492c-863b-c3cd2edd592a,Härle,brewpub,5 Am Hopfengarten,,,Leutkirch im Allgäu,Baden-Württemberg,88299,Germany,+49 7561 98280,http://www.haerle.de,10.0240964,47.8236007
-3ab7d2d4-b9e7-4e43-be17-00e9863ba7e7,Härtsfelder,brewpub,19 Hofener Straße,,,Dischingen,Baden-Württemberg,89561,Germany,+49 7327 92290,http://www.haertsfelder.de,10.4131985,48.7229045
-19c75963-66ef-45f0-b3e2-c6777684ddda,Hatz- Moninger,brewpub,59 Durmersheimer Straße,,,Karlsruhe,Baden-Württemberg,76185,Germany,+49 721 57020,http://www.hatz-moninger.de,8.3543264,49.0018676
-dea548e8-6f6e-42b4-b965-d4143b2e26a8,Hausbrauerei JeSa,brewpub,9 Steingasse,,,Heidelberg,Baden-Württemberg,69117,Germany,+49 6221 165850,http://www.hausbrauerei-jesa.de,8.7096851,49.4126062
-a6005c74-6872-4d86-8738-c0e83202627d,Heidelberger,brewpub,112 Kurpfalzring,,,Heidelberg,Baden-Württemberg,69123,Germany,+49 6221 90140,http://www.heidelberger-brauerei.de,8.639920199999999,49.4048233
-85da8b2a-8088-4bf2-8c48-3a901442dbb0,Herbsthäuser,brewpub,28/1 Alte Kaiserstraße,,,Bad Mergentheim,Baden-Württemberg,97980,Germany,+49 7932 91000,http://www.herbsthaeuser.de,9.8295912,49.40393299999999
-72e61cd5-16b9-4c0d-aa4a-b9ea6d443638,Herr's Kleines Bierhaus,closed,55 Hauptstraße,,,Schwanau,Baden-Württemberg,77963,Germany,,http://www.kleinesbierhaus.de,7.756960999999999,48.32830999999999
-3d1ed94a-ccf9-40e8-8975-297c304a70d8,Heubacher,brewpub,99 Hauptstraße,,,Heubach,Baden-Württemberg,73540,Germany,+49 7173 18000,http://www.heubacher.de,9.936866499999999,48.7857784
-09884eb6-b343-44db-82e3-351d2090ead3,Heuberger Biermanufaktur,brewpub,10 Storzinger Straße,,,Stetten am kalten Markt,Baden-Württemberg,72510,Germany,,http://www.heuberger-biermanufaktur.de,9.0790706,48.122191
-93c29f97-316a-460b-b7a7-12198f7d95f0,Hey Joe Brewing,brewpub,93 Siegelsberger Straße,,,Murrhardt,Baden-Württemberg,71540,Germany,,http://www.heyjoebrewing.com,9.58845,48.99005
-4df10699-84df-4ad8-9c6c-3ce114085cce,Hieber's FrischeCenter,brewpub,1 Meeraner Platz,,,Lörrach,Baden-Württemberg,79539,Germany,+49 7621 914020,http://www.hieber.de,7.6582544,47.6079112
-4da2a973-1404-4ca4-8a0d-38a79219e27c,Hirsch,brewpub,34 Friedrichstraße,,,Wurmlingen,Baden-Württemberg,78573,Germany,+49 7461 9420,http://www.hirschbrauerei-soehnstetten.de,8.776947999999999,48.0053516
-2dee6626-c449-4d09-b809-38ef6d144dce,Hirschbräu,brewpub,1 Ringstraße,,,Rosenberg,Baden-Württemberg,74749,Germany,+49 6295 7159,http://www.hirschbraeu-hirschlanden.de,9.4998019,49.4743161
-20f427c9-b111-4938-a462-48e94e38d3c7,Hirschbrauerei,brewpub,15 Eschachstraße,,,Zimmern ob Rottweil,Baden-Württemberg,78658,Germany,+49 7403 489,http://www.hirsch-braeu.de,8.5322765,48.1668107
-55e18609-9d3f-4c54-bb7a-d29fba3dc369,Hirschbrauerei Schilling,closed,37 Aglishardter Straße,,,Römerstein,Baden-Württemberg,72587,Germany,+49 7382 93880,http://www.boehringer-biere.de,9.508918699999999,48.4920082
-7ca0eb65-5a5c-4446-9c5f-4022d55c8279,Hirschenbrauerei,micro,21 Goethestraße,,,Waldkirch,Baden-Württemberg,79183,Germany,+49 7681 40810,http://www.hirschenbrauerei.de,7.9591197,48.0887685
-569b5a8c-fe94-49dc-9ef1-42ae7b197e45,Hirtler,brewpub,10 Eichstetter Straße,,,March,Baden-Württemberg,79232,Germany,+49 7665 3304,http://www.brauerei-hirtler.de/,7.770066099999999,48.0689491
-35bc2139-4fcd-429e-b24c-9407c44628f5,Hochdorfer Kronenbrauerei,brewpub,16-20 Rottweiler Straße,,,Nagold,Baden-Württemberg,72202,Germany,+49 7459 92920,http://www.hochdorfer.de,8.7216124,48.4940448
-ca4ef6fd-1ed8-4502-a7ea-32b5b510a7f7,Hoepfner,brewpub,18 Haid-und-Neu-Straße,,,Karlsruhe,Baden-Württemberg,76131,Germany,+49 721 61830,http://www.hoepfner.de,8.4269801,49.0123462
-89fd5590-089a-4444-8815-280f33b0be0e,Hopfengut No20,brewpub,20 Hopfengut,,,Tettnang,Baden-Württemberg,88069,Germany,+49 7542 952206,http://www.hopfengut.de,9.6163814,47.6905211
-f441adfc-e3cc-48cb-9031-079982d78854,Hopfenschlingel,brewpub,2 Militärstraße,,,Rastatt,Baden-Württemberg,76437,Germany,+49 7222 30099,http://www.hopfenschlingel-pforzheim.de/,8.2115966,48.8494015
-92b15e6b-62b6-4c3d-a674-5419ab1d292e,HopfX Bräu,closed,43 Bahnhofstraße,,,Tuttlingen,Baden-Württemberg,78532,Germany,,http://www.facebook.com/HopfXBraeuTuttlingen/,8.8137709,47.9832651
-8d58821b-75b6-400b-a5b9-874ee0b719f8,Joh. Albrecht,brewpub,2 Konradigasse,,,Konstanz,Baden-Württemberg,78462,Germany,+49 7531 25045,http://www.konstanz.brauhaus-joh-albrecht.de,9.175008499999999,47.6650112
-fde19132-3a27-4acb-88ba-e91c50b095ac,Jupiter,closed,21 Keltergasse,,,Sinsheim,Baden-Württemberg,74889,Germany,+49 7261 975537,http://www.brauhausjupiter.de,8.9051685,49.2394256
-f5d41049-75a4-4b3d-a79b-8848b6f4e45a,Kaiser,brewpub,24/26 Schubartstraße,,,Geislingen an der Steige,Baden-Württemberg,73312,Germany,+49 7331 93720,http://www.kaiser-brauerei.de,9.840786900000001,48.6135978
-8f7146ca-e0a1-4d09-96ea-4bd047c09a9d,Kesselhaus,brewpub,3 Arnoldstraße,,,Schorndorf,Baden-Württemberg,73614,Germany,+49 7181 484933,http://www.kesselhaus-schorndorf.de,9.5315062,48.8067612
-428956a8-d38a-4de9-a4da-a9731b6e13f6,Ketterer,brewpub,10 Jahnstraße,,,Pforzheim,Baden-Württemberg,75173,Germany,+49 7231 92110,http://www.brauerei-ketterer.de,8.6949614,48.88868739999999
-1f9a066a-f103-49bf-bf70-2e86050bb6aa,Kißlegger Kellerbräu,closed,3 Fürst-Maximilian-Straße,,,Kißlegg,Baden-Württemberg,88353,Germany,+49 7563 91090,http://www.kisslegger-kellerbraeu.de,9.8815598,47.7871065
-b2174086-a81e-40bd-b417-ea2a90aafac7,Klosterhof,brewpub,4 Stiftweg,,,Heidelberg,Baden-Württemberg,69118,Germany,+49 6221 6520365,http://www.brauerei-zum-klosterhof.de,8.740091900000001,49.4204577
-cd03f666-0d86-49aa-a454-0ea75a61d702,Königsbräu Majer,brewpub,1 Oggenhauser Hauptstraße,,,Heidenheim an der Brenz,Baden-Württemberg,89522,Germany,+49 7321 97970,http://www.koenigsbraeu.de,10.2359869,48.67018179999999
-5dc16ffb-53ba-456d-8601-6987f0171479,Königsegger Walderbräu,brewpub,6 Hauptstraße,,,Königseggwald,Baden-Württemberg,88376,Germany,+49 7587 95040,http://www.koenigsegger.de,9.4206063,47.9258844
-a69fee5a-7b4b-4a00-a228-4e1ed0f73f31,Krokodil,brewpub,15 In Grubäcker,,,Trossingen,Baden-Württemberg,78647,Germany,+49 7425 21194,http://www.krokodil-trossingen.de,8.628559,48.07165639999999
-02609436-82a3-4a8f-9cf2-b66b55e0e4ee,Krone,brewpub,7 Bärenplatz,,,Tettnang,Baden-Württemberg,88069,Germany,+49 7542 7452,http://www.krone-tettnang.de,9.588956,47.671561
-3d81eb1a-0d72-4938-ac67-062c313350d2,Kronenbrauerei,brewpub,5 Kirchberg,,,Laupheim,Baden-Württemberg,88471,Germany,+49 7392 8345,http://www.kronenbrauerei-laupheim.de,9.8860393,48.2294
-5a1bc158-3f43-49bc-8c27-6b8235aa09c0,Kronenbrauerei Schimpf,brewpub,1 Hauptstraße,,,Neustetten,Baden-Württemberg,72149,Germany,+49 7472 98940,http://www.brauerei-schimpf.de,8.887230599999999,48.48200730000001
-109f15c2-2c21-4f43-a692-338e3bb679d4,Kronenbrauerei Söflingen,brewpub,10 Uhrenmachergasse,,,Ulm,Baden-Württemberg,89077,Germany,+49 731 388320,http://www.soeflinger-kronenbier.de,9.9559727,48.3952774
-f52bc93d-92fe-4729-a8df-241909873fa0,Kühler Krug,brewpub,3a Wilhelm-Baur-Straße,,,Karlsruhe,Baden-Württemberg,76135,Germany,+49 721 8316416,http://www.brauhaus-kuehler-krug.de,8.368266799999999,49.00409819999999
-da672eef-21a1-4552-b119-fbd2762476f1,Kulturbrauerei,brewpub,6 Leyergasse,,,Heidelberg,Baden-Württemberg,69117,Germany,+49 6221 502980,http://www.heidelberger-kulturbrauerei.de,8.7131758,49.4131355
-21768171-8411-4c79-9a60-ddde23fc5ae4,Ladenburger,brewpub,16 Hauptstraße,,,Neuler,Baden-Württemberg,73491,Germany,+49 7961 91140,http://www.brauerei-ladenburger.de,10.0674097,48.9276432
-c1e2f5c9-0cdb-4761-900e-a641d88d13c5,Lamm,brewpub,2 Nellmersbacher Straße,,,Leutenbach,Baden-Württemberg,71397,Germany,+49 7195 9779230,http://www.lamm-leutenbach.de,9.3929081,48.8876645
-3dc7ad60-2e9c-4f5f-94f7-266939905e52,Lammbrauerei,brewpub,2 Haller Straße,,,Abtsgmünd,Baden-Württemberg,73453,Germany,+49 7975 284,http://www.lammbrauerei.de,9.89177,48.91881
-88b34b96-2f91-4de5-a1ee-f12ff0f3183b,Lammbrauerei Hilsenbeck,brewpub,37 Hauptstraße,,,Gruibingen,Baden-Württemberg,73344,Germany,+49 7335 96440,http://www.lammbrauerei-hilsenbeck.de,9.642365999999999,48.5953507
-2cf1e09f-a630-4e93-9172-79c05df11345,Lasser,brewpub,5 Belchenstraße,,,Lörrach,Baden-Württemberg,79539,Germany,+49 7621 40200,http://www.lasser.de,7.663968199999999,47.6114046
-9d2d464b-65d6-4da9-a1d7-bd80fea9b026,Lehner,brewpub,7 Balinger Straße,,,Rosenfeld,Baden-Württemberg,72348,Germany,+49 7428 945160,http://www.lehner-wein.de,8.72348,48.28667979999999
-3a6be169-b268-40de-8e30-834d3fd4b856,Leibinger,brewpub,26 Friedhofstraße,,,Ravensburg,Baden-Württemberg,88212,Germany,+49 751 36990,http://www.leibinger.de,9.6210866,47.781332
-4ba0bffd-2d96-4655-959f-66fc3a2c0a8a,Lindenbräu,brewpub,43 Stuttgarter Straße,,,Waldbronn,Baden-Württemberg,76337,Germany,+49 7243 652881,http://www.lindenbraeu-waldbronn.de,8.478138999999999,48.9254312
-295c4e3b-73d8-4288-8774-3c92e46134fc,Lobdengau-Brauerei,brewpub,101 Schriesheimer Straße,,,Ladenburg,Baden-Württemberg,68526,Germany,+49 173 8623820,http://www.lobdengau-brauerei.de,8.635884899999999,49.4692233
-9d8aa3bc-9287-4a99-9911-a16fc5c0cd78,Löwen,brewpub,23 Sasbachwaldener Straße,,,Sasbach,Baden-Württemberg,77880,Germany,+49 7841 20780,http://www.loewen-sasbach.de,8.1044064,48.6320457
-5301ab27-4d23-426b-8004-554ed8f4b0b8,Löwenbrauerei,brewpub,4 Friedhofweg,,,Bräunlingen,Baden-Württemberg,78199,Germany,+49 771 61121,http://www.braeunlinger-loewenbrauerei.de,8.45082,47.92717
-8c0aaa67-6cd9-4f2d-99a0-1aba40f1c916,Löwenbrauerei Wasseralfingen,brewpub,162 Wilhelmstraße,,,Aalen,Baden-Württemberg,73433,Germany,+49 7361 57200,http://www.wasseralfinger.de,10.09898,48.85067
-e61dde28-e5cb-4fba-8f65-30b6fdf0543e,Mall,closed,23 Eschelbronner Straße,,,Meckesheim,Baden-Württemberg,74909,Germany,+49 6226 785450,http://www.mall-braeu.de,8.82293,49.3185
-88182e4d-0de9-4113-aa9d-7c623ac0c5c3,Mangold,brewpub,3-8 Veitsbrunnenweg,,,Ulm,Baden-Württemberg,89073,Germany,+49 731 1640,http://www.mangold.hn,9.9906291,48.4065628
-e65e27fa-1982-4aea-9d93-0fb9a4077b36,Markgräfler Brauwerk,brewpub,1 Flühgasse,,,Kandern,Baden-Württemberg,79400,Germany,+49 176 45968965,http://www.markgraefler-brauwerk.de,7.607081999999998,47.710753
-49d23a47-fb8f-4f11-841d-ad2e01cc0e3a,Martin's Bräu,brewpub,237 Kaiser-Joseph-Straße,,,Freiburg im Breisgau,Baden-Württemberg,79098,Germany,+49 761 3870018,http://www.mbfr.de,7.8495611,47.99365239999999
-27035f7a-63e0-43b4-9cc1-57244dad4190,Max & Moritz,brewpub,6 Weinbichl,,,Kressbronn am Bodensee,Baden-Württemberg,88079,Germany,+49 7543 6508,http://www.maxmoritz-bier.de,9.6058571,47.6062796
-82a020b0-2f23-48fe-9cfc-05cc30a5b9dd,Michelbr,brewpub,10 Schwanner Straße,,,Straubenhardt,Baden-Württemberg,75334,Germany,+49 177 3094339,http://www.michelbraeu.de,8.5311938,48.8539882
-050ab871-bdc8-4d50-babc-d3a3517a2fb9,Mönchwasen,brewpub,30 Im Mönchgraben,,,Simmozheim,Baden-Württemberg,75397,Germany,+49 7033 809030,http://www.moenchwasen.com,8.80667,48.74584
-28db6031-2bdc-4d97-8914-2c59668b2be3,Mosbacher Brauhaus,brewpub,18 Eisenbahnstraße,,,Mosbach,Baden-Württemberg,74821,Germany,+49 6261 36969,http://www.mosbacher-brauhaus.de,9.1415601,49.3512099
-74ece269-6bcb-49a8-b0d3-5451a3e84d96,Mülhaupt,brewpub,26 Mulsowstraße,,,Lörrach,Baden-Württemberg,79541,Germany,+49 7621 51654,http://www.hausbraeu-muelhaupt.de,7.6930556,47.6313583
-d73bbe10-425b-4f7e-a3e7-4c5d6bb2e05b,Nattheimer,brewpub,7 Heidenheimer Straße,,,Nattheim,Baden-Württemberg,89564,Germany,+49 7321 97980,http://www.nattheimer.de,10.2401356,48.6995845
-9ecbcbd1-5625-4c7d-b84f-cc67190c9eb2,Naturkost Lang,closed,24/1 Wimpfener Straße,,,Neckarsulm,Baden-Württemberg,74172,Germany,+49 7132 43427,http://www.naturkost-lang.de,9.203669999999999,49.19801
-5f1ede1a-402c-4220-9e0b-814e08156531,Neckarmüller,brewpub,4 Gartenstraße,,,Tübingen,Baden-Württemberg,72074,Germany,+49 7071 27848,http://www.neckarmueller.de,9.0586193,48.5193271
-a734ee5e-a520-4f22-9339-acbbd8581c27,Neckarsulmer Brauhaus,brewpub,9 Felix-Wankel-Straße,,,Neckarsulm,Baden-Württemberg,74172,Germany,+49 7132 343511,http://www.neckarsulmer-brauhaus.de,9.2251207,49.1935146
-da903134-6e11-4d59-a39d-76378ac43b91,Neuenstädter Biermanufaktur,brewpub,6 Helmbundstraße,,,Neuenstadt am Kocher,Baden-Württemberg,74196,Germany,+49 176 87944600,,9.3278,49.23659
-4a77146a-97de-431d-ac65-1825e3f7c280,Neureuter Braumanufaktur,brewpub,59 Durmersheimer Straße,,,Karlsruhe,Baden-Württemberg,76185,Germany,+49 721 57020,http://www.braumanufaktur-neureut.de,8.3543264,49.0018676
-eee8c88b-20a1-47ba-ace7-9fab250138ac,Ochsenbräu,closed,5 Albrecht-Wirt-Straße,,,Rottenburg am Neckar,Baden-Württemberg,72108,Germany,+49 7457 1263,http://www.ochsenbrauerei.de,8.809683699999999,48.4952468
-be9f49b0-c496-4065-9fc1-49424d05e424,Ostel Bräu,brewpub,2 Riegeler Straße,,,Endingen am Kaiserstuhl,Baden-Württemberg,79346,Germany,,http://ostelbraeu.de/,7.7081686,48.1414996
-6068deb4-d365-49bb-a729-990c4fbfa318,Palmbräu,brewpub,2 Ludwig-Zorn-Straße,,,Eppingen,Baden-Württemberg,75031,Germany,+49 7262 6020,http://www.palmbraeu.de,8.90837,49.13762999999999
-1d75c91c-6c40-4be4-a092-3aeb5f734f92,Pflugbrauerei,brewpub,7 Wirtsgasse,,,Langenau,Baden-Württemberg,89129,Germany,+49 7348 6237,http://www.pflugbrauerei.de,10.0276355,48.4859605
-47fd2a30-a032-4401-ac93-4eb2dd4f9227,Poppel-Mühle,closed,11 Mühleweg,,,Enzklösterle,Baden-Württemberg,75337,Germany,+49 7085 7870,http://www.poppel-muehle.de,8.43801,48.62724
-48f7c0ae-b304-4e19-8cb5-79f3b163ead2,Prestelbräu,brewpub,2a Obere Mühlstraße,,,Ubstadt-Weiher,Baden-Württemberg,76698,Germany,+49 163 1302511,http://www.prestelbräu.de,8.64894,49.18295
-52220ab8-a491-4f78-a1d3-c1b1ed0add0c,Rega Bräu,brewpub,20 Lerchenstraße,,,Waibstadt,Baden-Württemberg,74915,Germany,+49 178 6122172,http://www.rega-braeu.de,8.91803,49.29765
-e801d573-214b-40d1-b0e8-26ff18405abc,Reichenau Inselbier,brewpub,7 Am Vögelisberg,,,Reichenau,Baden-Württemberg,78479,Germany,+49 176 21818393,http://www.reichenau-inselbier.de,9.0689409,47.6939726
-1c52becd-05a6-491c-90a3-41d914c2a039,Reiners Rosine,brewpub,6 Bildstraße,,,Flein,Baden-Württemberg,74223,Germany,+49 7131 30909,http://www.reiners-rosine.de,9.2170264,49.1021327
-fa5b7c01-f633-43a0-a6c7-99011d87512b,Rogg,brewpub,61-65 Bonndorfer Straße,,,Lenzkirch,Baden-Württemberg,79853,Germany,,http://www.brauerei-rogg.de,8.223880399999999,47.8612834
-1bdcdaef-0d0d-48b7-a717-185785405443,Römerbräu,brewpub,2 Großherzog-Leopold-Platz,,,Riegel am Kaiserstuhl,Baden-Württemberg,79359,Germany,+49 160 94144467,http://www.roemerbraeu.de,7.7533902,48.1484312
-eba4c2fa-fe4e-4800-ace9-29d2139a8f44,Rommelmühle,brewpub,60 Flößerstraße,,,Bietigheim-Bissingen,Baden-Württemberg,74321,Germany,+49 7142 9938490,http://www.brauhaus-rommelmuehle.de,9.0990416,48.9487523
-b447927d-96ba-4ac1-91db-4be12f4f1ae2,Rossknecht,brewpub,21 Reithausplatz,,,Ludwigsburg,Baden-Württemberg,71634,Germany,+49 7141 902551,http://www.rossknecht.net,9.1888154,48.8991509
-11a3d14c-8f36-4520-8448-8260507bc17e,Rößle,brewpub,8 Obere Torstraße,,,Neubulach,Baden-Württemberg,75387,Germany,+49 7053 7766,http://www.roessle-neubulach.de,8.694891,48.6617894
-ba2f5010-96eb-4020-8afd-c0fafc53b596,Rothaus,brewpub,1 Rothaus,,,Grafenhausen,Baden-Württemberg,79865,Germany,+49 7748 5220,http://www.rothaus.de,8.2449303,47.7955017
-1be002bf-94d8-4b0f-95ff-955b1a4f3955,Rotochsen,brewpub,4 Alte Steige,,,Ellwangen (Jagst),Baden-Württemberg,73479,Germany,+49 7961 2039,http://www.roter-ochsen-ellwangen.de,10.138083,48.959929
-f9f493bd-7613-442a-a40b-6e2845c28083,Ruppaner,brewpub,41-51 Hoheneggstraße,,,Konstanz,Baden-Württemberg,78464,Germany,+49 7531 93730,http://www.ruppaner.de,9.2078911,47.6857011
-e829844f-7662-4f5e-a1d5-335e23d6f126,Sacher,brewpub,82 Bahnhofstraße,,,Leonberg,Baden-Württemberg,71229,Germany,+49 7152 339515,http://www.brauhaus-sacher.de,9.003049899999999,48.79913750000001
-aa0efba9-b620-467e-bbb6-0ef2b31eafa6,Salzscheuer,brewpub,11 Mittlere Holdergasse,,,Marbach am Neckar,Baden-Württemberg,71672,Germany,+49 7144 889754,http://www.salzscheuer.com,9.2573104,48.9411671
-9c864f49-790d-4a4c-afb7-db402f6a39ad,Schlachthof,brewpub,15 Mühlstraße,,,Nürtingen,Baden-Württemberg,72622,Germany,+49 7022 939571,http://www.schlachthofbraeu.de,9.334195,48.6294309
-23534f99-8067-4cb8-aad9-54ca8e06c677,Schlossbrauerei,brewpub,30 Hauptstraße,,,Aulendorf,Baden-Württemberg,88326,Germany,+49 7525 9213520,http://www.schlossbrauerei-aulendorf.de,9.638224,47.954831
-ce9d043b-3185-4290-951e-d36953b4b47a,Schlüsselbräu,brewpub,34 Oggenhauser Straße,,,Giengen an der Brenz,Baden-Württemberg,89537,Germany,+49 7322 96570,http://www.schluesselbraeu.de,10.2442936,48.6258341
-0ec22be2-75c6-462a-b561-585f71a11625,Schnitzerbräu,brewpub,9 Marlener Straße,,,Offenburg,Baden-Württemberg,77656,Germany,+49 781 125570,http://www.schnitzerbraeu.de,7.925876999999999,48.469551
-0825123f-f6da-4aa8-9230-bf2853216768,Schönbuch,brewpub,20 Lange Straße,,,Böblingen,Baden-Württemberg,71032,Germany,+49 7031 681323,http://www.schoenbuchbraeu.de,9.0173569,48.6843842
-c74a6d51-702b-47df-a88c-77c06e369235,Schörebräu,brewpub,2 Dietmannsweiler,,,Tettnang,Baden-Württemberg,88069,Germany,+49 7528 2317,http://www.schoere.de,9.6588444,47.656731
-c60e47c2-89ce-4bfe-a2dc-df63339c30a1,Schussenrieder,brewpub,12 Wilhelm-Schussen-Straße,,,Bad Schussenried,Baden-Württemberg,88427,Germany,+49 7583 4040,http://www.schussenrieder.de,9.6582198,48.0041016
-1c84e0e5-8a56-4365-93f7-8b34b96dcb39,Schwanen-Bräu,brewpub,36 Bernhäuser Hauptstraße,,,Filderstadt,Baden-Württemberg,70794,Germany,+49 711 706954,http://www.schwanen-braeu.de,9.2182968,48.6793827
-a07c830a-0608-4dc1-b187-a68e409ef5a4,Schwanenbrauerei,brewpub,18-20 Schwanengasse,,,Ehingen (Donau),Baden-Württemberg,89584,Germany,+49 7391 53420,http://www.schwanen-ehingen.de,9.728232499999999,48.2830996
-281e252e-3971-43b0-a365-50a7d05e95f8,Sonne,brewpub,1 Bösinger Straße,,,Bösingen,Baden-Württemberg,78662,Germany,+49 7404 2444,,8.58,48.2244444
-c0093a5c-58fa-43e1-92a3-5da60ca5771c,Sophie's Brauhaus,brewpub,28 Marienstraße,,,Stuttgart,Baden-Württemberg,70178,Germany,+49 711 610962,http://www.sophies-brauhaus.de,9.17231,48.77302
-3715d1b1-72d4-4b37-b259-6c5d79391434,Spall,brewpub,21 Georg-Metzler-Straße,,,Ravenstein,Baden-Württemberg,74747,Germany,+49 6297 219,,9.5513251,49.4000754
-69341b90-6f8f-424f-9918-a144daf06caa,Speidel's Brauerei'le,brewpub,5 Im Dorf,,,Hohenstein,Baden-Württemberg,72531,Germany,+49 7387 98900,http://www.speidels-brauereile.de,9.375336599999999,48.3482475
-8f6e05fd-e040-4132-8846-408a04e23b43,Stadtbräu Rimmele,brewpub,25 Hiltensweiler,,,Wangen im Allgäu,Baden-Württemberg,88239,Germany,+49 7528 97030,http://www.stadtbräu-rimmele.de,9.773755,47.6546898
-d1600c69-78cc-481f-918f-418f857f4526,Steinacher Hausbräu,closed,135 Steinacher Straße,,,Bad Waldsee,Baden-Württemberg,88339,Germany,+49 175 4188020,http://www.steinacherbier.de,9.737096,47.9198026
-e9c0da53-ca88-4d2c-a89a-cc93838637e4,Stiftsscheuer,brewpub,6-8 Widerholtstraße,,,Kirchheim unter Teck,Baden-Württemberg,73230,Germany,+49 7021 736154,http://www.stiftsscheuer.de,9.4522719,48.6490003
+9c64e21e-be0d-4805-a31e-d9f933c06cda,Häberlen,brewpub,Karlstraße 66,,,Gaildorf,Baden-Württemberg,74405,Germany,+49 7971 6250,http://www.brauerei-haeberlen.de,9.772335,48.99837489999999
+9f9ef817-e0a4-44f5-b454-6460f5732e9a,Hader Karle,brewpub,Längentalstraße 3,,,Villingen-Schwenningen,Baden-Württemberg,78052,Germany,+49 7721 63591,http://www.hader-karle.de,8.501249099999999,48.09449799999999
+e591bd3e-352b-43d6-9783-5de9556f7d4a,Häffner,brewpub,Salinenstraße 24,,,Bad Rappenau,Baden-Württemberg,74906,Germany,+49 7264 8050,http://www.haeffner-braeu.de,9.112063000000001,49.238093
+1187d3e8-4d29-43c0-8ea0-ea6757ab4dc4,Haller Löwenbräu,brewpub,Ritterstraße 6,,,Schwäbisch Hall,Baden-Württemberg,74523,Germany,+49 791 50901,http://www.haller-loewenbraeu.de,9.733312699999999,49.1060052
+5ae2d546-fb98-492c-863b-c3cd2edd592a,Härle,brewpub,Am Hopfengarten 5,,,Leutkirch im Allgäu,Baden-Württemberg,88299,Germany,+49 7561 98280,http://www.haerle.de,10.0240964,47.8236007
+3ab7d2d4-b9e7-4e43-be17-00e9863ba7e7,Härtsfelder,brewpub,Hofener Straße 19,,,Dischingen,Baden-Württemberg,89561,Germany,+49 7327 92290,http://www.haertsfelder.de,10.4131985,48.7229045
+19c75963-66ef-45f0-b3e2-c6777684ddda,Hatz- Moninger,brewpub,Durmersheimer Straße 59,,,Karlsruhe,Baden-Württemberg,76185,Germany,+49 721 57020,http://www.hatz-moninger.de,8.3543264,49.0018676
+dea548e8-6f6e-42b4-b965-d4143b2e26a8,Hausbrauerei JeSa,brewpub,Steingasse 9,,,Heidelberg,Baden-Württemberg,69117,Germany,+49 6221 165850,http://www.hausbrauerei-jesa.de,8.7096851,49.4126062
+a6005c74-6872-4d86-8738-c0e83202627d,Heidelberger,brewpub,Kurpfalzring 112,,,Heidelberg,Baden-Württemberg,69123,Germany,+49 6221 90140,http://www.heidelberger-brauerei.de,8.639920199999999,49.4048233
+85da8b2a-8088-4bf2-8c48-3a901442dbb0,Herbsthäuser,brewpub,Alte Kaiserstraße 28/1,,,Bad Mergentheim,Baden-Württemberg,97980,Germany,+49 7932 91000,http://www.herbsthaeuser.de,9.8295912,49.40393299999999
+72e61cd5-16b9-4c0d-aa4a-b9ea6d443638,Herr's Kleines Bierhaus,closed,Hauptstraße 55,,,Schwanau,Baden-Württemberg,77963,Germany,,http://www.kleinesbierhaus.de,7.756960999999999,48.32830999999999
+3d1ed94a-ccf9-40e8-8975-297c304a70d8,Heubacher,brewpub,Hauptstraße 99,,,Heubach,Baden-Württemberg,73540,Germany,+49 7173 18000,http://www.heubacher.de,9.936866499999999,48.7857784
+09884eb6-b343-44db-82e3-351d2090ead3,Heuberger Biermanufaktur,brewpub,Storzinger Straße 10,,,Stetten am kalten Markt,Baden-Württemberg,72510,Germany,,http://www.heuberger-biermanufaktur.de,9.0790706,48.122191
+93c29f97-316a-460b-b7a7-12198f7d95f0,Hey Joe Brewing,brewpub,Siegelsberger Straße 93,,,Murrhardt,Baden-Württemberg,71540,Germany,,http://www.heyjoebrewing.com,9.58845,48.99005
+4df10699-84df-4ad8-9c6c-3ce114085cce,Hieber's FrischeCenter,brewpub,Meeraner Platz 1,,,Lörrach,Baden-Württemberg,79539,Germany,+49 7621 914020,http://www.hieber.de,7.6582544,47.6079112
+4da2a973-1404-4ca4-8a0d-38a79219e27c,Hirsch,brewpub,Friedrichstraße 34,,,Wurmlingen,Baden-Württemberg,78573,Germany,+49 7461 9420,http://www.hirschbrauerei-soehnstetten.de,8.776947999999999,48.0053516
+2dee6626-c449-4d09-b809-38ef6d144dce,Hirschbräu,brewpub,Ringstraße 1,,,Rosenberg,Baden-Württemberg,74749,Germany,+49 6295 7159,http://www.hirschbraeu-hirschlanden.de,9.4998019,49.4743161
+20f427c9-b111-4938-a462-48e94e38d3c7,Hirschbrauerei,brewpub,Eschachstraße 15,,,Zimmern ob Rottweil,Baden-Württemberg,78658,Germany,+49 7403 489,http://www.hirsch-braeu.de,8.5322765,48.1668107
+55e18609-9d3f-4c54-bb7a-d29fba3dc369,Hirschbrauerei Schilling,closed,Aglishardter Straße 37,,,Römerstein,Baden-Württemberg,72587,Germany,+49 7382 93880,http://www.boehringer-biere.de,9.508918699999999,48.4920082
+7ca0eb65-5a5c-4446-9c5f-4022d55c8279,Hirschenbrauerei,micro,Goethestraße 21,,,Waldkirch,Baden-Württemberg,79183,Germany,+49 7681 40810,http://www.hirschenbrauerei.de,7.9591197,48.0887685
+569b5a8c-fe94-49dc-9ef1-42ae7b197e45,Hirtler,brewpub,Eichstetter Straße 10,,,March,Baden-Württemberg,79232,Germany,+49 7665 3304,http://www.brauerei-hirtler.de/,7.770066099999999,48.0689491
+35bc2139-4fcd-429e-b24c-9407c44628f5,Hochdorfer Kronenbrauerei,brewpub,Rottweiler Straße 16-20,,,Nagold,Baden-Württemberg,72202,Germany,+49 7459 92920,http://www.hochdorfer.de,8.7216124,48.4940448
+ca4ef6fd-1ed8-4502-a7ea-32b5b510a7f7,Hoepfner,brewpub,Haid-und-Neu-Straße 18,,,Karlsruhe,Baden-Württemberg,76131,Germany,+49 721 61830,http://www.hoepfner.de,8.4269801,49.0123462
+89fd5590-089a-4444-8815-280f33b0be0e,Hopfengut No20,brewpub,Hopfengut 20,,,Tettnang,Baden-Württemberg,88069,Germany,+49 7542 952206,http://www.hopfengut.de,9.6163814,47.6905211
+f441adfc-e3cc-48cb-9031-079982d78854,Hopfenschlingel,brewpub,Militärstraße 2,,,Rastatt,Baden-Württemberg,76437,Germany,+49 7222 30099,http://www.hopfenschlingel-pforzheim.de/,8.2115966,48.8494015
+92b15e6b-62b6-4c3d-a674-5419ab1d292e,HopfX Bräu,closed,Bahnhofstraße 43,,,Tuttlingen,Baden-Württemberg,78532,Germany,,http://www.facebook.com/HopfXBraeuTuttlingen/,8.8137709,47.9832651
+8d58821b-75b6-400b-a5b9-874ee0b719f8,Joh. Albrecht,brewpub,Konradigasse 2,,,Konstanz,Baden-Württemberg,78462,Germany,+49 7531 25045,http://www.konstanz.brauhaus-joh-albrecht.de,9.175008499999999,47.6650112
+fde19132-3a27-4acb-88ba-e91c50b095ac,Jupiter,closed,Keltergasse 21,,,Sinsheim,Baden-Württemberg,74889,Germany,+49 7261 975537,http://www.brauhausjupiter.de,8.9051685,49.2394256
+f5d41049-75a4-4b3d-a79b-8848b6f4e45a,Kaiser,brewpub,Schubartstraße 24/26,,,Geislingen an der Steige,Baden-Württemberg,73312,Germany,+49 7331 93720,http://www.kaiser-brauerei.de,9.840786900000001,48.6135978
+8f7146ca-e0a1-4d09-96ea-4bd047c09a9d,Kesselhaus,brewpub,Arnoldstraße 3,,,Schorndorf,Baden-Württemberg,73614,Germany,+49 7181 484933,http://www.kesselhaus-schorndorf.de,9.5315062,48.8067612
+428956a8-d38a-4de9-a4da-a9731b6e13f6,Ketterer,brewpub,Jahnstraße 10,,,Pforzheim,Baden-Württemberg,75173,Germany,+49 7231 92110,http://www.brauerei-ketterer.de,8.6949614,48.88868739999999
+1f9a066a-f103-49bf-bf70-2e86050bb6aa,Kißlegger Kellerbräu,closed,Fürst-Maximilian-Straße 3,,,Kißlegg,Baden-Württemberg,88353,Germany,+49 7563 91090,http://www.kisslegger-kellerbraeu.de,9.8815598,47.7871065
+b2174086-a81e-40bd-b417-ea2a90aafac7,Klosterhof,brewpub,Stiftweg 4,,,Heidelberg,Baden-Württemberg,69118,Germany,+49 6221 6520365,http://www.brauerei-zum-klosterhof.de,8.740091900000001,49.4204577
+cd03f666-0d86-49aa-a454-0ea75a61d702,Königsbräu Majer,brewpub,Oggenhauser Hauptstraße 1,,,Heidenheim an der Brenz,Baden-Württemberg,89522,Germany,+49 7321 97970,http://www.koenigsbraeu.de,10.2359869,48.67018179999999
+5dc16ffb-53ba-456d-8601-6987f0171479,Königsegger Walderbräu,brewpub,Hauptstraße 6,,,Königseggwald,Baden-Württemberg,88376,Germany,+49 7587 95040,http://www.koenigsegger.de,9.4206063,47.9258844
+a69fee5a-7b4b-4a00-a228-4e1ed0f73f31,Krokodil,brewpub,In Grubäcker 15,,,Trossingen,Baden-Württemberg,78647,Germany,+49 7425 21194,http://www.krokodil-trossingen.de,8.628559,48.07165639999999
+02609436-82a3-4a8f-9cf2-b66b55e0e4ee,Krone,brewpub,Bärenplatz 7,,,Tettnang,Baden-Württemberg,88069,Germany,+49 7542 7452,http://www.krone-tettnang.de,9.588956,47.671561
+3d81eb1a-0d72-4938-ac67-062c313350d2,Kronenbrauerei,brewpub,Kirchberg 5,,,Laupheim,Baden-Württemberg,88471,Germany,+49 7392 8345,http://www.kronenbrauerei-laupheim.de,9.8860393,48.2294
+5a1bc158-3f43-49bc-8c27-6b8235aa09c0,Kronenbrauerei Schimpf,brewpub,Hauptstraße 1,,,Neustetten,Baden-Württemberg,72149,Germany,+49 7472 98940,http://www.brauerei-schimpf.de,8.887230599999999,48.48200730000001
+109f15c2-2c21-4f43-a692-338e3bb679d4,Kronenbrauerei Söflingen,brewpub,Uhrenmachergasse 10,,,Ulm,Baden-Württemberg,89077,Germany,+49 731 388320,http://www.soeflinger-kronenbier.de,9.9559727,48.3952774
+f52bc93d-92fe-4729-a8df-241909873fa0,Kühler Krug,brewpub,Wilhelm-Baur-Straße 3a,,,Karlsruhe,Baden-Württemberg,76135,Germany,+49 721 8316416,http://www.brauhaus-kuehler-krug.de,8.368266799999999,49.00409819999999
+da672eef-21a1-4552-b119-fbd2762476f1,Kulturbrauerei,brewpub,Leyergasse 6,,,Heidelberg,Baden-Württemberg,69117,Germany,+49 6221 502980,http://www.heidelberger-kulturbrauerei.de,8.7131758,49.4131355
+21768171-8411-4c79-9a60-ddde23fc5ae4,Ladenburger,brewpub,Hauptstraße 16,,,Neuler,Baden-Württemberg,73491,Germany,+49 7961 91140,http://www.brauerei-ladenburger.de,10.0674097,48.9276432
+c1e2f5c9-0cdb-4761-900e-a641d88d13c5,Lamm,brewpub,Nellmersbacher Straße 2,,,Leutenbach,Baden-Württemberg,71397,Germany,+49 7195 9779230,http://www.lamm-leutenbach.de,9.3929081,48.8876645
+3dc7ad60-2e9c-4f5f-94f7-266939905e52,Lammbrauerei,brewpub,Haller Straße 2,,,Abtsgmünd,Baden-Württemberg,73453,Germany,+49 7975 284,http://www.lammbrauerei.de,9.89177,48.91881
+88b34b96-2f91-4de5-a1ee-f12ff0f3183b,Lammbrauerei Hilsenbeck,brewpub,Hauptstraße 37,,,Gruibingen,Baden-Württemberg,73344,Germany,+49 7335 96440,http://www.lammbrauerei-hilsenbeck.de,9.642365999999999,48.5953507
+2cf1e09f-a630-4e93-9172-79c05df11345,Lasser,brewpub,Belchenstraße 5,,,Lörrach,Baden-Württemberg,79539,Germany,+49 7621 40200,http://www.lasser.de,7.663968199999999,47.6114046
+9d2d464b-65d6-4da9-a1d7-bd80fea9b026,Lehner,brewpub,Balinger Straße 7,,,Rosenfeld,Baden-Württemberg,72348,Germany,+49 7428 945160,http://www.lehner-wein.de,8.72348,48.28667979999999
+3a6be169-b268-40de-8e30-834d3fd4b856,Leibinger,brewpub,Friedhofstraße 26,,,Ravensburg,Baden-Württemberg,88212,Germany,+49 751 36990,http://www.leibinger.de,9.6210866,47.781332
+4ba0bffd-2d96-4655-959f-66fc3a2c0a8a,Lindenbräu,brewpub,Stuttgarter Straße 43,,,Waldbronn,Baden-Württemberg,76337,Germany,+49 7243 652881,http://www.lindenbraeu-waldbronn.de,8.478138999999999,48.9254312
+295c4e3b-73d8-4288-8774-3c92e46134fc,Lobdengau-Brauerei,brewpub,Schriesheimer Straße 101,,,Ladenburg,Baden-Württemberg,68526,Germany,+49 173 8623820,http://www.lobdengau-brauerei.de,8.635884899999999,49.4692233
+9d8aa3bc-9287-4a99-9911-a16fc5c0cd78,Löwen,brewpub,Sasbachwaldener Straße 23,,,Sasbach,Baden-Württemberg,77880,Germany,+49 7841 20780,http://www.loewen-sasbach.de,8.1044064,48.6320457
+5301ab27-4d23-426b-8004-554ed8f4b0b8,Löwenbrauerei,brewpub,Friedhofweg 4,,,Bräunlingen,Baden-Württemberg,78199,Germany,+49 771 61121,http://www.braeunlinger-loewenbrauerei.de,8.45082,47.92717
+8c0aaa67-6cd9-4f2d-99a0-1aba40f1c916,Löwenbrauerei Wasseralfingen,brewpub,Wilhelmstraße 162,,,Aalen,Baden-Württemberg,73433,Germany,+49 7361 57200,http://www.wasseralfinger.de,10.09898,48.85067
+e61dde28-e5cb-4fba-8f65-30b6fdf0543e,Mall,closed,Eschelbronner Straße 23,,,Meckesheim,Baden-Württemberg,74909,Germany,+49 6226 785450,http://www.mall-braeu.de,8.82293,49.3185
+88182e4d-0de9-4113-aa9d-7c623ac0c5c3,Mangold,brewpub,Veitsbrunnenweg 3-8,,,Ulm,Baden-Württemberg,89073,Germany,+49 731 1640,http://www.mangold.hn,9.9906291,48.4065628
+e65e27fa-1982-4aea-9d93-0fb9a4077b36,Markgräfler Brauwerk,brewpub,Flühgasse 1,,,Kandern,Baden-Württemberg,79400,Germany,+49 176 45968965,http://www.markgraefler-brauwerk.de,7.607081999999998,47.710753
+49d23a47-fb8f-4f11-841d-ad2e01cc0e3a,Martin's Bräu,brewpub,Kaiser-Joseph-Straße 237,,,Freiburg im Breisgau,Baden-Württemberg,79098,Germany,+49 761 3870018,http://www.mbfr.de,7.8495611,47.99365239999999
+27035f7a-63e0-43b4-9cc1-57244dad4190,Max & Moritz,brewpub,Weinbichl 6,,,Kressbronn am Bodensee,Baden-Württemberg,88079,Germany,+49 7543 6508,http://www.maxmoritz-bier.de,9.6058571,47.6062796
+82a020b0-2f23-48fe-9cfc-05cc30a5b9dd,Michelbr,brewpub,Schwanner Straße 10,,,Straubenhardt,Baden-Württemberg,75334,Germany,+49 177 3094339,http://www.michelbraeu.de,8.5311938,48.8539882
+050ab871-bdc8-4d50-babc-d3a3517a2fb9,Mönchwasen,brewpub,Im Mönchgraben 30,,,Simmozheim,Baden-Württemberg,75397,Germany,+49 7033 809030,http://www.moenchwasen.com,8.80667,48.74584
+28db6031-2bdc-4d97-8914-2c59668b2be3,Mosbacher Brauhaus,brewpub,Eisenbahnstraße 18,,,Mosbach,Baden-Württemberg,74821,Germany,+49 6261 36969,http://www.mosbacher-brauhaus.de,9.1415601,49.3512099
+74ece269-6bcb-49a8-b0d3-5451a3e84d96,Mülhaupt,brewpub,Mulsowstraße 26,,,Lörrach,Baden-Württemberg,79541,Germany,+49 7621 51654,http://www.hausbraeu-muelhaupt.de,7.6930556,47.6313583
+d73bbe10-425b-4f7e-a3e7-4c5d6bb2e05b,Nattheimer,brewpub,Heidenheimer Straße 7,,,Nattheim,Baden-Württemberg,89564,Germany,+49 7321 97980,http://www.nattheimer.de,10.2401356,48.6995845
+9ecbcbd1-5625-4c7d-b84f-cc67190c9eb2,Naturkost Lang,closed,Wimpfener Straße 24/1,,,Neckarsulm,Baden-Württemberg,74172,Germany,+49 7132 43427,http://www.naturkost-lang.de,9.203669999999999,49.19801
+5f1ede1a-402c-4220-9e0b-814e08156531,Neckarmüller,brewpub,Gartenstraße 4,,,Tübingen,Baden-Württemberg,72074,Germany,+49 7071 27848,http://www.neckarmueller.de,9.0586193,48.5193271
+a734ee5e-a520-4f22-9339-acbbd8581c27,Neckarsulmer Brauhaus,brewpub,Felix-Wankel-Straße 9,,,Neckarsulm,Baden-Württemberg,74172,Germany,+49 7132 343511,http://www.neckarsulmer-brauhaus.de,9.2251207,49.1935146
+da903134-6e11-4d59-a39d-76378ac43b91,Neuenstädter Biermanufaktur,brewpub,Helmbundstraße 6,,,Neuenstadt am Kocher,Baden-Württemberg,74196,Germany,+49 176 87944600,,9.3278,49.23659
+4a77146a-97de-431d-ac65-1825e3f7c280,Neureuter Braumanufaktur,brewpub,Durmersheimer Straße 59,,,Karlsruhe,Baden-Württemberg,76185,Germany,+49 721 57020,http://www.braumanufaktur-neureut.de,8.3543264,49.0018676
+eee8c88b-20a1-47ba-ace7-9fab250138ac,Ochsenbräu,closed,Albrecht-Wirt-Straße 5,,,Rottenburg am Neckar,Baden-Württemberg,72108,Germany,+49 7457 1263,http://www.ochsenbrauerei.de,8.809683699999999,48.4952468
+be9f49b0-c496-4065-9fc1-49424d05e424,Ostel Bräu,brewpub,Riegeler Straße 2,,,Endingen am Kaiserstuhl,Baden-Württemberg,79346,Germany,,http://ostelbraeu.de/,7.7081686,48.1414996
+6068deb4-d365-49bb-a729-990c4fbfa318,Palmbräu,brewpub,Ludwig-Zorn-Straße 2,,,Eppingen,Baden-Württemberg,75031,Germany,+49 7262 6020,http://www.palmbraeu.de,8.90837,49.13762999999999
+1d75c91c-6c40-4be4-a092-3aeb5f734f92,Pflugbrauerei,brewpub,Wirtsgasse 7,,,Langenau,Baden-Württemberg,89129,Germany,+49 7348 6237,http://www.pflugbrauerei.de,10.0276355,48.4859605
+47fd2a30-a032-4401-ac93-4eb2dd4f9227,Poppel-Mühle,closed,Mühleweg 11,,,Enzklösterle,Baden-Württemberg,75337,Germany,+49 7085 7870,http://www.poppel-muehle.de,8.43801,48.62724
+48f7c0ae-b304-4e19-8cb5-79f3b163ead2,Prestelbräu,brewpub,Obere Mühlstraße 2a,,,Ubstadt-Weiher,Baden-Württemberg,76698,Germany,+49 163 1302511,http://www.prestelbräu.de,8.64894,49.18295
+52220ab8-a491-4f78-a1d3-c1b1ed0add0c,Rega Bräu,brewpub,Lerchenstraße 20,,,Waibstadt,Baden-Württemberg,74915,Germany,+49 178 6122172,http://www.rega-braeu.de,8.91803,49.29765
+e801d573-214b-40d1-b0e8-26ff18405abc,Reichenau Inselbier,brewpub,Am Vögelisberg 7,,,Reichenau,Baden-Württemberg,78479,Germany,+49 176 21818393,http://www.reichenau-inselbier.de,9.0689409,47.6939726
+1c52becd-05a6-491c-90a3-41d914c2a039,Reiners Rosine,brewpub,Bildstraße 6,,,Flein,Baden-Württemberg,74223,Germany,+49 7131 30909,http://www.reiners-rosine.de,9.2170264,49.1021327
+fa5b7c01-f633-43a0-a6c7-99011d87512b,Rogg,brewpub,Bonndorfer Straße 61-65,,,Lenzkirch,Baden-Württemberg,79853,Germany,,http://www.brauerei-rogg.de,8.223880399999999,47.8612834
+1bdcdaef-0d0d-48b7-a717-185785405443,Römerbräu,brewpub,Großherzog-Leopold-Platz 2,,,Riegel am Kaiserstuhl,Baden-Württemberg,79359,Germany,+49 160 94144467,http://www.roemerbraeu.de,7.7533902,48.1484312
+eba4c2fa-fe4e-4800-ace9-29d2139a8f44,Rommelmühle,brewpub,Flößerstraße 60,,,Bietigheim-Bissingen,Baden-Württemberg,74321,Germany,+49 7142 9938490,http://www.brauhaus-rommelmuehle.de,9.0990416,48.9487523
+b447927d-96ba-4ac1-91db-4be12f4f1ae2,Rossknecht,brewpub,Reithausplatz 21,,,Ludwigsburg,Baden-Württemberg,71634,Germany,+49 7141 902551,http://www.rossknecht.net,9.1888154,48.8991509
+11a3d14c-8f36-4520-8448-8260507bc17e,Rößle,brewpub,Obere Torstraße 8,,,Neubulach,Baden-Württemberg,75387,Germany,+49 7053 7766,http://www.roessle-neubulach.de,8.694891,48.6617894
+ba2f5010-96eb-4020-8afd-c0fafc53b596,Rothaus,brewpub,Rothaus 1,,,Grafenhausen,Baden-Württemberg,79865,Germany,+49 7748 5220,http://www.rothaus.de,8.2449303,47.7955017
+1be002bf-94d8-4b0f-95ff-955b1a4f3955,Rotochsen,brewpub,Alte Steige 4,,,Ellwangen (Jagst),Baden-Württemberg,73479,Germany,+49 7961 2039,http://www.roter-ochsen-ellwangen.de,10.138083,48.959929
+f9f493bd-7613-442a-a40b-6e2845c28083,Ruppaner,brewpub,Hoheneggstraße 41-51,,,Konstanz,Baden-Württemberg,78464,Germany,+49 7531 93730,http://www.ruppaner.de,9.2078911,47.6857011
+e829844f-7662-4f5e-a1d5-335e23d6f126,Sacher,brewpub,Bahnhofstraße 82,,,Leonberg,Baden-Württemberg,71229,Germany,+49 7152 339515,http://www.brauhaus-sacher.de,9.003049899999999,48.79913750000001
+aa0efba9-b620-467e-bbb6-0ef2b31eafa6,Salzscheuer,brewpub,Mittlere Holdergasse 11,,,Marbach am Neckar,Baden-Württemberg,71672,Germany,+49 7144 889754,http://www.salzscheuer.com,9.2573104,48.9411671
+9c864f49-790d-4a4c-afb7-db402f6a39ad,Schlachthof,brewpub,Mühlstraße 15,,,Nürtingen,Baden-Württemberg,72622,Germany,+49 7022 939571,http://www.schlachthofbraeu.de,9.334195,48.6294309
+23534f99-8067-4cb8-aad9-54ca8e06c677,Schlossbrauerei,brewpub,Hauptstraße 30,,,Aulendorf,Baden-Württemberg,88326,Germany,+49 7525 9213520,http://www.schlossbrauerei-aulendorf.de,9.638224,47.954831
+ce9d043b-3185-4290-951e-d36953b4b47a,Schlüsselbräu,brewpub,Oggenhauser Straße 34,,,Giengen an der Brenz,Baden-Württemberg,89537,Germany,+49 7322 96570,http://www.schluesselbraeu.de,10.2442936,48.6258341
+0ec22be2-75c6-462a-b561-585f71a11625,Schnitzerbräu,brewpub,Marlener Straße 9,,,Offenburg,Baden-Württemberg,77656,Germany,+49 781 125570,http://www.schnitzerbraeu.de,7.925876999999999,48.469551
+0825123f-f6da-4aa8-9230-bf2853216768,Schönbuch,brewpub,Lange Straße 20,,,Böblingen,Baden-Württemberg,71032,Germany,+49 7031 681323,http://www.schoenbuchbraeu.de,9.0173569,48.6843842
+c74a6d51-702b-47df-a88c-77c06e369235,Schörebräu,brewpub,Dietmannsweiler 2,,,Tettnang,Baden-Württemberg,88069,Germany,+49 7528 2317,http://www.schoere.de,9.6588444,47.656731
+c60e47c2-89ce-4bfe-a2dc-df63339c30a1,Schussenrieder,brewpub,Wilhelm-Schussen-Straße 12,,,Bad Schussenried,Baden-Württemberg,88427,Germany,+49 7583 4040,http://www.schussenrieder.de,9.6582198,48.0041016
+1c84e0e5-8a56-4365-93f7-8b34b96dcb39,Schwanen-Bräu,brewpub,Bernhäuser Hauptstraße 36,,,Filderstadt,Baden-Württemberg,70794,Germany,+49 711 706954,http://www.schwanen-braeu.de,9.2182968,48.6793827
+a07c830a-0608-4dc1-b187-a68e409ef5a4,Schwanenbrauerei,brewpub,Schwanengasse 18-20,,,Ehingen (Donau),Baden-Württemberg,89584,Germany,+49 7391 53420,http://www.schwanen-ehingen.de,9.728232499999999,48.2830996
+281e252e-3971-43b0-a365-50a7d05e95f8,Sonne,brewpub,Bösinger Straße 1,,,Bösingen,Baden-Württemberg,78662,Germany,+49 7404 2444,,8.58,48.2244444
+c0093a5c-58fa-43e1-92a3-5da60ca5771c,Sophie's Brauhaus,brewpub,Marienstraße 28,,,Stuttgart,Baden-Württemberg,70178,Germany,+49 711 610962,http://www.sophies-brauhaus.de,9.17231,48.77302
+3715d1b1-72d4-4b37-b259-6c5d79391434,Spall,brewpub,Georg-Metzler-Straße 21,,,Ravenstein,Baden-Württemberg,74747,Germany,+49 6297 219,,9.5513251,49.4000754
+69341b90-6f8f-424f-9918-a144daf06caa,Speidel's Brauerei'le,brewpub,Im Dorf 5,,,Hohenstein,Baden-Württemberg,72531,Germany,+49 7387 98900,http://www.speidels-brauereile.de,9.375336599999999,48.3482475
+8f6e05fd-e040-4132-8846-408a04e23b43,Stadtbräu Rimmele,brewpub,Hiltensweiler 25,,,Wangen im Allgäu,Baden-Württemberg,88239,Germany,+49 7528 97030,http://www.stadtbräu-rimmele.de,9.773755,47.6546898
+d1600c69-78cc-481f-918f-418f857f4526,Steinacher Hausbräu,closed,Steinacher Straße 135,,,Bad Waldsee,Baden-Württemberg,88339,Germany,+49 175 4188020,http://www.steinacherbier.de,9.737096,47.9198026
+e9c0da53-ca88-4d2c-a89a-cc93838637e4,Stiftsscheuer,brewpub,Widerholtstraße 6-8,,,Kirchheim unter Teck,Baden-Württemberg,73230,Germany,+49 7021 736154,http://www.stiftsscheuer.de,9.4522719,48.6490003
 f8e40a2f-b566-4a93-b9e6-5770bd48851b,Stiftungs-Bräu,micro,Neurott 20,,,Lobbach in Baden,Baden-Württemberg,74931,Germany,,http://www.msstiftung.de,,
-c856c007-1562-4f59-9f83-77bd9aa1f280,Stolz,brewpub,2 Rotenbacher Weg,,,Isny im Allgäu,Baden-Württemberg,88316,Germany,+49 7562 971130,http://www.brauerei-stolz.de,10.0437361,47.6964252
-094ad2f1-38be-4b15-a45f-b02726db9452,Stuttgarter Hofbräu,brewpub,132 Böblinger Straße,,,Stuttgart,Baden-Württemberg,70199,Germany,+49 711 64880,http://www.stuttgarter-hofbraeu.de,9.1539925,48.7613176
-25b61994-a923-41e7-9674-25a58bd67585,Sudhaus,brewpub,35/1 Lange Straße,,,Schwäbisch Hall,Baden-Württemberg,74523,Germany,,http://www.sudhaus-sha.de,9.733111899999999,49.11079489999999
-68cdc6f4-dfbe-464e-a1f4-16e4e225eebe,Sudwerkstatt,closed,3/1 Heerweg,,,Mössingen,Baden-Württemberg,72116,Germany,,http://www.sudwerkstatt.de,9.069119299999999,48.40999799999999
-d7378b89-055d-4323-9334-ba2652c2e9af,Tomo Bräu,closed,5 Im Gässle,,,Reutlingen,Baden-Württemberg,72770,Germany,+49 7121 580868,http://www.cafe-venus.de,9.1765148,48.49865519999999
-7d659d76-2e6f-4ba5-8603-a1fea00be200,Turm-Bräu,brewpub,64 Marktplatz,,,Freudenstadt,Baden-Württemberg,72250,Germany,+49 7441 905121,http://www.turmbraeu.de,8.4122567,48.4639187
-e506e435-6f5b-4f35-a3c1-39f673610416,Vetter,brewpub,9 Steingasse,,,Heidelberg,Baden-Württemberg,69117,Germany,+49 6221 165850,http://www.brauhaus-vetter.de,8.7096851,49.4126062
-c81b4a84-116e-4cd1-a85e-d6c3592e072a,Vogel Hausbräu,brewpub,4 Rheinstraße,,,Ettlingen,Baden-Württemberg,76275,Germany,+49 7243 13739,http://www.vogelbraeu.de,8.404943,48.94173019999999
-2983370a-cf64-4b60-ac24-d312aaf98282,Vogel Hausbräu (Durlach),brewpub,16 Amalienbadstraße,,,Karlsruhe,Baden-Württemberg,76227,Germany,+49 721 819680,http://www.vogelbraeu.de,8.4659696,48.99848679999999
-f487d70b-1639-4195-9562-a034627bb711,Vogelbräu (Karlsruhe),brewpub,50 Kapellenstraße,,,Karlsruhe,Baden-Württemberg,76131,Germany,+49 721 605438660,http://www.vogelbraeu.de,8.4140611,49.0074745
-b0a7d7a4-25f2-46d5-a84d-69dfb38815d6,Volksbräu,brewpub,6 Hauptstraße,,,Königseggwald,Baden-Württemberg,88376,Germany,+49 7587 95040,http://www.volksbraeu-durbach.de,9.4206063,47.9258844
+c856c007-1562-4f59-9f83-77bd9aa1f280,Stolz,brewpub,Rotenbacher Weg 2,,,Isny im Allgäu,Baden-Württemberg,88316,Germany,+49 7562 971130,http://www.brauerei-stolz.de,10.0437361,47.6964252
+094ad2f1-38be-4b15-a45f-b02726db9452,Stuttgarter Hofbräu,brewpub,Böblinger Straße 132,,,Stuttgart,Baden-Württemberg,70199,Germany,+49 711 64880,http://www.stuttgarter-hofbraeu.de,9.1539925,48.7613176
+25b61994-a923-41e7-9674-25a58bd67585,Sudhaus,brewpub,Lange Straße 35/1,,,Schwäbisch Hall,Baden-Württemberg,74523,Germany,,http://www.sudhaus-sha.de,9.733111899999999,49.11079489999999
+68cdc6f4-dfbe-464e-a1f4-16e4e225eebe,Sudwerkstatt,closed,Heerweg 3/1,,,Mössingen,Baden-Württemberg,72116,Germany,,http://www.sudwerkstatt.de,9.069119299999999,48.40999799999999
+d7378b89-055d-4323-9334-ba2652c2e9af,Tomo Bräu,closed,Im Gässle 5,,,Reutlingen,Baden-Württemberg,72770,Germany,+49 7121 580868,http://www.cafe-venus.de,9.1765148,48.49865519999999
+7d659d76-2e6f-4ba5-8603-a1fea00be200,Turm-Bräu,brewpub,Marktplatz 64,,,Freudenstadt,Baden-Württemberg,72250,Germany,+49 7441 905121,http://www.turmbraeu.de,8.4122567,48.4639187
+e506e435-6f5b-4f35-a3c1-39f673610416,Vetter,brewpub,Steingasse 9,,,Heidelberg,Baden-Württemberg,69117,Germany,+49 6221 165850,http://www.brauhaus-vetter.de,8.7096851,49.4126062
+c81b4a84-116e-4cd1-a85e-d6c3592e072a,Vogel Hausbräu,brewpub,Rheinstraße 4,,,Ettlingen,Baden-Württemberg,76275,Germany,+49 7243 13739,http://www.vogelbraeu.de,8.404943,48.94173019999999
+2983370a-cf64-4b60-ac24-d312aaf98282,Vogel Hausbräu (Durlach),brewpub,Amalienbadstraße 16,,,Karlsruhe,Baden-Württemberg,76227,Germany,+49 721 819680,http://www.vogelbraeu.de,8.4659696,48.99848679999999
+f487d70b-1639-4195-9562-a034627bb711,Vogelbräu (Karlsruhe),brewpub,Kapellenstraße 50,,,Karlsruhe,Baden-Württemberg,76131,Germany,+49 721 605438660,http://www.vogelbraeu.de,8.4140611,49.0074745
+b0a7d7a4-25f2-46d5-a84d-69dfb38815d6,Volksbräu,brewpub,Hauptstraße 6,,,Königseggwald,Baden-Württemberg,88376,Germany,+49 7587 95040,http://www.volksbraeu-durbach.de,9.4206063,47.9258844
 9a9a0817-f53a-4b5b-bccf-e423e828c699,Wahnsinnsbräu,micro,Muehlrain 1,,,Spraitbach,Baden-Württemberg,73565,Germany,,http://www.brutzelbaer.com/,,
-ad67f2b2-41d6-4a0b-af72-e338bd4f04e6,Waldhaus,brewpub,1 Waldhaus,,,Weilheim,Baden-Württemberg,79809,Germany,+49 7755 1600,http://www.privatbrauerei-waldhaus.de,8.1577671,47.68292659999999
-f812e4d1-40ff-4c3d-a47d-d926c92b59e3,Wallhall,brewpub,8 Kübelmarkt,,,Bruchsal,Baden-Württemberg,76646,Germany,+49 7251 72130,http://www.brauhaus-wallhall-bruchsal.de,8.599071499999999,49.1228714
-249d1956-290e-4bac-b822-09b270fa1f7b,Welde Bräu,brewpub,1 Brauereistraße,,,Plankstadt,Baden-Württemberg,68723,Germany,+49 6202 93000,http://www.welde.de,8.57863,49.40197
+ad67f2b2-41d6-4a0b-af72-e338bd4f04e6,Waldhaus,brewpub,Waldhaus 1,,,Weilheim,Baden-Württemberg,79809,Germany,+49 7755 1600,http://www.privatbrauerei-waldhaus.de,8.1577671,47.68292659999999
+f812e4d1-40ff-4c3d-a47d-d926c92b59e3,Wallhall,brewpub,Kübelmarkt 8,,,Bruchsal,Baden-Württemberg,76646,Germany,+49 7251 72130,http://www.brauhaus-wallhall-bruchsal.de,8.599071499999999,49.1228714
+249d1956-290e-4bac-b822-09b270fa1f7b,Welde Bräu,brewpub,Brauereistraße 1,,,Plankstadt,Baden-Württemberg,68723,Germany,+49 6202 93000,http://www.welde.de,8.57863,49.40197
 b821ba0e-329d-4ad0-b4fc-652e27f72d53,Wichtel,brewpub,Graf-Zeppelin-Platz,,,Böblingen,Baden-Württemberg,71034,Germany,+49 7031 3069899,http://www.wichtel.de,9.003333099999999,48.6900583
-d949aa6c-04b3-45c1-a2f6-f59096787d97,Wieland,brewpub,1a Dewanger Straße,,,Abtsgmünd,Baden-Württemberg,73453,Germany,+49 7366 9209990,http://www.wielands-bier.de,10.0071701,48.89382089999999
-1be11e01-01c6-492d-8733-ab5be3ee9a95,Woinemer,brewpub,23 Friedrichstraße,,,Weinheim,Baden-Württemberg,69469,Germany,+49 6201 12001,http://www.woinemer-hausbrauerei.de,8.6696276,49.553681
-6115020a-4682-4110-ac5f-b0d103dbfe0d,Zoller-Hof,brewpub,5-7 Fürst-Wilhelm-Straße,,,Sigmaringen,Baden-Württemberg,72488,Germany,+49 7571 1843160,http://www.zoller-hof.de,9.218293100000002,48.087454
-28634b80-db00-46fb-8527-03d776630eeb,Zum Ritter,brewpub,1 Schloßplatz,,,Schwetzingen,Baden-Württemberg,68723,Germany,+49 6202 924950,http://www.brauhaus-zum-ritter.de,8.5720637,49.3846283
-7ff5d6ab-9d31-41c5-80cf-9234281e0e7a,Zum Schwanen,brewpub,3 Franziskanergasse,,,Esslingen am Neckar,Baden-Württemberg,73728,Germany,+49 711 353253,http://www.schwanen-es.com,9.3101129,48.7411831
-a7b24dff-2e6d-4944-965e-ee795917e4b5,Zum Schwert,brewpub,9 Am Viehmarkt,,,Ehingen (Donau),Baden-Württemberg,89584,Germany,+49 7391 1288,http://www.schwertbrauerei.de,9.7220391,48.2834104
-3c61df21-3f5b-40e2-add1-bbdf62f58151,Zum Stadtpark,closed,1 Parkstraße,,,Hockenheim,Baden-Württemberg,68766,Germany,+49 6205 283688,http://www.brauereizumstadtpark.de,8.5518626,49.3184333
-c41b9b09-caa6-4c06-a065-660009143d5c,Zwiefalter Klosterbräu,brewpub,24 Hauptstraße,,,Zwiefalten,Baden-Württemberg,88529,Germany,+49 7373 200960,http://www.zwiefalter.de,9.4610206,48.2311628
+d949aa6c-04b3-45c1-a2f6-f59096787d97,Wieland,brewpub,Dewanger Straße 1a,,,Abtsgmünd,Baden-Württemberg,73453,Germany,+49 7366 9209990,http://www.wielands-bier.de,10.0071701,48.89382089999999
+1be11e01-01c6-492d-8733-ab5be3ee9a95,Woinemer,brewpub,Friedrichstraße 23,,,Weinheim,Baden-Württemberg,69469,Germany,+49 6201 12001,http://www.woinemer-hausbrauerei.de,8.6696276,49.553681
+6115020a-4682-4110-ac5f-b0d103dbfe0d,Zoller-Hof,brewpub,Fürst-Wilhelm-Straße 5-7,,,Sigmaringen,Baden-Württemberg,72488,Germany,+49 7571 1843160,http://www.zoller-hof.de,9.218293100000002,48.087454
+28634b80-db00-46fb-8527-03d776630eeb,Zum Ritter,brewpub,Schloßplatz 1,,,Schwetzingen,Baden-Württemberg,68723,Germany,+49 6202 924950,http://www.brauhaus-zum-ritter.de,8.5720637,49.3846283
+7ff5d6ab-9d31-41c5-80cf-9234281e0e7a,Zum Schwanen,brewpub,Franziskanergasse 3,,,Esslingen am Neckar,Baden-Württemberg,73728,Germany,+49 711 353253,http://www.schwanen-es.com,9.3101129,48.7411831
+a7b24dff-2e6d-4944-965e-ee795917e4b5,Zum Schwert,brewpub,Am Viehmarkt 9,,,Ehingen (Donau),Baden-Württemberg,89584,Germany,+49 7391 1288,http://www.schwertbrauerei.de,9.7220391,48.2834104
+3c61df21-3f5b-40e2-add1-bbdf62f58151,Zum Stadtpark,closed,Parkstraße 1,,,Hockenheim,Baden-Württemberg,68766,Germany,+49 6205 283688,http://www.brauereizumstadtpark.de,8.5518626,49.3184333
+c41b9b09-caa6-4c06-a065-660009143d5c,Zwiefalter Klosterbräu,brewpub,Hauptstraße 24,,,Zwiefalten,Baden-Württemberg,88529,Germany,+49 7373 200960,http://www.zwiefalter.de,9.4610206,48.2311628

--- a/data/germany/bayern.csv
+++ b/data/germany/bayern.csv
@@ -1,598 +1,598 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-ae7b3174-8be8-4d53-a3a5-9b8240970eea,'s,brewpub,1 Friesener Straße,,,Kronach,Bayern,96317,Germany,+49 9261 628000,http://www.antla.de,11.327765,50.241246
-21f21cc0-5b2f-4b79-be29-3bc625bcc4c8,1. Altenberger Brauhaus,brewpub,18 Zirndorfer Straße,,,Oberasbach,Bayern,90522,Germany,+49 911 604237,http://www.altenberger-brauhaus.de,10.9685585,49.4369958
-c1dc2b15-1ad0-4af4-840b-13a5c204f19a,1516 Westparkbräu,brewpub,6 Am Westpark,,,Ingolstadt,Bayern,85057,Germany,+49 841 9568777,http://www.westparkbraeu.com,11.3903278,48.77525869999999
-d1142d5b-e9e8-47bd-b3a8-3ce42c22ddda,Adam-Bräu,brewpub,53 Bahnhofstraße,,,Bodenmais,Bayern,94249,Germany,+49 9924 94000,http://www.adam-braeu.de,13.1022222,49.0697222
-9e48e89b-22b3-44d9-a0b9-eab4f611009f,Adler Bräu,brewpub,2A Bahnhofstraße,,,Stettfeld,Bayern,96188,Germany,,http://www.adlerbraeu-stettfeld.de,10.7209419,49.9693024
-b4896cfc-4731-4bc7-8794-d2d6650f7fe2,Aichinger,brewpub,5 Marktplatz,,,Heiligenstadt in Oberfranken,Bayern,91332,Germany,+49 9198 522,,11.1704687,49.8637819
+ae7b3174-8be8-4d53-a3a5-9b8240970eea,'s,brewpub,Friesener Straße 1,,,Kronach,Bayern,96317,Germany,+49 9261 628000,http://www.antla.de,11.327765,50.241246
+21f21cc0-5b2f-4b79-be29-3bc625bcc4c8,1. Altenberger Brauhaus,brewpub,Zirndorfer Straße 18,,,Oberasbach,Bayern,90522,Germany,+49 911 604237,http://www.altenberger-brauhaus.de,10.9685585,49.4369958
+c1dc2b15-1ad0-4af4-840b-13a5c204f19a,1516 Westparkbräu,brewpub,Am Westpark 6,,,Ingolstadt,Bayern,85057,Germany,+49 841 9568777,http://www.westparkbraeu.com,11.3903278,48.77525869999999
+d1142d5b-e9e8-47bd-b3a8-3ce42c22ddda,Adam-Bräu,brewpub,Bahnhofstraße 53,,,Bodenmais,Bayern,94249,Germany,+49 9924 94000,http://www.adam-braeu.de,13.1022222,49.0697222
+9e48e89b-22b3-44d9-a0b9-eab4f611009f,Adler Bräu,brewpub,Bahnhofstraße 2A,,,Stettfeld,Bayern,96188,Germany,,http://www.adlerbraeu-stettfeld.de,10.7209419,49.9693024
+b4896cfc-4731-4bc7-8794-d2d6650f7fe2,Aichinger,brewpub,Marktplatz 5,,,Heiligenstadt in Oberfranken,Bayern,91332,Germany,+49 9198 522,,11.1704687,49.8637819
 4feeca61-265e-4195-9234-75f78693fd14,Airbräu,brewpub,München Airport Center - Ebene 03,,,Oberding,Bayern,85356,Germany,+49 89 97593111,http://www.airbraeu.de,11.7873402,48.3540889
-64d12e0f-0abc-41ce-96c2-cd45b04d35e4,Aktienbrauerei,brewpub,3 Hohe Buchleuthe,,,Kaufbeuren,Bayern,87600,Germany,+49 8341 43040,http://www.aktien-brauerei.de,10.61612,47.87813999999999
-49f94bf3-f861-4b9f-b773-9c43f0070ed1,Albertshöfer Sternbräu,brewpub,5 Hindenburgstraße,,,Albertshofen,Bayern,97320,Germany,+49 162 2699078,http://www.albertshoefer-sternbraeu.de,10.15941,49.77149
-5958cbc2-f9d9-4bc3-9b9a-7469ce2d84d9,Aldersbacher,brewpub,1 Freiherr-von-Aretin-Platz,,,Aldersbach,Bayern,94501,Germany,+49 8543 96040,http://www.aldersbacher.de,13.0848087,48.5873322
-328d8ab7-c82a-44c6-b252-e6d85e39b14c,Allgäuer Brauhaus,brewpub,18 Schwendener Straße,,,Marktoberdorf,Bayern,87616,Germany,+49 8342 96470,http://www.allgaeuer-brauhaus.de,10.5679674,47.7496109
-98939b4a-14d7-4427-a99e-3d686784abca,Alt,brewpub,10 Dorfstraße,,,Leutenbach,Bayern,91359,Germany,+49 9199 403,http://www.brauerei-alt.de,11.1728824,49.7108499
-7c5ca24c-37df-43db-859f-ac5831866aef,Alte Brauerei / Zapfbräu,brewpub,2 Kirchplatz,,,Uettingen,Bayern,97292,Germany,+49 9369 8221,http://www.alte-brauerei.de,9.7296212,49.7941875
-f14b5ab3-92fc-487f-9869-07b1c8db5bf7,Alte Brauerei Stegen,brewpub,57 Landsberger Straße,,,Inning am Ammersee,Bayern,82266,Germany,+49 8143 9976431,http://www.alte-brauerei-stegen.de,11.1386516,48.0762625
-773770b1-b840-45c1-8bff-487ac7268d25,Altstadthof,brewpub,19 Bergstraße,,,Nürnberg,Bayern,90403,Germany,+49 911 2449859,http://www.altstadthof.de,11.0748976,49.4570626
-ef19c7ac-4313-4b3a-80bd-890f59ece1ea,Ambräusianum,brewpub,10 Dominikanerstraße,,,Bamberg,Bayern,96049,Germany,+49 951 5090262,http://www.ambraeusianum.de,10.884593,49.891758
-aacf9c9e-ec62-43b9-bcaa-877d54ffce8b,Ametsbichler,brewpub,13 Hauptstraße,,,Aschau am Inn,Bayern,84544,Germany,+49 8638 3204,http://www.ametsbichler.de,12.3505556,48.1980556
-7fe7f410-f9f7-4eed-a402-648d3651e910,Ammergauer Maxbräu,brewpub,5 Ettaler Straße,,,Oberammergau,Bayern,82487,Germany,+49 8822 9487460,http://www.maximilian-oberammergau.de,11.066696,47.5953971
-bdf3e527-3362-46ec-829a-0804de5150a3,Andorfer,brewpub,2 Rennweg,,,Passau,Bayern,94034,Germany,+49 851 754444,http://www.andorfer-weissbraeu.de,13.453345,48.586244
-5b484569-0e34-4ba7-9a4c-c89657d75a4e,Apostelbräu,brewpub,11 - 13 Eben,,,Hauzenberg,Bayern,94051,Germany,+49 8586 2200,http://www.apostelbraeu.de,13.63452,48.6390058
-7861ed8a-e099-49ad-9507-2b901120320d,Appl,brewpub,2 Schloß,,,Alerheim,Bayern,86733,Germany,+49 9085 1212,http://www.donare-appl.de,10.61385,48.83533
-27cfc500-a1ad-4a6a-9224-6f4e2a7a75b9,Arcobräu,brewpub,1 Schloßallee,,,Moos,Bayern,94554,Germany,+49 9938 918180,http://www.arcobraeu.de,12.9610071,48.7454643
-2f4fd4b1-0018-461a-a75e-cdc71ad9ad19,Arnsteiner,brewpub,9 Schweinfurter Straße,,,Arnstein,Bayern,97450,Germany,+49 9363 90910,http://www.arnsteiner-brauerei.de,9.973691299999999,49.9771374
-2092fc73-491d-4f20-ba70-3e3bc2cb83a9,Auerbräu,brewpub,80 Münchener Straße,,,Rosenheim,Bayern,83022,Germany,+49 8031 18050,http://www.auerbraeu.de,12.1152728,47.8525325
-ab02b540-6a18-4020-8363-d5102897f4e0,Augustiner,brewpub,52 Arnulfstraße,,,München,Bayern,80335,Germany,+49 89 594393,http://www.augustinerbraeu.de,11.5519791,48.1433523
-fb81c7bf-88a8-4508-a3cf-e75c7edc510a,Auxburg City Brewery,closed,43 Ulmer Straße,,,Augsburg,Bayern,86154,Germany,+49 821 4508486,http://www.auxburg-city-brewery.de,10.8744319,48.3811986
-46a6a14a-e7c7-4df8-b28a-76a988c4152c,Ayinger,brewpub,21 Münchener Straße,,,Aying,Bayern,85653,Germany,+49 8095 880,http://www.ayinger-bier.de,11.7744366,47.9720722
-805f26cb-59f1-4e8d-91ce-13f0c1a8ba6c,Bachmayer,brewpub,7 Loh,,,Dorfen,Bayern,84405,Germany,+49 8082 442,http://www.brauerei-bachmayer.de,12.2172716,48.2656576
-143796a4-b99e-46f7-9a3e-8d206c45c0e5,Baderbräu,brewpub,4 Baderweg,,,Schnaitsee,Bayern,83530,Germany,+49 176 32357045,http://www.baderbraeu.de,12.3689993,48.0708381
-f74bbdc2-cba6-4df2-a5c6-7b1d6e1b2424,Barbarossa Bräu,brewpub,18 Aschaffenburger Straße,,,Schöllkrippen,Bayern,63825,Germany,+49 6024 5454,http://www.brauhaus-barbarossa.de,9.2453186,50.0836644
-efb7f668-5151-49a8-8a95-6eac23234197,Bärenbräu,brewpub,2 Hohlgasse,,,Holzheim,Bayern,89291,Germany,+49 7302 3113,http://www.baerenbraeu-neuhausen.de,10.0934872,48.3781962
-b750c15e-557f-4103-838c-bc54fa0e23d1,Barleys Braukeller,brewpub,8 Königstraße,,,Kempten (Allgäu),Bayern,87435,Germany,+49 831 20500,http://www.allgaeu-zapf.de,10.3138189,47.7226693
-4ed5d507-4af0-47ec-b3bf-a8a31ff7b9ca,Bauer's,closed,2 Am Straußenhof,,,Hohenaltheim,Bayern,86745,Germany,+49 9088 887,http://www.bauers-brauerei.de,10.5369853,48.7834309
-c91fae81-7bd4-4a04-9759-4c5f2c39b940,Bauernhof- & Wintersportmusem,micro,5 Brunnbichl,,,Schliersee,Bayern,83727,Germany,+49 8026 929220,http://www.wasmeier.de,11.8780282,47.70784039999999
-af1b6148-1637-4deb-9a1b-9ca8084f2b1c,Baumer,closed,1 Marktplatz,,,Gars am Inn,Bayern,83536,Germany,+49 8073 1219,,12.2772244,48.15225849999999
-d5242d91-383f-4831-8ecc-6a5f162c2366,Bauriedl,brewpub,21 Ludwig-Müller-Straße,,,Eslarn,Bayern,92693,Germany,+49 9653 274,,12.5218042,49.5781911
-e57c6575-ca4b-4de1-b06f-8e3cb47a308e,Bavarian Festbeer Brewery,brewpub,6 Brauhausgasse,,,Ebermannstadt,Bayern,91320,Germany,,http://www.festbeer-shop.com,11.1872692,49.77948259999999
-4439df5b-9bb6-4355-a56c-56908428fd67,Bayer,brewpub,15 Schulterbachstraße,,,Rauhenebrach,Bayern,96181,Germany,+49 9554 293,http://www.bayer-theinheim.de,10.5868699,49.8846745
-aebfde0b-a3a3-4a65-8fe3-0b513e76311d,Bayerische-Böhmische Brauhaus,brewpub,1 Schloßplatz,,,Tegernsee,Bayern,83684,Germany,+49 8022 18020,https://www.brauhaus-tegernsee.de/,11.7564449,47.70781059999999
-aec8a521-93d7-4df1-bc07-c1ed4e7cb8b9,Bayerisches Brauereimuseum,micro,20 Hofer Straße,,,Kulmbach,Bayern,95326,Germany,+49 9221 80514,http://www.bayerisches-brauereimuseum.de,11.4697406,50.114645
-cd540d28-7c5b-41bd-9038-eafefaab017a,Bayrisch Brau Pub,brewpub,38 Frauentorstraße,,,Augsburg,Bayern,86152,Germany,+49 821 2970718,http://www.bayrisch-brau-pub.de,10.8954085,48.37616939999999
-a93cdcc7-00f3-4f69-b089-74ee4143d982,Becher-Bräu,brewpub,25 St.-Nikolaus-Straße,,,Bayreuth,Bayern,95445,Germany,+49 921 68993,http://www.becherbraeu.de,11.5519465,49.9385572
-1746ec27-f2f6-4c15-a056-55d2b5cc0390,Beck,brewpub,8 Steigerwaldstraße,,,Lisberg,Bayern,96170,Germany,+49 9549 252,http://www.beck-braeu.de,10.7250006,49.8948755
-4179acc1-6db7-40e8-aa41-04a693599e25,Behringer,brewpub,35 Marktplatz,,,Vohenstrauß,Bayern,92648,Germany,+49 9651 9244604,https://www.brauerei-behringer.de/,12.3406698,49.6246699
-b91bc958-55d5-40d7-814b-0e395d8fac9a,Bender,closed,7-9 Kirchgasse,,,Mühlhausen,Bayern,92360,Germany,+49 9185 406,,11.4442251,49.16867509999999
-25a72c40-7b7c-4cb2-aa0d-1e4790931895,Berabecka Boandl-Bräu,brewpub,36 Hauptstraße,,,Aichach,Bayern,86551,Germany,+49 8251 52355,http://www.boandlbraeu.de,11.127037,48.470683
-112f20d5-c6f8-40cc-b6df-4546d0052cc8,Berger,brewpub,3 Öttinger Straße,,,Reischach,Bayern,84571,Germany,+49 8670 218,http://www.brauerei-berger.de/,12.7251573,48.2900526
-10ce0b22-d232-440c-bc1c-330a70d705ee,Berggasthof Sonne,closed,12 Imberg,,,Sonthofen,Bayern,87527,Germany,,http://www.berggasthof-sonne.de,10.31413,47.4979723
-ec8700ac-6c55-4427-a64b-d30612a988fb,Berghammer,brewpub,55 Donaustraße,,,Bad Abbach,Bayern,93077,Germany,+49 9405 962176,http://www.brauerei-berghammer.de,12.0172235,48.9480575
-74631351-c8b4-4395-b29e-0ad8fe8ab83a,BernardiBräu,brewpub,7 Kammeregger Weg,,,Rettenberg,Bayern,87549,Germany,+49 8327 9326180,http://www.bernardibraeu.de,10.3110528,47.5742673
-e40105c1-c1d6-4350-884f-b28b0268be05,Betz,micro,15 Oberglaim,,,Ergolding,Bayern,84030,Germany,+49 8784 262,http://www.gasthaus-betz.de,12.1127913,48.6092265
-5b4eaf49-3385-4a08-9b42-5d5982708f3a,Bierhimmel,brewpub,100 Friedrich-Ebert-Straße,,,Fürth,Bayern,90766,Germany,+49 911 7873091,http://www.bierhimmel.bayern,10.9738569,49.4863733
-fdd8c0de-3556-4f49-b02a-494559a43e9f,Biermanufaktur Sparifankal,brewpub,7 Zechenstraße,,,Peiting,Bayern,86971,Germany,+49 171 8097979,http://www.sparifankal.de,10.9442663,47.78497309999999
-16b4e7be-07b1-4846-81e8-a94acab94f65,Bierwerk Kreativbrauerei / Hausbrauerei Wohlfart,brewpub,2a Bründeläckerstraße,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 162 2801313,http://www.bierwerk.bayern,11.2177723,49.5309956
-d59ae9c0-d156-400c-8df0-e8fc598e7700,Bio Bräu Wagner,brewpub,31-35 Landsberger Straße,,,München,Bayern,80339,Germany,+49 89 519940,http://www.hofbrauerei-wagner.de,11.5425211,48.13937
-d7efa13d-4084-4dd8-a0e2-af9480661600,Bischofshof,brewpub,2 Heitzerstraße,,,Regensburg,Bayern,93049,Germany,+49 941 20010,http://www.bischofshof.de,12.0761156,49.0151786
-0c73ca9a-a654-4bae-a00e-d63b43a970a0,Blauer Löwe,brewpub,9 Brückenstraße,,,Höchstadt an der Aisch,Bayern,91315,Germany,+49 9193 8219,http://www.brauerei-blauer-loewe.de,10.8056391,49.7021622
-a35abcc1-aa2b-45b6-893c-59905a5432d5,Brandy's Braugarage,brewpub,1 Schafbergstraße,,,Straßkirchen,Bayern,94342,Germany,+49 1512 1024564,http://www.brandys-braugarage.de,12.73178,48.83253999999999
-6dd4108b-671f-4ee2-a85b-bfe76319c369,Bräu im Moos,brewpub,1 Bräu im Moos Straße,,,Tüßling,Bayern,84577,Germany,+49 8633 1041,http://www.braeuimmoos.de,12.5956936,48.1875609
-81892b74-c2c2-4b47-b482-dbd2ec359a4c,Bräu z'Loh,brewpub,7 Loh,,,Dorfen,Bayern,84405,Germany,+49 8082 442,http://www.braeuzloh.de,12.2172716,48.2656576
-d481b440-36c7-4955-8133-e9b0ba0343b1,Brauer-Vereinigung,brewpub,4 Am Buchauer Berg,,,Pegnitz,Bayern,91257,Germany,+49 9241 4839937,,11.5420619,49.7581857
-aea1843a-7bec-4390-911d-b8bb6e20fe29,Brauerei Brauda,brewpub,3 Gewerbering,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://www.camba-bavaria.de/,12.4661335,47.9793527
-baa7e27d-ebaa-45ed-912e-c490414597ba,Brauerei Gasthof Blomenhof 1571,closed,8 Berliner Ring,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 2705527,http://www.facebook.com/BlomenhofNeumarkt/,11.4613017,49.29822799999999
-ba4509c4-d96c-4534-9b3e-be788787a24b,Brauerei im Eiswerk,closed,44 Ohlmüllerstraße,,,München,Bayern,81541,Germany,,http://www.brauerei-im-eiswerk.de,11.5815965,48.1222976
-bbd5d195-b4a5-435d-9616-5806e68879c7,Brauerei Mainstockeim,brewpub,3 Untere Brunnengasse,,,Mainstockheim,Bayern,97320,Germany,,http://www.brauerei-mainstockheim.de,10.1512373,49.7717061
-4f301473-bd46-44b2-9bac-c05faf4b4956,Brauerei Thomas Ernst / Silbersteg Bier,brewpub,39 Schöngeisinger Straße,,,Fürstenfeldbruck,Bayern,82256,Germany,+49 160 7530519,http://brauerei-ernst.de/,11.2521966,48.1766513
-47b8e313-8f99-4ccc-8c65-3b581e42662c,Brauereigasthof St. Afra im Felde,brewpub,144 Afrastraße,,,Friedberg,Bayern,86316,Germany,+49 821 6089150,http://www.sankt-afra.eu,10.9663669,48.3399966
-96912cbb-f8cc-4819-8c50-a2f698d8b00e,Brauereigenossenschaft,brewpub,3 Bräuhausstraße,,,Taufkirchen (Vils),Bayern,84416,Germany,+49 8084 2377,http://www.taufkirchner-brauerei.de,12.1326082,48.3457547
-c77a1e35-b020-4d24-86b5-f3034dc2697a,Brauhaus,brewpub,17 Jägerstraße,,,Würzburg,Bayern,97082,Germany,+49 931 42970,http://www.brauhausbar.de,9.9148122,49.7923439
-a3d242ce-8d0a-4011-8dcd-5ecb52648f33,Brauhaus am Kreuzberg,brewpub,1 Kreuzberg,,,Hallerndorf,Bayern,91352,Germany,+49 9545 4736,http://www.friedels-keller.de,10.9555412,49.7590977
-13c17d55-708d-4003-905a-9392317b16da,Brauhaus am Schloss,brewpub,6 Waffnergasse,,,Regensburg,Bayern,93047,Germany,+49 941 2804330,http://www.brauhaus-am-schloss.com,12.0912231,49.01549139999999
-6a820e1c-54f1-4914-9e3b-bc60226006af,Brauhaus Binkert,brewpub,5 Westring,,,Breitengüßbach,Bayern,96149,Germany,+49 9544 9848857,http://www.mainseidla.de,10.8819446,49.9636314
-be282c19-c16c-43e5-97d8-ff7c1a7911de,Brauhaus Brandmeier,brewpub,59 Hindenburgstraße,,,Cadolzburg,Bayern,90556,Germany,+49 9103 7129990,http://www.cadolzburger.de,10.8512624,49.45422199999999
-1680d0a1-7bc3-4030-92b3-d5df7a771176,Brauhaus Budenschuster,bar,4 Friedrichstraße,,,Bad Steben,Bayern,95138,Germany,+49 160 94832696,http://www.brauhaus-budenschuster.de,11.6440746,50.3661598
-5450b2b7-9010-4106-a576-660a8d6ed237,Brauhaus Floß,brewpub,4 Graf-Gebhard-Straße,,,Floß,Bayern,92685,Germany,+49 9603 6769867,http://www.brauhaus-floss.de,12.2777759,49.72393049999999
-0eeeacf2-0423-4f23-942b-aebeb6639c59,Bräuhaus Freising,brewpub,26 Mainburger Straße,,,Freising,Bayern,85356,Germany,+49 8161 6010,http://www.brauhaus-freising.de,11.7467485,48.4060454
-493a4717-621e-4244-89f4-35bd9de7b608,Brauhaus Germering,brewpub,15 Dorfstraße,,,Germering,Bayern,82110,Germany,+49 89 20921348,http://www.brauhaus-germering.de,11.3581283,48.1372993
-f86b494a-19db-4086-8900-d643a762db1a,Brauhaus Höchstadt,brewpub,11 Kellerstraße,,,Höchstadt an der Aisch,Bayern,91315,Germany,+49 9193 8367,http://www.brauhaus-hoechstadt.de,10.806307,49.7072797
-3bc9ac35-1637-4ed7-b7d1-e01dff06d6b7,Brauhaus im Wurzgrund,brewpub,58 Hauptstraße,,,Karlstadt,Bayern,97753,Germany,+49 9353 97710,http://www.alte-brauerei-karlstadt.de/,9.7646456,49.9600173
-5e65395f-1aaa-4e4b-9bf7-610bbecc4441,Bräuhaus Melkendorf,brewpub,13 Otterbachstraße,,,Litzendorf,Bayern,96123,Germany,,https://www.brandholz-brauerei.de/,11.0315904,49.8996122
-6585c6c0-a794-4188-b610-c0141f623ec0,Brauhaus Niederlauer,brewpub,6 Brückenauer Straße,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.hausbrauerbier.de,9.771565299999999,50.3953363
-c508ccd7-6a2b-4766-8383-0481740a781d,Brauhaus Oberstreu,brewpub,6 Brückenauer Straße,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.brauhaus-oberstreu.de,9.771565299999999,50.3953363
-b3bb3e75-7c12-4f7d-80e3-afa4bf68b195,Brauhaus Rosenberg,brewpub,14 Rosenberger Straße,,,Sulzbach-Rosenberg,Bayern,92237,Germany,+49 9661 87090,http://www.brauhaus-rosenberg.de,11.7409574,49.5042589
-7eba6a41-179a-46e1-be8e-81d8fce0872d,Brauhaus zu Coburg,brewpub,4 Nägleinsgasse,,,Coburg,Bayern,96450,Germany,+49 9561 7059192,http://www.brauhaus-coburg.de,10.9638777,50.2589586
-5cd41322-411f-4e4f-a7c1-c086ab0be192,Braukraft,closed,20 Münchener Straße,,,Gilching,Bayern,82205,Germany,,http://www.braukraft.de,11.3147331,48.1072348
-bff1405c-1264-4753-83e9-4450852577a8,Braumanufaktur Hertl,brewpub,61 Thüngfeld,,,Schlüsselfeld,Bayern,96132,Germany,+49 9552 981028,https://braumanufaktur-hertl.de/,10.6288136,49.7508498
-de3bc66b-04a0-49af-9bee-bfcc72fe1035,Braumanufaktur Lippert,brewpub,77 Bamberger Straße,,,Lichtenfels,Bayern,96215,Germany,+49 9571 9480817,http://www.braumanufaktur-lippert.de,11.0515598,50.138872
-bf84d0cf-4744-4666-bb61-2c134345aa4b,Brauschmiede,brewpub,2a Schmiedgasse,,,Mainbernheim,Bayern,97350,Germany,,http://www.brauschmie.de,10.216905,49.7116463
-cb6cabc7-4403-4768-8ca4-3cc8106eddb7,Braustall,brewpub,33 Regensburger Straße,,,Deuerling,Bayern,93180,Germany,+49 171 1414981,http://www.facebook.com/braustall/,11.9049973,49.0371628
-14306ffc-12ae-40bb-a184-9210f278f04b,Bräuwerck,brewpub,2A Marktplatz,,,Neudrossenfeld,Bayern,95512,Germany,+49 9203 9736515,http://www.braeuwerck.de,11.50362,50.0154973
-d4cec2ae-de0b-4b05-84e5-89177d23e6ea,Brauwerkstatt,brewpub,5 Am Bahnhof,,,Haag an der Amper,Bayern,85410,Germany,+49 8167 693737,http://www.diebrauwerkstatt.de,11.8364779,48.45679089999999
-a98558f6-158b-4f9a-bbd3-e199fdf5931a,Brauwerkstatt Lauterachquelle,brewpub,31 Lauterachstraße,,,Lauterhofen,Bayern,92283,Germany,+49 9186 569,http://www.kulturstadel-lauterhofen.de,11.6015309,49.3697065
-d86e9627-51fa-4f7a-b9ef-5a4b7e45545e,Bräuwirt,brewpub,9 Unterer Markt,,,Weiden in der Oberpfalz,Bayern,92637,Germany,+49 961 481330,http://www.braeuwirt.de,12.16396,49.67589
-198233f7-7ed5-4f07-9732-9e341f889396,Bruckmüller,brewpub,4 Vilsstraße,,,Amberg,Bayern,92224,Germany,+49 9621 488018,http://www.bruckmueller.de,11.8536997,49.4457678
-b8616ca6-6e88-4fba-aaae-3e8c90acf9e7,Bruderherz,brewpub,15 Luitpoldstraße,,,Nürnberg,Bayern,90402,Germany,+49 911 2165010,http://www.bruderherz-nuernberg.de,11.0787306,49.44796849999999
-7f2e1f17-16b0-409b-b02b-58773e00bf60,Brunner-Bräu,brewpub,5 Spanberg,,,Eggenfelden,Bayern,84307,Germany,+49 8721 6801,http://www.brunner-braeu.de,12.715085,48.3897018
-9035fff0-6ec5-44b7-bf58-b30b66a53910,Bub,brewpub,14 Marktplatz,,,Leinburg,Bayern,91227,Germany,+49 9120 204,http://www.leinburger-bier.de,11.3090901,49.4501327
-c1eadf6c-cb56-4dab-92c9-ba954821b9d9,Bucher Bräu,brewpub,5 Elsenthaler Straße,,,Grafenau,Bayern,94481,Germany,+49 8552 40870,http://www.bucher-braeu.de,13.392805,48.8543494
-67fb95d8-20cd-4efc-abe2-8118f95ad701,Büchner,brewpub,76 Heilmfurt,,,Malgersdorf,Bayern,84333,Germany,+49 9954 303,http://www.brauerei-buechner.de,12.7359383,48.527147
-77d522ae-6ef7-410a-a365-4bb2187ec6e3,Bürgerbräu,brewpub,1-2 Waaggasse,,,Bad Reichenhall,Bayern,83435,Germany,+49 8651 6089,http://www.buergerbraeu.by,12.8751949,47.722114
-9cefd079-cec5-4e2d-9377-07da5eeb91ae,Bürgerliches Brauhaus,brewpub,99 Hauptstraße,,,Wiesen,Bayern,63831,Germany,+49 6096 373,http://www.brauhaus-wiesen.de,9.363306099999999,50.1133555
-0bdd0f61-c475-46a7-b62b-010f99db499b,Burghauser Brauwerkstatt,closed,80 Piracher Straße,,,Burghausen,Bayern,84489,Germany,+49 8677 9187220,http://www.burghauser-brauwerkstatt.de,12.8068642,48.1607727
-579a052e-428e-4492-a536-f4e4a81adbea,Burgholz Bräu,closed,2 Burgholz,,,Hebertsfelden,Bayern,84332,Germany,+49 8726 503,,12.8229495,48.450879
-0086f789-6171-4f28-9478-0bb9190db28e,Büttner,brewpub,8 Untergreuth,,,Frensdorf,Bayern,96158,Germany,+49 9502 342,http://www.brauerei-buettner.de,10.8601672,49.8346413
-ed536e05-573a-475d-a3b7-ecffacb29ecd,Café Hein,brewpub,17 Münchberger Straße,,,Schwarzenbach an der Saale,Bayern,95126,Germany,+49 9284 7574,http://www.frankonianer.de,11.9303595,50.2223882
-a7fc18bb-77b8-4649-b197-f297e3349b47,Camba Bavaria,brewpub,3 Gewerbering,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://www.cambabavaria.de,12.4661335,47.9793527
-aa2a8ab9-cb4f-48f4-ba0e-63ab7bf3ffd5,Camba Old Factory,brewpub,3 Gewerbering,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://camba-old-factory.de,12.4661335,47.9793527
-44efba25-e932-4101-93d6-056cbb1ff434,Canada,brewpub,5B Hofmarkstraße,,,Aichach,Bayern,86551,Germany,+49 8251 1860,http://www.canada-mauerbach.de,11.18787,48.42966999999999
-acf86d31-ca14-41c6-9e6a-e98aa75c6286,Cervecium Hermann's Bierwerkstatt,brewpub,66 Kirchenlamitzer Straße,,,Weißenstadt,Bayern,95163,Germany,+49 9253 265,http://www.brauerei-michael.de,11.8895715,50.1054426
-a73c4f5f-ccd6-476f-9b2d-6277900491b3,Cheyenne Beer,brewpub,3 Gewerbering,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://www.cheyennebeer.com,12.4661335,47.9793527
-fa596c0e-13e3-46a3-89ae-e93690a490b0,Chiemseebräu,brewpub,1A Gewerbestraße,,,Grabenstätt,Bayern,83355,Germany,+49 8661 929922,http://www.chiemseebraeu.de,12.541788,47.850723
-603c5b07-5dd3-49b4-b450-0dd5e35f41b3,Communebrauerei,brewpub,1 Dr.- Kahlfresser-Platz,,,Kaufbeuren,Bayern,87600,Germany,+49 170 5458963,http://www.communebrauerei-kaufbeuren.de,10.6193516,47.87837829999999
-c6722388-3461-4f4c-9c77-30018508ee88,Craft Bräu,brewpub,12 Mühlstraße,,,Dießen am Ammersee,Bayern,86911,Germany,+49 175 1978708,http://www.craft-braeu.com,11.1046228,47.9485435
+64d12e0f-0abc-41ce-96c2-cd45b04d35e4,Aktienbrauerei,brewpub,Hohe Buchleuthe 3,,,Kaufbeuren,Bayern,87600,Germany,+49 8341 43040,http://www.aktien-brauerei.de,10.61612,47.87813999999999
+49f94bf3-f861-4b9f-b773-9c43f0070ed1,Albertshöfer Sternbräu,brewpub,Hindenburgstraße 5,,,Albertshofen,Bayern,97320,Germany,+49 162 2699078,http://www.albertshoefer-sternbraeu.de,10.15941,49.77149
+5958cbc2-f9d9-4bc3-9b9a-7469ce2d84d9,Aldersbacher,brewpub,Freiherr-von-Aretin-Platz 1,,,Aldersbach,Bayern,94501,Germany,+49 8543 96040,http://www.aldersbacher.de,13.0848087,48.5873322
+328d8ab7-c82a-44c6-b252-e6d85e39b14c,Allgäuer Brauhaus,brewpub,Schwendener Straße 18,,,Marktoberdorf,Bayern,87616,Germany,+49 8342 96470,http://www.allgaeuer-brauhaus.de,10.5679674,47.7496109
+98939b4a-14d7-4427-a99e-3d686784abca,Alt,brewpub,Dorfstraße 10,,,Leutenbach,Bayern,91359,Germany,+49 9199 403,http://www.brauerei-alt.de,11.1728824,49.7108499
+7c5ca24c-37df-43db-859f-ac5831866aef,Alte Brauerei / Zapfbräu,brewpub,Kirchplatz 2,,,Uettingen,Bayern,97292,Germany,+49 9369 8221,http://www.alte-brauerei.de,9.7296212,49.7941875
+f14b5ab3-92fc-487f-9869-07b1c8db5bf7,Alte Brauerei Stegen,brewpub,Landsberger Straße 57,,,Inning am Ammersee,Bayern,82266,Germany,+49 8143 9976431,http://www.alte-brauerei-stegen.de,11.1386516,48.0762625
+773770b1-b840-45c1-8bff-487ac7268d25,Altstadthof,brewpub,Bergstraße 19,,,Nürnberg,Bayern,90403,Germany,+49 911 2449859,http://www.altstadthof.de,11.0748976,49.4570626
+ef19c7ac-4313-4b3a-80bd-890f59ece1ea,Ambräusianum,brewpub,Dominikanerstraße 10,,,Bamberg,Bayern,96049,Germany,+49 951 5090262,http://www.ambraeusianum.de,10.884593,49.891758
+aacf9c9e-ec62-43b9-bcaa-877d54ffce8b,Ametsbichler,brewpub,Hauptstraße 13,,,Aschau am Inn,Bayern,84544,Germany,+49 8638 3204,http://www.ametsbichler.de,12.3505556,48.1980556
+7fe7f410-f9f7-4eed-a402-648d3651e910,Ammergauer Maxbräu,brewpub,Ettaler Straße 5,,,Oberammergau,Bayern,82487,Germany,+49 8822 9487460,http://www.maximilian-oberammergau.de,11.066696,47.5953971
+bdf3e527-3362-46ec-829a-0804de5150a3,Andorfer,brewpub,Rennweg 2,,,Passau,Bayern,94034,Germany,+49 851 754444,http://www.andorfer-weissbraeu.de,13.453345,48.586244
+5b484569-0e34-4ba7-9a4c-c89657d75a4e,Apostelbräu,brewpub,- 13 Eben 11,,,Hauzenberg,Bayern,94051,Germany,+49 8586 2200,http://www.apostelbraeu.de,13.63452,48.6390058
+7861ed8a-e099-49ad-9507-2b901120320d,Appl,brewpub,Schloß 2,,,Alerheim,Bayern,86733,Germany,+49 9085 1212,http://www.donare-appl.de,10.61385,48.83533
+27cfc500-a1ad-4a6a-9224-6f4e2a7a75b9,Arcobräu,brewpub,Schloßallee 1,,,Moos,Bayern,94554,Germany,+49 9938 918180,http://www.arcobraeu.de,12.9610071,48.7454643
+2f4fd4b1-0018-461a-a75e-cdc71ad9ad19,Arnsteiner,brewpub,Schweinfurter Straße 9,,,Arnstein,Bayern,97450,Germany,+49 9363 90910,http://www.arnsteiner-brauerei.de,9.973691299999999,49.9771374
+2092fc73-491d-4f20-ba70-3e3bc2cb83a9,Auerbräu,brewpub,Münchener Straße 80,,,Rosenheim,Bayern,83022,Germany,+49 8031 18050,http://www.auerbraeu.de,12.1152728,47.8525325
+ab02b540-6a18-4020-8363-d5102897f4e0,Augustiner,brewpub,Arnulfstraße 52,,,München,Bayern,80335,Germany,+49 89 594393,http://www.augustinerbraeu.de,11.5519791,48.1433523
+fb81c7bf-88a8-4508-a3cf-e75c7edc510a,Auxburg City Brewery,closed,Ulmer Straße 43,,,Augsburg,Bayern,86154,Germany,+49 821 4508486,http://www.auxburg-city-brewery.de,10.8744319,48.3811986
+46a6a14a-e7c7-4df8-b28a-76a988c4152c,Ayinger,brewpub,Münchener Straße 21,,,Aying,Bayern,85653,Germany,+49 8095 880,http://www.ayinger-bier.de,11.7744366,47.9720722
+805f26cb-59f1-4e8d-91ce-13f0c1a8ba6c,Bachmayer,brewpub,Loh 7,,,Dorfen,Bayern,84405,Germany,+49 8082 442,http://www.brauerei-bachmayer.de,12.2172716,48.2656576
+143796a4-b99e-46f7-9a3e-8d206c45c0e5,Baderbräu,brewpub,Baderweg 4,,,Schnaitsee,Bayern,83530,Germany,+49 176 32357045,http://www.baderbraeu.de,12.3689993,48.0708381
+f74bbdc2-cba6-4df2-a5c6-7b1d6e1b2424,Barbarossa Bräu,brewpub,Aschaffenburger Straße 18,,,Schöllkrippen,Bayern,63825,Germany,+49 6024 5454,http://www.brauhaus-barbarossa.de,9.2453186,50.0836644
+efb7f668-5151-49a8-8a95-6eac23234197,Bärenbräu,brewpub,Hohlgasse 2,,,Holzheim,Bayern,89291,Germany,+49 7302 3113,http://www.baerenbraeu-neuhausen.de,10.0934872,48.3781962
+b750c15e-557f-4103-838c-bc54fa0e23d1,Barleys Braukeller,brewpub,Königstraße 8,,,Kempten (Allgäu),Bayern,87435,Germany,+49 831 20500,http://www.allgaeu-zapf.de,10.3138189,47.7226693
+4ed5d507-4af0-47ec-b3bf-a8a31ff7b9ca,Bauer's,closed,Am Straußenhof 2,,,Hohenaltheim,Bayern,86745,Germany,+49 9088 887,http://www.bauers-brauerei.de,10.5369853,48.7834309
+c91fae81-7bd4-4a04-9759-4c5f2c39b940,Bauernhof- & Wintersportmusem,micro,Brunnbichl 5,,,Schliersee,Bayern,83727,Germany,+49 8026 929220,http://www.wasmeier.de,11.8780282,47.70784039999999
+af1b6148-1637-4deb-9a1b-9ca8084f2b1c,Baumer,closed,Marktplatz 1,,,Gars am Inn,Bayern,83536,Germany,+49 8073 1219,,12.2772244,48.15225849999999
+d5242d91-383f-4831-8ecc-6a5f162c2366,Bauriedl,brewpub,Ludwig-Müller-Straße 21,,,Eslarn,Bayern,92693,Germany,+49 9653 274,,12.5218042,49.5781911
+e57c6575-ca4b-4de1-b06f-8e3cb47a308e,Bavarian Festbeer Brewery,brewpub,Brauhausgasse 6,,,Ebermannstadt,Bayern,91320,Germany,,http://www.festbeer-shop.com,11.1872692,49.77948259999999
+4439df5b-9bb6-4355-a56c-56908428fd67,Bayer,brewpub,Schulterbachstraße 15,,,Rauhenebrach,Bayern,96181,Germany,+49 9554 293,http://www.bayer-theinheim.de,10.5868699,49.8846745
+aebfde0b-a3a3-4a65-8fe3-0b513e76311d,Bayerische-Böhmische Brauhaus,brewpub,Schloßplatz 1,,,Tegernsee,Bayern,83684,Germany,+49 8022 18020,https://www.brauhaus-tegernsee.de/,11.7564449,47.70781059999999
+aec8a521-93d7-4df1-bc07-c1ed4e7cb8b9,Bayerisches Brauereimuseum,micro,Hofer Straße 20,,,Kulmbach,Bayern,95326,Germany,+49 9221 80514,http://www.bayerisches-brauereimuseum.de,11.4697406,50.114645
+cd540d28-7c5b-41bd-9038-eafefaab017a,Bayrisch Brau Pub,brewpub,Frauentorstraße 38,,,Augsburg,Bayern,86152,Germany,+49 821 2970718,http://www.bayrisch-brau-pub.de,10.8954085,48.37616939999999
+a93cdcc7-00f3-4f69-b089-74ee4143d982,Becher-Bräu,brewpub,St.-Nikolaus-Straße 25,,,Bayreuth,Bayern,95445,Germany,+49 921 68993,http://www.becherbraeu.de,11.5519465,49.9385572
+1746ec27-f2f6-4c15-a056-55d2b5cc0390,Beck,brewpub,Steigerwaldstraße 8,,,Lisberg,Bayern,96170,Germany,+49 9549 252,http://www.beck-braeu.de,10.7250006,49.8948755
+4179acc1-6db7-40e8-aa41-04a693599e25,Behringer,brewpub,Marktplatz 35,,,Vohenstrauß,Bayern,92648,Germany,+49 9651 9244604,https://www.brauerei-behringer.de/,12.3406698,49.6246699
+b91bc958-55d5-40d7-814b-0e395d8fac9a,Bender,closed,Kirchgasse 7-9,,,Mühlhausen,Bayern,92360,Germany,+49 9185 406,,11.4442251,49.16867509999999
+25a72c40-7b7c-4cb2-aa0d-1e4790931895,Berabecka Boandl-Bräu,brewpub,Hauptstraße 36,,,Aichach,Bayern,86551,Germany,+49 8251 52355,http://www.boandlbraeu.de,11.127037,48.470683
+112f20d5-c6f8-40cc-b6df-4546d0052cc8,Berger,brewpub,Öttinger Straße 3,,,Reischach,Bayern,84571,Germany,+49 8670 218,http://www.brauerei-berger.de/,12.7251573,48.2900526
+10ce0b22-d232-440c-bc1c-330a70d705ee,Berggasthof Sonne,closed,Imberg 12,,,Sonthofen,Bayern,87527,Germany,,http://www.berggasthof-sonne.de,10.31413,47.4979723
+ec8700ac-6c55-4427-a64b-d30612a988fb,Berghammer,brewpub,Donaustraße 55,,,Bad Abbach,Bayern,93077,Germany,+49 9405 962176,http://www.brauerei-berghammer.de,12.0172235,48.9480575
+74631351-c8b4-4395-b29e-0ad8fe8ab83a,BernardiBräu,brewpub,Kammeregger Weg 7,,,Rettenberg,Bayern,87549,Germany,+49 8327 9326180,http://www.bernardibraeu.de,10.3110528,47.5742673
+e40105c1-c1d6-4350-884f-b28b0268be05,Betz,micro,Oberglaim 15,,,Ergolding,Bayern,84030,Germany,+49 8784 262,http://www.gasthaus-betz.de,12.1127913,48.6092265
+5b4eaf49-3385-4a08-9b42-5d5982708f3a,Bierhimmel,brewpub,Friedrich-Ebert-Straße 100,,,Fürth,Bayern,90766,Germany,+49 911 7873091,http://www.bierhimmel.bayern,10.9738569,49.4863733
+fdd8c0de-3556-4f49-b02a-494559a43e9f,Biermanufaktur Sparifankal,brewpub,Zechenstraße 7,,,Peiting,Bayern,86971,Germany,+49 171 8097979,http://www.sparifankal.de,10.9442663,47.78497309999999
+16b4e7be-07b1-4846-81e8-a94acab94f65,Bierwerk Kreativbrauerei / Hausbrauerei Wohlfart,brewpub,Bründeläckerstraße 2a,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 162 2801313,http://www.bierwerk.bayern,11.2177723,49.5309956
+d59ae9c0-d156-400c-8df0-e8fc598e7700,Bio Bräu Wagner,brewpub,Landsberger Straße 31-35,,,München,Bayern,80339,Germany,+49 89 519940,http://www.hofbrauerei-wagner.de,11.5425211,48.13937
+d7efa13d-4084-4dd8-a0e2-af9480661600,Bischofshof,brewpub,Heitzerstraße 2,,,Regensburg,Bayern,93049,Germany,+49 941 20010,http://www.bischofshof.de,12.0761156,49.0151786
+0c73ca9a-a654-4bae-a00e-d63b43a970a0,Blauer Löwe,brewpub,Brückenstraße 9,,,Höchstadt an der Aisch,Bayern,91315,Germany,+49 9193 8219,http://www.brauerei-blauer-loewe.de,10.8056391,49.7021622
+a35abcc1-aa2b-45b6-893c-59905a5432d5,Brandy's Braugarage,brewpub,Schafbergstraße 1,,,Straßkirchen,Bayern,94342,Germany,+49 1512 1024564,http://www.brandys-braugarage.de,12.73178,48.83253999999999
+6dd4108b-671f-4ee2-a85b-bfe76319c369,Bräu im Moos,brewpub,Bräu im Moos Straße 1,,,Tüßling,Bayern,84577,Germany,+49 8633 1041,http://www.braeuimmoos.de,12.5956936,48.1875609
+81892b74-c2c2-4b47-b482-dbd2ec359a4c,Bräu z'Loh,brewpub,Loh 7,,,Dorfen,Bayern,84405,Germany,+49 8082 442,http://www.braeuzloh.de,12.2172716,48.2656576
+d481b440-36c7-4955-8133-e9b0ba0343b1,Brauer-Vereinigung,brewpub,Am Buchauer Berg 4,,,Pegnitz,Bayern,91257,Germany,+49 9241 4839937,,11.5420619,49.7581857
+aea1843a-7bec-4390-911d-b8bb6e20fe29,Brauerei Brauda,brewpub,Gewerbering 3,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://www.camba-bavaria.de/,12.4661335,47.9793527
+baa7e27d-ebaa-45ed-912e-c490414597ba,Brauerei Gasthof Blomenhof 1571,closed,Berliner Ring 8,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 2705527,http://www.facebook.com/BlomenhofNeumarkt/,11.4613017,49.29822799999999
+ba4509c4-d96c-4534-9b3e-be788787a24b,Brauerei im Eiswerk,closed,Ohlmüllerstraße 44,,,München,Bayern,81541,Germany,,http://www.brauerei-im-eiswerk.de,11.5815965,48.1222976
+bbd5d195-b4a5-435d-9616-5806e68879c7,Brauerei Mainstockeim,brewpub,Untere Brunnengasse 3,,,Mainstockheim,Bayern,97320,Germany,,http://www.brauerei-mainstockheim.de,10.1512373,49.7717061
+4f301473-bd46-44b2-9bac-c05faf4b4956,Brauerei Thomas Ernst / Silbersteg Bier,brewpub,Schöngeisinger Straße 39,,,Fürstenfeldbruck,Bayern,82256,Germany,+49 160 7530519,http://brauerei-ernst.de/,11.2521966,48.1766513
+47b8e313-8f99-4ccc-8c65-3b581e42662c,Brauereigasthof St. Afra im Felde,brewpub,Afrastraße 144,,,Friedberg,Bayern,86316,Germany,+49 821 6089150,http://www.sankt-afra.eu,10.9663669,48.3399966
+96912cbb-f8cc-4819-8c50-a2f698d8b00e,Brauereigenossenschaft,brewpub,Bräuhausstraße 3,,,Taufkirchen (Vils),Bayern,84416,Germany,+49 8084 2377,http://www.taufkirchner-brauerei.de,12.1326082,48.3457547
+c77a1e35-b020-4d24-86b5-f3034dc2697a,Brauhaus,brewpub,Jägerstraße 17,,,Würzburg,Bayern,97082,Germany,+49 931 42970,http://www.brauhausbar.de,9.9148122,49.7923439
+a3d242ce-8d0a-4011-8dcd-5ecb52648f33,Brauhaus am Kreuzberg,brewpub,Kreuzberg 1,,,Hallerndorf,Bayern,91352,Germany,+49 9545 4736,http://www.friedels-keller.de,10.9555412,49.7590977
+13c17d55-708d-4003-905a-9392317b16da,Brauhaus am Schloss,brewpub,Waffnergasse 6,,,Regensburg,Bayern,93047,Germany,+49 941 2804330,http://www.brauhaus-am-schloss.com,12.0912231,49.01549139999999
+6a820e1c-54f1-4914-9e3b-bc60226006af,Brauhaus Binkert,brewpub,Westring 5,,,Breitengüßbach,Bayern,96149,Germany,+49 9544 9848857,http://www.mainseidla.de,10.8819446,49.9636314
+be282c19-c16c-43e5-97d8-ff7c1a7911de,Brauhaus Brandmeier,brewpub,Hindenburgstraße 59,,,Cadolzburg,Bayern,90556,Germany,+49 9103 7129990,http://www.cadolzburger.de,10.8512624,49.45422199999999
+1680d0a1-7bc3-4030-92b3-d5df7a771176,Brauhaus Budenschuster,bar,Friedrichstraße 4,,,Bad Steben,Bayern,95138,Germany,+49 160 94832696,http://www.brauhaus-budenschuster.de,11.6440746,50.3661598
+5450b2b7-9010-4106-a576-660a8d6ed237,Brauhaus Floß,brewpub,Graf-Gebhard-Straße 4,,,Floß,Bayern,92685,Germany,+49 9603 6769867,http://www.brauhaus-floss.de,12.2777759,49.72393049999999
+0eeeacf2-0423-4f23-942b-aebeb6639c59,Bräuhaus Freising,brewpub,Mainburger Straße 26,,,Freising,Bayern,85356,Germany,+49 8161 6010,http://www.brauhaus-freising.de,11.7467485,48.4060454
+493a4717-621e-4244-89f4-35bd9de7b608,Brauhaus Germering,brewpub,Dorfstraße 15,,,Germering,Bayern,82110,Germany,+49 89 20921348,http://www.brauhaus-germering.de,11.3581283,48.1372993
+f86b494a-19db-4086-8900-d643a762db1a,Brauhaus Höchstadt,brewpub,Kellerstraße 11,,,Höchstadt an der Aisch,Bayern,91315,Germany,+49 9193 8367,http://www.brauhaus-hoechstadt.de,10.806307,49.7072797
+3bc9ac35-1637-4ed7-b7d1-e01dff06d6b7,Brauhaus im Wurzgrund,brewpub,Hauptstraße 58,,,Karlstadt,Bayern,97753,Germany,+49 9353 97710,http://www.alte-brauerei-karlstadt.de/,9.7646456,49.9600173
+5e65395f-1aaa-4e4b-9bf7-610bbecc4441,Bräuhaus Melkendorf,brewpub,Otterbachstraße 13,,,Litzendorf,Bayern,96123,Germany,,https://www.brandholz-brauerei.de/,11.0315904,49.8996122
+6585c6c0-a794-4188-b610-c0141f623ec0,Brauhaus Niederlauer,brewpub,Brückenauer Straße 6,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.hausbrauerbier.de,9.771565299999999,50.3953363
+c508ccd7-6a2b-4766-8383-0481740a781d,Brauhaus Oberstreu,brewpub,Brückenauer Straße 6,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.brauhaus-oberstreu.de,9.771565299999999,50.3953363
+b3bb3e75-7c12-4f7d-80e3-afa4bf68b195,Brauhaus Rosenberg,brewpub,Rosenberger Straße 14,,,Sulzbach-Rosenberg,Bayern,92237,Germany,+49 9661 87090,http://www.brauhaus-rosenberg.de,11.7409574,49.5042589
+7eba6a41-179a-46e1-be8e-81d8fce0872d,Brauhaus zu Coburg,brewpub,Nägleinsgasse 4,,,Coburg,Bayern,96450,Germany,+49 9561 7059192,http://www.brauhaus-coburg.de,10.9638777,50.2589586
+5cd41322-411f-4e4f-a7c1-c086ab0be192,Braukraft,closed,Münchener Straße 20,,,Gilching,Bayern,82205,Germany,,http://www.braukraft.de,11.3147331,48.1072348
+bff1405c-1264-4753-83e9-4450852577a8,Braumanufaktur Hertl,brewpub,Thüngfeld 61,,,Schlüsselfeld,Bayern,96132,Germany,+49 9552 981028,https://braumanufaktur-hertl.de/,10.6288136,49.7508498
+de3bc66b-04a0-49af-9bee-bfcc72fe1035,Braumanufaktur Lippert,brewpub,Bamberger Straße 77,,,Lichtenfels,Bayern,96215,Germany,+49 9571 9480817,http://www.braumanufaktur-lippert.de,11.0515598,50.138872
+bf84d0cf-4744-4666-bb61-2c134345aa4b,Brauschmiede,brewpub,Schmiedgasse 2a,,,Mainbernheim,Bayern,97350,Germany,,http://www.brauschmie.de,10.216905,49.7116463
+cb6cabc7-4403-4768-8ca4-3cc8106eddb7,Braustall,brewpub,Regensburger Straße 33,,,Deuerling,Bayern,93180,Germany,+49 171 1414981,http://www.facebook.com/braustall/,11.9049973,49.0371628
+14306ffc-12ae-40bb-a184-9210f278f04b,Bräuwerck,brewpub,Marktplatz 2A,,,Neudrossenfeld,Bayern,95512,Germany,+49 9203 9736515,http://www.braeuwerck.de,11.50362,50.0154973
+d4cec2ae-de0b-4b05-84e5-89177d23e6ea,Brauwerkstatt,brewpub,Am Bahnhof 5,,,Haag an der Amper,Bayern,85410,Germany,+49 8167 693737,http://www.diebrauwerkstatt.de,11.8364779,48.45679089999999
+a98558f6-158b-4f9a-bbd3-e199fdf5931a,Brauwerkstatt Lauterachquelle,brewpub,Lauterachstraße 31,,,Lauterhofen,Bayern,92283,Germany,+49 9186 569,http://www.kulturstadel-lauterhofen.de,11.6015309,49.3697065
+d86e9627-51fa-4f7a-b9ef-5a4b7e45545e,Bräuwirt,brewpub,Unterer Markt 9,,,Weiden in der Oberpfalz,Bayern,92637,Germany,+49 961 481330,http://www.braeuwirt.de,12.16396,49.67589
+198233f7-7ed5-4f07-9732-9e341f889396,Bruckmüller,brewpub,Vilsstraße 4,,,Amberg,Bayern,92224,Germany,+49 9621 488018,http://www.bruckmueller.de,11.8536997,49.4457678
+b8616ca6-6e88-4fba-aaae-3e8c90acf9e7,Bruderherz,brewpub,Luitpoldstraße 15,,,Nürnberg,Bayern,90402,Germany,+49 911 2165010,http://www.bruderherz-nuernberg.de,11.0787306,49.44796849999999
+7f2e1f17-16b0-409b-b02b-58773e00bf60,Brunner-Bräu,brewpub,Spanberg 5,,,Eggenfelden,Bayern,84307,Germany,+49 8721 6801,http://www.brunner-braeu.de,12.715085,48.3897018
+9035fff0-6ec5-44b7-bf58-b30b66a53910,Bub,brewpub,Marktplatz 14,,,Leinburg,Bayern,91227,Germany,+49 9120 204,http://www.leinburger-bier.de,11.3090901,49.4501327
+c1eadf6c-cb56-4dab-92c9-ba954821b9d9,Bucher Bräu,brewpub,Elsenthaler Straße 5,,,Grafenau,Bayern,94481,Germany,+49 8552 40870,http://www.bucher-braeu.de,13.392805,48.8543494
+67fb95d8-20cd-4efc-abe2-8118f95ad701,Büchner,brewpub,Heilmfurt 76,,,Malgersdorf,Bayern,84333,Germany,+49 9954 303,http://www.brauerei-buechner.de,12.7359383,48.527147
+77d522ae-6ef7-410a-a365-4bb2187ec6e3,Bürgerbräu,brewpub,Waaggasse 1-2,,,Bad Reichenhall,Bayern,83435,Germany,+49 8651 6089,http://www.buergerbraeu.by,12.8751949,47.722114
+9cefd079-cec5-4e2d-9377-07da5eeb91ae,Bürgerliches Brauhaus,brewpub,Hauptstraße 99,,,Wiesen,Bayern,63831,Germany,+49 6096 373,http://www.brauhaus-wiesen.de,9.363306099999999,50.1133555
+0bdd0f61-c475-46a7-b62b-010f99db499b,Burghauser Brauwerkstatt,closed,Piracher Straße 80,,,Burghausen,Bayern,84489,Germany,+49 8677 9187220,http://www.burghauser-brauwerkstatt.de,12.8068642,48.1607727
+579a052e-428e-4492-a536-f4e4a81adbea,Burgholz Bräu,closed,Burgholz 2,,,Hebertsfelden,Bayern,84332,Germany,+49 8726 503,,12.8229495,48.450879
+0086f789-6171-4f28-9478-0bb9190db28e,Büttner,brewpub,Untergreuth 8,,,Frensdorf,Bayern,96158,Germany,+49 9502 342,http://www.brauerei-buettner.de,10.8601672,49.8346413
+ed536e05-573a-475d-a3b7-ecffacb29ecd,Café Hein,brewpub,Münchberger Straße 17,,,Schwarzenbach an der Saale,Bayern,95126,Germany,+49 9284 7574,http://www.frankonianer.de,11.9303595,50.2223882
+a7fc18bb-77b8-4649-b197-f297e3349b47,Camba Bavaria,brewpub,Gewerbering 3,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://www.cambabavaria.de,12.4661335,47.9793527
+aa2a8ab9-cb4f-48f4-ba0e-63ab7bf3ffd5,Camba Old Factory,brewpub,Gewerbering 3,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://camba-old-factory.de,12.4661335,47.9793527
+44efba25-e932-4101-93d6-056cbb1ff434,Canada,brewpub,Hofmarkstraße 5B,,,Aichach,Bayern,86551,Germany,+49 8251 1860,http://www.canada-mauerbach.de,11.18787,48.42966999999999
+acf86d31-ca14-41c6-9e6a-e98aa75c6286,Cervecium Hermann's Bierwerkstatt,brewpub,Kirchenlamitzer Straße 66,,,Weißenstadt,Bayern,95163,Germany,+49 9253 265,http://www.brauerei-michael.de,11.8895715,50.1054426
+a73c4f5f-ccd6-476f-9b2d-6277900491b3,Cheyenne Beer,brewpub,Gewerbering 3,,,Seeon-Seebruck,Bayern,83370,Germany,+49 8624 4073300,http://www.cheyennebeer.com,12.4661335,47.9793527
+fa596c0e-13e3-46a3-89ae-e93690a490b0,Chiemseebräu,brewpub,Gewerbestraße 1A,,,Grabenstätt,Bayern,83355,Germany,+49 8661 929922,http://www.chiemseebraeu.de,12.541788,47.850723
+603c5b07-5dd3-49b4-b450-0dd5e35f41b3,Communebrauerei,brewpub,Dr.- Kahlfresser-Platz 1,,,Kaufbeuren,Bayern,87600,Germany,+49 170 5458963,http://www.communebrauerei-kaufbeuren.de,10.6193516,47.87837829999999
+c6722388-3461-4f4c-9c77-30018508ee88,Craft Bräu,brewpub,Mühlstraße 12,,,Dießen am Ammersee,Bayern,86911,Germany,+49 175 1978708,http://www.craft-braeu.com,11.1046228,47.9485435
 7b4eba8c-a899-432d-bebe-2e8980a67d67,Crew Republic,micro,Am-Herzogsburg 32,,,Velburg,Bayern,92355,Germany,,http://www.crewrepublic.de,,
-4961a572-dda6-47f6-80b9-8cf7167ae847,Dachsbräu,brewpub,5 Murnauer Straße,,,Weilheim in Oberbayern,Bayern,82362,Germany,+49 881 2693,http://www.dachsbier.de,11.1428236,47.836442
-f0621546-3c77-478d-9fab-2354acd65b56,Dampfbierbrauerei,brewpub,8 Bahnhofplatz,,,Oberstdorf,Bayern,87561,Germany,+49 8322 8908,http://www.dampfbierbrauerei.de,10.2782337,47.4105875
-8e6266bd-3b7c-4dbc-b489-ae220ea610d6,Daniel Br,brewpub,1 Roseneckstraße,,,Ingolstadt,Bayern,85049,Germany,+49 841 35272,http://www.facebook.com/gasthausdaniel/,11.4225134,48.7631654
-ca36f6f0-69ab-4aa6-8e96-9d3b004adbd9,Dein Bier,brewpub,3 Hausen,,,Mauerstetten,Bayern,87665,Germany,+49 1512 8776077,http://www.deinbier-allgaeu.de,10.6692827,47.8773855
-120190a2-fc62-4d5a-9672-57d703ff7084,Der Bergbauernwirt,brewpub,18 Sonderdorf,,,Bolsterlang,Bayern,87538,Germany,+49 8326 7444,http://www.derbergbauernwirt.de,10.2332341,47.4532562
-78f0b535-cf56-4bf3-b26d-dfaebd59b319,Die Biobraumeister,brewpub,11a Weitzkaut,,,Glattbach,Bayern,63864,Germany,+49 6021 429410,http://www.biobraumeister.de,9.1406726,50.0061188
-cd1fccd3-7ffa-497d-a140-f1d368b5d3c0,Die Hecke,brewpub,1 Eitlöd,,,Bad Füssing,Bayern,94072,Germany,+49 8531 310730,http://www.die-hecke.de,13.3293568,48.35657699999999
-f5f33fc7-b194-4917-ad31-56dd77623c0f,Dietl,brewpub,1 Holzollinger Straße,,,Weyarn,Bayern,83629,Germany,+49 8020 282,,11.8328875,47.85580059999999
-fcfa2fdd-ca50-42df-99c6-6b104bf80f06,Dimpfl,brewpub,34 Bräuhausstraße,,,Furth im Wald,Bayern,93437,Germany,+49 9973 3816,http://www.dimpfl-bier.de,12.8449812,49.3054648
-b8040acd-01e7-41e9-9c51-6715bb32cd1b,Dinkel,brewpub,19 Am Dorfbrunnen,,,Bad Staffelstein,Bayern,96231,Germany,+49 170 3073281,http://www.dinkel-stublang.de,11.0433569,50.07814639999999
-295a716c-60c5-4481-84c8-400276dc497f,Döbler,brewpub,6 Kornmarkt,,,Bad Windsheim,Bayern,91438,Germany,+49 9841 2002,http://www.brauhaus-doebler.de,10.415994,49.501932
-ed9b6811-8093-4f75-a36f-21964fe9b243,Dorn-Bräu,brewpub,1 Marktplatz,,,Ammerndorf,Bayern,90614,Germany,+49 9127 57544,http://www.ammerndorfer-bier.de,10.852007,49.4208378
-952bb3c4-7593-4cd7-98e3-7225d4576ff8,Drei Kronen,brewpub,39 Hauptstraße,,,Scheßlitz,Bayern,96110,Germany,+49 9542 1564,http://www.kronabier.de,11.0337909,49.9764182
-b04370c1-42fb-4b34-a749-9ca12f87d2ac,Dremel,brewpub,21 Hauptstraße,,,Wattendorf,Bayern,96196,Germany,+49 9504 271,http://www.brauerei-dremel.de,11.1263371,50.0326561
-ddac7ca4-41c7-489d-b036-70272298de24,Drexler,brewpub,3 Bräustraße,,,Pösing,Bayern,93483,Germany,+49 9461 2154,,12.5499752,49.2290187
-e186c0a5-1392-42f6-9192-518d77019ac2,Dreykorn,brewpub,9 Mauergasse,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 9123 2424,https://www.facebook.com/Dreykorn-Br%C3%A4u-117872041603103/,11.2796445,49.5120649
-b52c236a-af11-46ae-a3f1-03d5ccb47708,Drummer,brewpub,10 Dorfstraße,,,Leutenbach,Bayern,91359,Germany,+49 9199 403,http://www.brauerei-gasthof-drummer.de,11.1728824,49.7108499
-89812b72-279d-4a9b-b5e0-e90dbbe158ec,Düll,brewpub,1 Pfarrer-Geyer-Straße,,,Marktbreit,Bayern,97340,Germany,+49 9332 8663,http://www.duell-gnodstadt.de,10.1204804,49.6374345
-459f6ecb-63e5-40ce-b5ac-fc7cb9ddff6c,Ebensfelder Brauhaus,brewpub,7 Oberer Kellbachdamm,,,Ebensfeld,Bayern,96250,Germany,+49 9573 885,http://www.ebensfelderbrauhaus.de,10.9593065,50.06591239999999
-a09b057a-2de7-4115-a608-592d371171cb,Ecker Bräu,micro,1 Eck,,,Böbrach,Bayern,94255,Germany,+49 9923 84050,http://www.brauerei-eck.de,13.0307539,49.0516699
-9d028e4c-6c61-46fe-bab7-13b535dea430,Eder & Heylands,brewpub,3-5 Aschaffenburger Straße,,,Großostheim,Bayern,63762,Germany,+49 6026 5090,http://www.eder-heylands.de,9.075799,49.922702
-1da7a405-aa63-4c51-8b69-1fbb121d8bbe,Egerer,brewpub,27 Dachinger Straße,,,Pilsting,Bayern,94431,Germany,+49 9953 3010,http://www.egerer.de,12.6003458,48.7001764
-af2e868e-568e-49f3-a21d-7f655e4c04b0,Eichhorn,brewpub,43 Dörfleinser Straße,,,Hallstadt,Bayern,96103,Germany,+49 951 75660,http://www.brauerei-eichhorn.de,10.8591572,49.9317242
-59e81f23-fa26-44de-8593-868b2bb603a6,Eismann,closed,9 Buchsteig,,,Altenstadt an der Waldnaab,Bayern,92665,Germany,+49 9602 636797,http://www.brauerei-eismann.de,12.15688,49.72456
-0b776924-43a7-4311-9e9d-94bb71737f01,Eittinger Fischerbräu,brewpub,20 Gadener Straße,,,Eitting,Bayern,85462,Germany,+49 8122 9598960,http://www.eittinger-fischerbräu.de,11.88766,48.36624
-9062c8f0-9f1b-4a89-8ac6-7d0c652a866b,Elch-Bräu,brewpub,11 Thuisbrunn,,,Gräfenberg,Bayern,91322,Germany,+49 9197 221,http://www.gasthof-seitz.de,11.2477778,49.68694439999999
-b2d5c630-7987-4028-b4ba-1af8209353b7,Eller,brewpub,10 Brunnenstraße,,,Untersiemau,Bayern,96253,Germany,+49 9565 1033,https://www.facebook.com/profile.php?id=100057570364732,10.995102,50.1804914
-778184e3-11ea-4672-b845-a065283a1816,Engelbräu,brewpub,17 Burgberger Straße,,,Rettenberg,Bayern,87549,Germany,+49 8327 93000,http://www.engelbraeu.de,10.2893706,47.5735158
-7b32763f-ce7f-45e5-b6c4-b8f8a62cc760,Enzensteiner,closed,8 Enzenreuth,,,Schnaittach,Bayern,91220,Germany,+49 9153 924733,http://www.enzensteiner.de,11.3686238,49.5618371
-8364cef4-e1a4-4f97-adba-753c7a71580d,Enzianhütte,brewpub,24 Mühlenstraße,,,Oberstaufen,Bayern,87534,Germany,+49 8386 661,http://www.enzianhuette-oberstdorf.de,10.0193975,47.5454878
-252bc777-db1f-40b4-80af-d91154677024,Eppelein & Friends,brewpub,43 Feldgasse,,,Nürnberg,Bayern,90489,Germany,+49 172 8342323,http://www.eppeleinfriends.de,11.0941944,49.459256
-cc5c019a-0e91-4570-ac76-d98e2bde2bad,Erdinger,brewpub,1-3 Lange Zeile,,,Erding,Bayern,85435,Germany,+49 8122 4090,https://erdinger.de/de-DE,11.9065773,48.3067462
+4961a572-dda6-47f6-80b9-8cf7167ae847,Dachsbräu,brewpub,Murnauer Straße 5,,,Weilheim in Oberbayern,Bayern,82362,Germany,+49 881 2693,http://www.dachsbier.de,11.1428236,47.836442
+f0621546-3c77-478d-9fab-2354acd65b56,Dampfbierbrauerei,brewpub,Bahnhofplatz 8,,,Oberstdorf,Bayern,87561,Germany,+49 8322 8908,http://www.dampfbierbrauerei.de,10.2782337,47.4105875
+8e6266bd-3b7c-4dbc-b489-ae220ea610d6,Daniel Br,brewpub,Roseneckstraße 1,,,Ingolstadt,Bayern,85049,Germany,+49 841 35272,http://www.facebook.com/gasthausdaniel/,11.4225134,48.7631654
+ca36f6f0-69ab-4aa6-8e96-9d3b004adbd9,Dein Bier,brewpub,Hausen 3,,,Mauerstetten,Bayern,87665,Germany,+49 1512 8776077,http://www.deinbier-allgaeu.de,10.6692827,47.8773855
+120190a2-fc62-4d5a-9672-57d703ff7084,Der Bergbauernwirt,brewpub,Sonderdorf 18,,,Bolsterlang,Bayern,87538,Germany,+49 8326 7444,http://www.derbergbauernwirt.de,10.2332341,47.4532562
+78f0b535-cf56-4bf3-b26d-dfaebd59b319,Die Biobraumeister,brewpub,Weitzkaut 11a,,,Glattbach,Bayern,63864,Germany,+49 6021 429410,http://www.biobraumeister.de,9.1406726,50.0061188
+cd1fccd3-7ffa-497d-a140-f1d368b5d3c0,Die Hecke,brewpub,Eitlöd 1,,,Bad Füssing,Bayern,94072,Germany,+49 8531 310730,http://www.die-hecke.de,13.3293568,48.35657699999999
+f5f33fc7-b194-4917-ad31-56dd77623c0f,Dietl,brewpub,Holzollinger Straße 1,,,Weyarn,Bayern,83629,Germany,+49 8020 282,,11.8328875,47.85580059999999
+fcfa2fdd-ca50-42df-99c6-6b104bf80f06,Dimpfl,brewpub,Bräuhausstraße 34,,,Furth im Wald,Bayern,93437,Germany,+49 9973 3816,http://www.dimpfl-bier.de,12.8449812,49.3054648
+b8040acd-01e7-41e9-9c51-6715bb32cd1b,Dinkel,brewpub,Am Dorfbrunnen 19,,,Bad Staffelstein,Bayern,96231,Germany,+49 170 3073281,http://www.dinkel-stublang.de,11.0433569,50.07814639999999
+295a716c-60c5-4481-84c8-400276dc497f,Döbler,brewpub,Kornmarkt 6,,,Bad Windsheim,Bayern,91438,Germany,+49 9841 2002,http://www.brauhaus-doebler.de,10.415994,49.501932
+ed9b6811-8093-4f75-a36f-21964fe9b243,Dorn-Bräu,brewpub,Marktplatz 1,,,Ammerndorf,Bayern,90614,Germany,+49 9127 57544,http://www.ammerndorfer-bier.de,10.852007,49.4208378
+952bb3c4-7593-4cd7-98e3-7225d4576ff8,Drei Kronen,brewpub,Hauptstraße 39,,,Scheßlitz,Bayern,96110,Germany,+49 9542 1564,http://www.kronabier.de,11.0337909,49.9764182
+b04370c1-42fb-4b34-a749-9ca12f87d2ac,Dremel,brewpub,Hauptstraße 21,,,Wattendorf,Bayern,96196,Germany,+49 9504 271,http://www.brauerei-dremel.de,11.1263371,50.0326561
+ddac7ca4-41c7-489d-b036-70272298de24,Drexler,brewpub,Bräustraße 3,,,Pösing,Bayern,93483,Germany,+49 9461 2154,,12.5499752,49.2290187
+e186c0a5-1392-42f6-9192-518d77019ac2,Dreykorn,brewpub,Mauergasse 9,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 9123 2424,https://www.facebook.com/Dreykorn-Br%C3%A4u-117872041603103/,11.2796445,49.5120649
+b52c236a-af11-46ae-a3f1-03d5ccb47708,Drummer,brewpub,Dorfstraße 10,,,Leutenbach,Bayern,91359,Germany,+49 9199 403,http://www.brauerei-gasthof-drummer.de,11.1728824,49.7108499
+89812b72-279d-4a9b-b5e0-e90dbbe158ec,Düll,brewpub,Pfarrer-Geyer-Straße 1,,,Marktbreit,Bayern,97340,Germany,+49 9332 8663,http://www.duell-gnodstadt.de,10.1204804,49.6374345
+459f6ecb-63e5-40ce-b5ac-fc7cb9ddff6c,Ebensfelder Brauhaus,brewpub,Oberer Kellbachdamm 7,,,Ebensfeld,Bayern,96250,Germany,+49 9573 885,http://www.ebensfelderbrauhaus.de,10.9593065,50.06591239999999
+a09b057a-2de7-4115-a608-592d371171cb,Ecker Bräu,micro,Eck 1,,,Böbrach,Bayern,94255,Germany,+49 9923 84050,http://www.brauerei-eck.de,13.0307539,49.0516699
+9d028e4c-6c61-46fe-bab7-13b535dea430,Eder & Heylands,brewpub,Aschaffenburger Straße 3-5,,,Großostheim,Bayern,63762,Germany,+49 6026 5090,http://www.eder-heylands.de,9.075799,49.922702
+1da7a405-aa63-4c51-8b69-1fbb121d8bbe,Egerer,brewpub,Dachinger Straße 27,,,Pilsting,Bayern,94431,Germany,+49 9953 3010,http://www.egerer.de,12.6003458,48.7001764
+af2e868e-568e-49f3-a21d-7f655e4c04b0,Eichhorn,brewpub,Dörfleinser Straße 43,,,Hallstadt,Bayern,96103,Germany,+49 951 75660,http://www.brauerei-eichhorn.de,10.8591572,49.9317242
+59e81f23-fa26-44de-8593-868b2bb603a6,Eismann,closed,Buchsteig 9,,,Altenstadt an der Waldnaab,Bayern,92665,Germany,+49 9602 636797,http://www.brauerei-eismann.de,12.15688,49.72456
+0b776924-43a7-4311-9e9d-94bb71737f01,Eittinger Fischerbräu,brewpub,Gadener Straße 20,,,Eitting,Bayern,85462,Germany,+49 8122 9598960,http://www.eittinger-fischerbräu.de,11.88766,48.36624
+9062c8f0-9f1b-4a89-8ac6-7d0c652a866b,Elch-Bräu,brewpub,Thuisbrunn 11,,,Gräfenberg,Bayern,91322,Germany,+49 9197 221,http://www.gasthof-seitz.de,11.2477778,49.68694439999999
+b2d5c630-7987-4028-b4ba-1af8209353b7,Eller,brewpub,Brunnenstraße 10,,,Untersiemau,Bayern,96253,Germany,+49 9565 1033,https://www.facebook.com/profile.php?id=100057570364732,10.995102,50.1804914
+778184e3-11ea-4672-b845-a065283a1816,Engelbräu,brewpub,Burgberger Straße 17,,,Rettenberg,Bayern,87549,Germany,+49 8327 93000,http://www.engelbraeu.de,10.2893706,47.5735158
+7b32763f-ce7f-45e5-b6c4-b8f8a62cc760,Enzensteiner,closed,Enzenreuth 8,,,Schnaittach,Bayern,91220,Germany,+49 9153 924733,http://www.enzensteiner.de,11.3686238,49.5618371
+8364cef4-e1a4-4f97-adba-753c7a71580d,Enzianhütte,brewpub,Mühlenstraße 24,,,Oberstaufen,Bayern,87534,Germany,+49 8386 661,http://www.enzianhuette-oberstdorf.de,10.0193975,47.5454878
+252bc777-db1f-40b4-80af-d91154677024,Eppelein & Friends,brewpub,Feldgasse 43,,,Nürnberg,Bayern,90489,Germany,+49 172 8342323,http://www.eppeleinfriends.de,11.0941944,49.459256
+cc5c019a-0e91-4570-ac76-d98e2bde2bad,Erdinger,brewpub,Lange Zeile 1-3,,,Erding,Bayern,85435,Germany,+49 8122 4090,https://erdinger.de/de-DE,11.9065773,48.3067462
 f583793e-9f73-474e-8a5f-97cd6181d596,Erdinger Weißbräu,brewpub,1+3 Lange Zeile,,,Erding,Bayern,85435,Germany,+49 8122 88001801,http://www.erdinger.de,11.9070582,48.3067551
-ebf9f71e-0388-49d6-a780-698d98d88530,Erharting,brewpub,6 Hauptstraße,,,Erharting,Bayern,84513,Germany,+49 8631 18610,http://www.erhartinger-bier.de,12.57541,48.278236
-bb6a5ca4-c616-4273-92ac-8e7486853bfe,Erl,brewpub,10 Straubinger Straße,,,Geiselhöring,Bayern,94333,Germany,+49 9423 94170,http://www.brauerei-erl.de,12.3959966,48.8271315
-d5cd76bf-7053-459d-b077-766106d0f446,Eschenbacher Wagner Bräu,brewpub,12 Eltmanner Straße,,,Eltmann,Bayern,97483,Germany,+49 9522 288,http://www.eschenbacher.de,10.7006638,49.9662715
-7915a77a-5e49-43c1-aad9-5f25e693a7d4,Ettl-Bräu,brewpub,2 Bahnhofstraße,,,Teisnach,Bayern,94244,Germany,+49 9923 80130,http://www.brauerei-ettl.de,12.9951526,49.0380626
-bdd79126-1bbd-47c7-9346-efa2ee17ae46,Falkenstein,brewpub,28 Allgäuer Straße,,,Pfronten,Bayern,87459,Germany,+49 8363 960658,http://www.braugasthof-falkenstein.de,10.5602701,47.5838496
-5c1bfda2-158d-4622-8d21-6213e8dc5439,Falter,brewpub,15 Am Sand,,,Regen,Bayern,94209,Germany,+49 9921 88230,http://www.jb-falter.de,13.1245315,48.9689391
-5f921c57-2aa6-4ad9-9c67-80ea8ee443eb,Falterbräu,brewpub,5 Hofmark,,,Drachselsried,Bayern,94256,Germany,+49 9945 943230,http://www.falter-braeu.de,13.0137601,49.1063401
-0e786e48-5208-4b75-b737-ffe529f45ef1,Fässla,brewpub,19 -21 Obere Königstraße,,,Bamberg,Bayern,96052,Germany,+49 951 26516,http://www.faessla.de,10.892754,49.897245
-7ff80c48-1a3a-48b3-9561-3ac6c23b8c68,Faust,brewpub,219 Hauptstraße,,,Miltenberg,Bayern,63897,Germany,+49 9371 97130,http://www.faust.de,9.249293999999999,49.699247
-3ec58c8f-af60-43ab-9c3d-484ab2b8320c,Felsenbräu,brewpub,2 Felsenweg,,,Bergen,Bayern,91790,Germany,+49 9147 94266,http://www.felsenbraeu.com,11.1518618,49.0695067
-0f4923ba-091b-4e40-8cdb-05daada376cb,Felsenkeller,brewpub,33 Lengfurter Straße,,,Marktheidenfeld,Bayern,97828,Germany,+49 9391 5424,http://www.felsenkeller-marktheidenfeld.de,9.5949852,49.8379987
-d7fc5120-f5c1-48e8-b03c-2cfad91a0f83,Findler,brewpub,31 Sachsenkamer Straße,,,Greiling,Bayern,83677,Germany,+49 8041 7944993,http://www.facebook.com/FindlerBier/,11.6082761,47.7681094
-2ddd8177-018f-4406-87e3-3209e23c6636,Fischer,brewpub,2 Freudeneck,,,Rattelsdorf,Bayern,96179,Germany,+49 9547 488,http://www.hahnerla.de,10.8798398,50.03520959999999
-79bbf84d-b0d6-4060-8f56-2c8c303b3b89,Flötzinger-Bräu,brewpub,7 Herzog-Heinrich-Straße,,,Rosenheim,Bayern,83022,Germany,+49 8031 36630,http://www.floetzinger-braeu.de,12.1218899,47.8559652
-d9b009f5-a3cc-4ac4-8c1d-068370c0b9c9,Flugwerk,brewpub,2 Sonnenstraße,,,Feldkirchen,Bayern,85622,Germany,+49 89 94417718,http://www.flugwerk-feldkirchen.de,11.7353484,48.1478974
-ce742d6f-8371-4f1e-b853-3fa78af11f99,Forschungsbrauerei,brewpub,78 Unterhachinger Straße,,,München,Bayern,81737,Germany,+49 89 28788273,http://www.forschungsbrauerei.de,11.6248116,48.0941438
-282306ea-4a52-45f3-8caa-13df45cc34dc,Forschungsbrauerei Weihenstephan,brewpub,2 Alte Akademie,,,Freising,Bayern,85354,Germany,+49 8161 5360,https://www.lbgt.wzw.tum.de/index.php?id=133,11.7289326,48.3952883
-4d02bd57-7804-45b4-b507-e61bfa326b55,Forstquell,brewpub,35 Fürnheim,,,Wassertrüdingen,Bayern,91717,Germany,+49 9832 9657,http://www.forstquell.de,10.52403,49.02195
-7bfeaf70-8ba1-412b-8408-cbfe3bcf18fc,Frankenw,brewpub,6 Brauhausgasse,,,Ebermannstadt,Bayern,91320,Germany,,http://www.buergerbraeu-naila.de,11.1872692,49.77948259999999
-0b400d46-777d-4a0c-bd6a-9a38e6ea5a42,Fränkisches Freilandmuseum,micro,1 Eisweiherweg,,,Bad Windsheim,Bayern,91438,Germany,+49 9841 66800,http://www.freilandmuseum.de,10.4176898,49.4983486
-20b1250c-c1ac-40d8-a44a-8afe4cb13b4d,Freilandmuseum,micro,19 Bahnhofstraße,,,Fladungen,Bayern,97650,Germany,+49 9778 91230,http://www.freilandmuseum-fladungen.de,10.1496119,50.520473
-38170b7e-f416-4fbf-a69e-5a2749485a83,Friedel,brewpub,1 Höchstadter Straße,,,Höchstadt an der Aisch,Bayern,91315,Germany,+49 9502 209,,10.8937851,49.7607521
-88b7e107-c8da-438b-a408-5d8f61e6797d,Friedmann,brewpub,16 Jägersberg,,,Gräfenberg,Bayern,91322,Germany,+49 9192 318,http://www.brauerei-friedmann.de,11.25271,49.64453
-c8323f66-de79-41d1-9b79-9e8ad3f89e2c,Frischeisen,brewpub,69 Regensburger Straße,,,Kelheim,Bayern,93309,Germany,+49 9441 50490,http://www.brauerei-frischeisen.de,11.8969167,48.9059889
-de49b2ef-6f82-4219-baca-1a7ebd762464,Fuchsbeck,brewpub,1 Hagtor,,,Sulzbach-Rosenberg,Bayern,92237,Germany,+49 9661 4518,http://www.fuchsbeck.de,11.7372364,49.505455
-74e395c9-22e1-4151-883f-5b07bb9b8861,Fürst Wallerstein,brewpub,78 Obere Bergstraße,,,Wallerstein,Bayern,86757,Germany,+49 9081 782220,http://www.fuerst-wallerstein.de,10.475172,48.8882914
-ed60d959-d195-461f-9e30-1d2ff67db9f4,Fürstliches Brauhaus,brewpub,10 Schloßstraße,,,Ellingen,Bayern,91792,Germany,+49 9141 9780,http://www.fuerst-carl.de,10.9653098,49.060503
-ba443e98-4edf-48a7-95b4-f3552b406e5d,Gabreta Silva / Böhmerwald Brauwerkstatt,closed,4 Kritzenast,,,Waldmünchen,Bayern,93449,Germany,,http://www.gabreta-silva.de,12.6372412,49.3716793
-27a2b411-440a-4b34-8293-bce010a4ecd9,Gambrinus,closed,15 Keplerstraße,,,Weiden in der Oberpfalz,Bayern,92637,Germany,+49 961 670330,http://www.gambrinus-weiden.de,12.1532083,49.6786657
-38466783-9774-4983-9e9c-9ffaa24163cf,Gampertbräu,brewpub,2-4 Braustraße,,,Weißenbrunn,Bayern,96369,Germany,+49 9261 60330,http://www.gampertbraeu.de,11.346798,50.199725
-76c10d32-56d7-485c-801d-3f8e59078ce7,Gansbräu,brewpub,4 Ringstraße,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 905885,http://www.gansbrauerei.de,11.4592982,49.2770954
-2db13336-1be7-49e7-901d-68ab9e8eb419,Gänstaller-Bräu,brewpub,37 Hafenstraße,,,Bamberg,Bayern,96052,Germany,,http://www.gaenstaller.de,10.8599707,49.9150568
-7190aae3-6c49-4ccc-8775-6a151725b7e6,Gasthof Erlhof,brewpub,9 Laurentiusstraße,,,Ursensollen,Bayern,92289,Germany,+49 9628 273,http://www.erlhof-erlheim.de,11.8093544,49.3824875
-9a5b5a3a-14c1-43a3-8afe-54523144baff,Gaststätte Scheuern,brewpub,7 Bach,,,Aschau im Chiemgau,Bayern,83229,Germany,+49 8052 9573370,http://www.scheuern-aschau.de,12.3138339,47.755917
-5bdaae14-c3e6-4bcf-bab4-92ee49157b77,Genossenschaftsbrauerei,brewpub,17 Hussenstraße,,,Rötz,Bayern,92444,Germany,+49 9976 1425,http://www.genossenbrauhaus.de/,12.5258894,49.34203369999999
-1a0f1e70-1d4e-420f-a1d4-2cb000d5d8f9,Gesellschaftsbrauerei,micro,3a Bahnhofstraße,,,Viechtach,Bayern,94234,Germany,+49 9942 809783,http://gb-brauerei.de,12.8849996,49.0820519
+ebf9f71e-0388-49d6-a780-698d98d88530,Erharting,brewpub,Hauptstraße 6,,,Erharting,Bayern,84513,Germany,+49 8631 18610,http://www.erhartinger-bier.de,12.57541,48.278236
+bb6a5ca4-c616-4273-92ac-8e7486853bfe,Erl,brewpub,Straubinger Straße 10,,,Geiselhöring,Bayern,94333,Germany,+49 9423 94170,http://www.brauerei-erl.de,12.3959966,48.8271315
+d5cd76bf-7053-459d-b077-766106d0f446,Eschenbacher Wagner Bräu,brewpub,Eltmanner Straße 12,,,Eltmann,Bayern,97483,Germany,+49 9522 288,http://www.eschenbacher.de,10.7006638,49.9662715
+7915a77a-5e49-43c1-aad9-5f25e693a7d4,Ettl-Bräu,brewpub,Bahnhofstraße 2,,,Teisnach,Bayern,94244,Germany,+49 9923 80130,http://www.brauerei-ettl.de,12.9951526,49.0380626
+bdd79126-1bbd-47c7-9346-efa2ee17ae46,Falkenstein,brewpub,Allgäuer Straße 28,,,Pfronten,Bayern,87459,Germany,+49 8363 960658,http://www.braugasthof-falkenstein.de,10.5602701,47.5838496
+5c1bfda2-158d-4622-8d21-6213e8dc5439,Falter,brewpub,Am Sand 15,,,Regen,Bayern,94209,Germany,+49 9921 88230,http://www.jb-falter.de,13.1245315,48.9689391
+5f921c57-2aa6-4ad9-9c67-80ea8ee443eb,Falterbräu,brewpub,Hofmark 5,,,Drachselsried,Bayern,94256,Germany,+49 9945 943230,http://www.falter-braeu.de,13.0137601,49.1063401
+0e786e48-5208-4b75-b737-ffe529f45ef1,Fässla,brewpub,-21 Obere Königstraße 19,,,Bamberg,Bayern,96052,Germany,+49 951 26516,http://www.faessla.de,10.892754,49.897245
+7ff80c48-1a3a-48b3-9561-3ac6c23b8c68,Faust,brewpub,Hauptstraße 219,,,Miltenberg,Bayern,63897,Germany,+49 9371 97130,http://www.faust.de,9.249293999999999,49.699247
+3ec58c8f-af60-43ab-9c3d-484ab2b8320c,Felsenbräu,brewpub,Felsenweg 2,,,Bergen,Bayern,91790,Germany,+49 9147 94266,http://www.felsenbraeu.com,11.1518618,49.0695067
+0f4923ba-091b-4e40-8cdb-05daada376cb,Felsenkeller,brewpub,Lengfurter Straße 33,,,Marktheidenfeld,Bayern,97828,Germany,+49 9391 5424,http://www.felsenkeller-marktheidenfeld.de,9.5949852,49.8379987
+d7fc5120-f5c1-48e8-b03c-2cfad91a0f83,Findler,brewpub,Sachsenkamer Straße 31,,,Greiling,Bayern,83677,Germany,+49 8041 7944993,http://www.facebook.com/FindlerBier/,11.6082761,47.7681094
+2ddd8177-018f-4406-87e3-3209e23c6636,Fischer,brewpub,Freudeneck 2,,,Rattelsdorf,Bayern,96179,Germany,+49 9547 488,http://www.hahnerla.de,10.8798398,50.03520959999999
+79bbf84d-b0d6-4060-8f56-2c8c303b3b89,Flötzinger-Bräu,brewpub,Herzog-Heinrich-Straße 7,,,Rosenheim,Bayern,83022,Germany,+49 8031 36630,http://www.floetzinger-braeu.de,12.1218899,47.8559652
+d9b009f5-a3cc-4ac4-8c1d-068370c0b9c9,Flugwerk,brewpub,Sonnenstraße 2,,,Feldkirchen,Bayern,85622,Germany,+49 89 94417718,http://www.flugwerk-feldkirchen.de,11.7353484,48.1478974
+ce742d6f-8371-4f1e-b853-3fa78af11f99,Forschungsbrauerei,brewpub,Unterhachinger Straße 78,,,München,Bayern,81737,Germany,+49 89 28788273,http://www.forschungsbrauerei.de,11.6248116,48.0941438
+282306ea-4a52-45f3-8caa-13df45cc34dc,Forschungsbrauerei Weihenstephan,brewpub,Alte Akademie 2,,,Freising,Bayern,85354,Germany,+49 8161 5360,https://www.lbgt.wzw.tum.de/index.php?id=133,11.7289326,48.3952883
+4d02bd57-7804-45b4-b507-e61bfa326b55,Forstquell,brewpub,Fürnheim 35,,,Wassertrüdingen,Bayern,91717,Germany,+49 9832 9657,http://www.forstquell.de,10.52403,49.02195
+7bfeaf70-8ba1-412b-8408-cbfe3bcf18fc,Frankenw,brewpub,Brauhausgasse 6,,,Ebermannstadt,Bayern,91320,Germany,,http://www.buergerbraeu-naila.de,11.1872692,49.77948259999999
+0b400d46-777d-4a0c-bd6a-9a38e6ea5a42,Fränkisches Freilandmuseum,micro,Eisweiherweg 1,,,Bad Windsheim,Bayern,91438,Germany,+49 9841 66800,http://www.freilandmuseum.de,10.4176898,49.4983486
+20b1250c-c1ac-40d8-a44a-8afe4cb13b4d,Freilandmuseum,micro,Bahnhofstraße 19,,,Fladungen,Bayern,97650,Germany,+49 9778 91230,http://www.freilandmuseum-fladungen.de,10.1496119,50.520473
+38170b7e-f416-4fbf-a69e-5a2749485a83,Friedel,brewpub,Höchstadter Straße 1,,,Höchstadt an der Aisch,Bayern,91315,Germany,+49 9502 209,,10.8937851,49.7607521
+88b7e107-c8da-438b-a408-5d8f61e6797d,Friedmann,brewpub,Jägersberg 16,,,Gräfenberg,Bayern,91322,Germany,+49 9192 318,http://www.brauerei-friedmann.de,11.25271,49.64453
+c8323f66-de79-41d1-9b79-9e8ad3f89e2c,Frischeisen,brewpub,Regensburger Straße 69,,,Kelheim,Bayern,93309,Germany,+49 9441 50490,http://www.brauerei-frischeisen.de,11.8969167,48.9059889
+de49b2ef-6f82-4219-baca-1a7ebd762464,Fuchsbeck,brewpub,Hagtor 1,,,Sulzbach-Rosenberg,Bayern,92237,Germany,+49 9661 4518,http://www.fuchsbeck.de,11.7372364,49.505455
+74e395c9-22e1-4151-883f-5b07bb9b8861,Fürst Wallerstein,brewpub,Obere Bergstraße 78,,,Wallerstein,Bayern,86757,Germany,+49 9081 782220,http://www.fuerst-wallerstein.de,10.475172,48.8882914
+ed60d959-d195-461f-9e30-1d2ff67db9f4,Fürstliches Brauhaus,brewpub,Schloßstraße 10,,,Ellingen,Bayern,91792,Germany,+49 9141 9780,http://www.fuerst-carl.de,10.9653098,49.060503
+ba443e98-4edf-48a7-95b4-f3552b406e5d,Gabreta Silva / Böhmerwald Brauwerkstatt,closed,Kritzenast 4,,,Waldmünchen,Bayern,93449,Germany,,http://www.gabreta-silva.de,12.6372412,49.3716793
+27a2b411-440a-4b34-8293-bce010a4ecd9,Gambrinus,closed,Keplerstraße 15,,,Weiden in der Oberpfalz,Bayern,92637,Germany,+49 961 670330,http://www.gambrinus-weiden.de,12.1532083,49.6786657
+38466783-9774-4983-9e9c-9ffaa24163cf,Gampertbräu,brewpub,Braustraße 2-4,,,Weißenbrunn,Bayern,96369,Germany,+49 9261 60330,http://www.gampertbraeu.de,11.346798,50.199725
+76c10d32-56d7-485c-801d-3f8e59078ce7,Gansbräu,brewpub,Ringstraße 4,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 905885,http://www.gansbrauerei.de,11.4592982,49.2770954
+2db13336-1be7-49e7-901d-68ab9e8eb419,Gänstaller-Bräu,brewpub,Hafenstraße 37,,,Bamberg,Bayern,96052,Germany,,http://www.gaenstaller.de,10.8599707,49.9150568
+7190aae3-6c49-4ccc-8775-6a151725b7e6,Gasthof Erlhof,brewpub,Laurentiusstraße 9,,,Ursensollen,Bayern,92289,Germany,+49 9628 273,http://www.erlhof-erlheim.de,11.8093544,49.3824875
+9a5b5a3a-14c1-43a3-8afe-54523144baff,Gaststätte Scheuern,brewpub,Bach 7,,,Aschau im Chiemgau,Bayern,83229,Germany,+49 8052 9573370,http://www.scheuern-aschau.de,12.3138339,47.755917
+5bdaae14-c3e6-4bcf-bab4-92ee49157b77,Genossenschaftsbrauerei,brewpub,Hussenstraße 17,,,Rötz,Bayern,92444,Germany,+49 9976 1425,http://www.genossenbrauhaus.de/,12.5258894,49.34203369999999
+1a0f1e70-1d4e-420f-a1d4-2cb000d5d8f9,Gesellschaftsbrauerei,micro,Bahnhofstraße 3a,,,Viechtach,Bayern,94234,Germany,+49 9942 809783,http://gb-brauerei.de,12.8849996,49.0820519
 60e9b80d-5dc9-45df-9575-2ba02d118ea0,Geyer,brewpub,Tanzenhaider Weg,,,Oberreichenbach,Bayern,91097,Germany,+49 9104 2802,http://www.brauereigasthof-geyer.de,10.7609669,49.59048809999999
-f7042903-4248-4a1a-9548-c9e4dfd4a074,Giesinger Bräu,brewpub,2 Martin-Luther-Straße,,,München,Bayern,81539,Germany,+49 89 55062184,http://www.giesinger-braeu.de,11.576744,48.1155998
-2c36de9a-41c0-433e-adfe-ccb87cc8d460,Glentleitner Wirtschaft,brewpub,1 An der Glentleiten,,,Schlehdorf,Bayern,82444,Germany,,http://www.glentleitner-wirtschaft.de,11.285346,47.6644515
-12575c3b-4e14-4ad0-9741-71585750bd23,Glossner,brewpub,88 Deininger Weg,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 2340,http://www.glossner.de,11.472773,49.262772
-4264296e-4266-4892-bf45-785663145ab3,Goikelbräu,brewpub,2 Zum Sommerhof,,,Lohr am Main,Bayern,97816,Germany,+49 9359 9097840,http://www.goikelbraeu.de,9.656018,50.01212169999999
-6c5917bc-c6f3-4225-9628-a3e493835c9a,Goldener Engel,brewpub,4 Raiffeisenstraße,,,Waldstetten,Bayern,89367,Germany,+49 8223 1274,http://www.engelbrauerei.de,10.2944521,48.3491813
-7af10aee-fdf1-40ae-a3f0-dedd721ea3c4,Goldener Löwe,brewpub,26 Drügendorf,,,Eggolsheim,Bayern,91330,Germany,+49 9545 8583,http://www.brauerei-foerst.de,11.1167625,49.8070265
-079c76a2-0adc-4716-9424-01d5bf8b9fc4,Göller,brewpub,7 Scheßlitzer Straße,,,Memmelsdorf,Bayern,96117,Germany,+49 9505 1745,http://www.goeller-brauerei.de,10.971651,49.94078769999999
-1a7c8d69-8295-47a0-97f1-bd8b0d0f2bbd,Goss,brewpub,16 Regensburger Straße,,,Deuerling,Bayern,93180,Germany,+49 9498 1512,http://www.brauerei-goss.de/,11.9076069,49.0350368
-88a65fa2-1755-43e5-9d7d-945b855b5ac5,Gradl,brewpub,6 Leups,,,Pegnitz,Bayern,91257,Germany,+49 9246 247,http://www.leupser.de/,11.5245981,49.81298409999999
-9f8f664a-b8ba-4a38-98df-5350db505512,Graf Arco,brewpub,14 Hauptstraße,,,Eichendorf,Bayern,94428,Germany,+49 9952 280,http://www.graf-arco.de,12.8368395,48.6341354
-f035b6f3-2125-452a-9615-31d503a6b3f0,Graminger Weissbräu,brewpub,79 Graming,,,Altötting,Bayern,84503,Germany,+49 8671 96140,http://www.graminger-weissbraeu.de,12.6668034,48.211029
-d60cfa3a-683e-4b17-b05d-41d66250bb56,Grasser,brewpub,25 Huppendorf,,,Königsfeld,Bayern,96167,Germany,+49 9207 270,http://www.huppendorfer-bier.de,11.150008,49.9320062
-5c848c89-5fcd-427c-9fe0-50a1f250f54c,Greif,brewpub,10 Serlbacher Straße,,,Forchheim,Bayern,91301,Germany,+49 9191 727920,http://www.brauerei-greif.de,11.0591894,49.7256641
-5b9acb35-0669-4869-ad0b-93add02c0f9b,Greifenklau,brewpub,20 Laurenziplatz,,,Bamberg,Bayern,96049,Germany,+49 951 53219,http://www.greifenklau.de,10.8821241,49.8836721
-5069335c-64b5-41ed-98f2-0db395c70441,Griesbräu,brewpub,37 Obermarkt,,,Murnau am Staffelsee,Bayern,82418,Germany,+49 8841 1422,http://www.griesbraeu.de,11.200572,47.6799353
-f8972817-a555-491e-b1d8-4cfd00fe87f4,Griess,brewpub,6 Magdalenenstraße,,,Strullendorf,Bayern,96129,Germany,+49 9505 1624,http://www.brauerei-griess.de,11.0113069,49.8805286
-304286b4-c9e7-4fba-824c-3531dcafcf7e,Grosch,brewpub,3 Coburger Straße,,,Rödental,Bayern,96472,Germany,,http://www.der-grosch.de,11.0266661,50.2877473
-24e35e4c-a64e-4a30-a577-a7c9e16d4015,Gundel,brewpub,15 Nördlinger Straße,,,Kammerstein,Bayern,91126,Germany,+49 9178 1504,http://www.brauerei-gundel.de,10.9280372,49.2744636
-6a6bb1e6-889e-47bc-9f33-05460243274b,Günther-Bräu,brewpub,27 In der Au,,,Burgkunstadt,Bayern,96224,Germany,+49 9572 386650,http://www.guenther-braeu.de,11.24823,50.13639999999999
-5a290fbb-5e8e-4f52-9d04-dea0c165c09c,Gut Forsting,brewpub,23 Münchner Straße,,,Pfaffing,Bayern,83539,Germany,+49 8094 1011,http://www.brauerei-gut-forsting.de,12.0891,48.08125
-2525ce71-1da1-4677-85a7-5723ac441d9a,Gutmann,brewpub,1 Am Kreuzberg,,,Titting,Bayern,85135,Germany,+49 8423 99660,http://www.brauerei-gutmann.de,11.2079458,48.99454919999999
-c593265c-7421-43d3-8cd6-11f21e3dc173,Gutsbräu,brewpub,1 Scheibe,,,Salzweg,Bayern,94121,Germany,+49 8505 93410,http://www.gutsbraeu.de,13.479179,48.635466
-895c2c82-8003-424b-a7a5-306755dfcde7,Haberstumpf,brewpub,31 Bergstraße,,,Trebgast,Bayern,95367,Germany,+49 9227 351,http://www.brauerei-haberstumpf.de,11.5457537,50.0723274
-cf96fce3-b0ee-438b-a4c4-d2223f583392,Hacklberg,brewpub,3 Bräuhausplatz,,,Passau,Bayern,94034,Germany,+49 851 50150,http://www.hacklberg.de,13.4434237,48.57780899999999
-82a821c6-b99d-401e-ba39-f79a2ae5e942,Haderner Bräu,brewpub,56a Großhaderner Straße,,,München,Bayern,81375,Germany,+49 89 92581988,http://www.haderner.de,11.4822463,48.1226804
-4f3bbd77-eae6-4111-a75f-6c101dc6abe8,Haidbräu,brewpub,41 Admiralbogen,,,München,Bayern,80939,Germany,+49 89 54047373,http://www.awo-muenchen.de/psychiatrie/awo-muenchen-conceptliving-gmbh/taetigkeitsfelder-und-standorte/haidbraeu/,11.6142492,48.2102829
-f080a133-0ee0-4772-a947-d80bd8f898a0,Häpfenbräu,brewpub,4 Am Bahnhof,,,Rammingen,Bayern,86871,Germany,+49 1512 9777903,http://www.braustadel-rammingen.de,10.5650688,48.0641512
-e5bf58bd-89b2-4dfc-a4c5-a412f9c35aaa,Hartl Bräu,micro,13 Industriestraße,,,Lappersdorf,Bayern,93138,Germany,+49 941 2800666,https://www.hausler-lappersdorf.de/,12.0910414,49.0584314
-98362eae-ed4c-4fb1-952c-673181ba4132,Hartl's Hausbrauerei,micro,5 Duringstraße,,,Türkenfeld,Bayern,82299,Germany,+49 8193 999517,http://www.gasthof-hartl.de,11.0859833,48.1075236
-f284736b-5d5b-41b0-a667-38316f62bed7,Hartleb,brewpub,9 Herrenstraße,,,Maroldsweisach,Bayern,96126,Germany,+49 9532 240,https://de-de.facebook.com/pages/Hartleb-Irmgard-Gastst%C3%A4tte-Brauerei/158561980838544,10.6607834,50.1966511
-f8642be5-23b2-47e7-8e9d-44fd7972cd6b,Hartmann,brewpub,26 Fränkische-Schweiz-Straße,,,Scheßlitz,Bayern,96110,Germany,+49 9542 920300,http://www.brauerei-hartmann.de,11.0898405,49.9791286
-e99ec846-7b9c-45f5-aea7-3c5c51dbe181,Hasen-Bräu,brewpub,36 Berliner Allee,,,Augsburg,Bayern,86153,Germany,+49 821 32990,http://www.kaelberhalle.de,10.9181108,48.3726464
-68db59f2-309e-4e26-b8d0-baca8c0b07f1,Hauf,brewpub,28 Heininger Straße,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 57520,http://www.hauf-bier.de,10.34418,49.06744
-dd157db9-d742-4efd-94bc-b8710f84870b,Hauff-Bräu,brewpub,28 Heininger Straße,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 57520,http://www.hauff-braeu.de,10.34418,49.06744
-980edf15-e774-404a-a687-d9fe557a0bef,Hausbräu,brewpub,6 Ruhlstraße,,,Stegaurach,Bayern,96135,Germany,+49 951 299709,http://www.hausbraeu-stegaurach.de,10.8551978,49.8606134
-3e446925-b16c-4854-b905-a5646e7727eb,Hausbrauerei Höpfl,brewpub,17 Steinfelder Straße,,,Steinfeld,Bayern,97854,Germany,+49 9396 1532,http://www.hausbrauerei-hoepfl.de,9.6287065,49.944489
-5cfe0eb0-5479-4e64-9f78-d7d708854a82,Hebendanz,brewpub,14 Sattlertorstraße,,,Forchheim,Bayern,91301,Germany,+49 9191 9790500,http://www.brauerei-hebendanz.de,11.0567992,49.7202231
-3cd041d8-c2f7-4a4b-9b76-8e1a68e22aae,Heberbräu,brewpub,14 Auerbacher Straße,,,Kirchenthumbach,Bayern,91281,Germany,+49 9647 929718,http://www.heberbraeu.de,11.72389,49.74596
-9cee6e35-2c75-4f92-8b64-904d6fc11f6f,Hechtbräu,brewpub,59 Zimmern,,,Pappenheim,Bayern,91788,Germany,+49 9143 212569,http://www.hechtbraeu-zimmern.de,10.98369,48.92698
-7162c7e4-aba2-4f1e-bd17-15c985e19f41,Heckel,brewpub,3 Vorstadt,,,Waischenfeld,Bayern,91344,Germany,+49 9202 493,https://www.facebook.com/share/p/189zjDdNch/,11.3463649,49.8451251
-41d6185d-91a4-4cf5-bcf2-a46c1ebf7c95,Heimat- & Bauernkriegsmuseum,micro,1 Stadtberg,,,Leipheim,Bayern,89340,Germany,+49 8221 72095,http://www.leipheim.de/index.php?selected_page_id=1622,10.2195256,48.4497821
-52547766-f12c-441d-961d-e1a3e6e4ff97,Heimbergers Craftbeer,brewpub,25 Flemingstraße,,,Hösbach,Bayern,63836,Germany,+49 6021 550872,http://www.facebook.com/craftladen/,9.194619699999999,50.0035237
-a8a839e8-7958-4cd9-809f-e8053ab61fe5,Heinen's Craft Beer,brewpub,25 Flemingstraße,,,Hösbach,Bayern,63836,Germany,+49 6021 550872,http://www.facebook.com/DieterHeinenBrauerei/,9.194619699999999,50.0035237
-c50d2241-90db-46c8-a858-d587d1c41b62,Held-Bräu,brewpub,19 Oberailsfeld,,,Ahorntal,Bayern,95491,Germany,+49 9242 295,http://www.held-braeu.de,11.35353,49.81245999999999
-ad6b75a4-4e80-4519-9cc2-6033ae03ad7c,Heldrich,brewpub,3 Sulzbacher Straße,,,Edelsfeld,Bayern,92265,Germany,+49 9665 441,http://www.fc-edelsfeld.de/,11.696092,49.5769402
-2f06d681-136c-4b5c-aa65-8f05b7443d09,Heller,brewpub,27 Oberer Stephansberg,,,Bamberg,Bayern,96049,Germany,+49 951 56060,http://www.smokebeer.com,10.8872004,49.8863561
-b1bf179e-200b-40a4-8a37-c627418e9884,Hellmuth,brewpub,14 Wiesen,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 4395,http://www.gasthaus-hellmuth.de,10.9499288,50.0961345
-1a5a3fad-4a6a-4264-a2bf-7905360d0a11,Hembach,closed,4 Siemensstraße,,,Rednitzhembach,Bayern,91126,Germany,+49 179 9471670,,11.0490865,49.3128237
-693e7819-b228-4607-8fb0-be1b32506628,Hennemann,brewpub,33 Sambach,,,Pommersfelden,Bayern,96178,Germany,+49 9502 4307,http://www.brauerei-hennemann.com,10.8419583,49.7808831
-3945e88e-f2fc-4c32-a6e0-0521c527ef37,Herold,closed,29 Marktstraße,,,Pegnitz,Bayern,91257,Germany,+49 9241 3311,http://www.beckn-bier.de,11.5102068,49.79403490000001
-1c3881d7-8f89-4595-a3ff-9d726d8cab09,Herr Max & Frau Hopfen,closed,1 Schloßweg,,,Holzgünz,Bayern,87752,Germany,+49 8393 9437870,http://www.herrmaxundfrauhopfen.de,10.2598894,48.0221381
-49fe05ef-66d5-41f5-a555-977814ce1924,Herrmann,brewpub,3 Brückenstraße,,,Burgebrach,Bayern,96138,Germany,+49 9546 372,http://www.brauerei-herrmann.franken-regio.de,10.7309815,49.8456206
-74e95ac8-7d48-48e1-90fb-34b38fa3cd9b,Herrmannsdorfer Schweinsbräu,brewpub,7 Herrmannsdorf,,,Glonn,Bayern,85625,Germany,+49 8093 909445,http://www.herrmannsdorfer.de,11.8980804,47.9933215
-180bf93e-96a5-481e-9c3a-38a321013b0f,Herrnbräu,brewpub,95 Manchinger Straße,,,Ingolstadt,Bayern,85053,Germany,+49 841 6310,http://www.herrnbraeu.de,11.4656471,48.7484823
-80a3e6bc-291a-46f4-9ddc-e76282d3ffbf,Herzogliches Brauhaus,brewpub,1 Schloßplatz,,,Tegernsee,Bayern,83684,Germany,+49 8022 18020,http://www.braeustueberl.com,11.7564449,47.70781059999999
-90a3f492-8ef7-4f15-9829-6bd2bc91af1d,Herzogsberg Bräu,brewpub,6 St.-Martin-Straße,,,Velburg,Bayern,92355,Germany,+49 9182 170,https://www.winkler-braeu.de/?utm_source=google&utm_medium=organic&utm_campaign=google_mybusiness&utm_term=hotel,11.628994,49.23766999999999
-133b9d57-f826-42f1-8f5b-93a2e24da16a,Hetzel,brewpub,11 A Frauendorf,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 6435,http://www.brauerei-hetzel.de/,11.06148,50.07127999999999
-54420e8a-9593-4bfd-ac20-952e64d1791b,Higgins Ale Works,brewpub,122 Karlstraße,,,München,Bayern,80335,Germany,+49 1525 7513113,http://www.higginsaleworks.com,11.5523408,48.1473322
-4aa22d3a-6809-47f1-bb45-d498c0855fe5,Hintereder,brewpub,48 Chammünster,,,Cham,Bayern,93413,Germany,+49 9971 3625,,12.694225,49.21099599999999
-17479050-c70b-41c0-97e4-7e89800ffdda,Hinterhofbräu,brewpub,2a Auenstraße,,,Aichach,Bayern,86551,Germany,+49 174 3265962,http://www.hinterhofbraeu-aichach.de,11.1345363,48.462405
-c241cc7c-c14f-46a1-8d68-efb214ee784e,Hirschbräu Gaissmaier,brewpub,1 Ulmer Straße,,,Leipheim,Bayern,89340,Germany,+49 8221 71411,,10.2185459,48.4491348
-b11bc011-1eef-4384-b07e-bffc01cd5a51,Hochholzer Brauhaus,closed,4a Hochholz,,,Solnhofen,Bayern,91807,Germany,+49 9145 837237,http://www.hochholzer-brauhaus.de,11.0294007,48.9007699
-2696375a-6ffb-4517-a609-f38c02bf6927,Hofbräu,brewpub,3 Stadionstraße,,,Abensberg,Bayern,93326,Germany,+49 9443 905666,http://www.hofbraeu.com,11.851301,48.8170359
-ecc6e778-ac00-4883-bd8c-3e6865a7ff5e,Hofbräu Oberle,brewpub,24 Am Deckersweiher,,,Erlangen,Bayern,91056,Germany,,http://www.fischerei-oberle.de,10.9352579,49.6004303
-c50351c1-18bc-4f45-9c45-9791f731f481,Hofbrauhaus,brewpub,15 Bräuhausstraße,,,Berchtesgaden,Bayern,83471,Germany,+49 8652 96640,http://www.hofbrauhaus-berchtesgaden.de,13.00716,47.63447
-5c104766-1433-4194-8975-e17fa2044905,Hofbräuhaus,brewpub,6 Hofgasse,,,Traunstein,Bayern,83278,Germany,+49 861 988660,http://www.hb-ts.de,12.6507064,47.868965
-1095a960-4475-4a1c-ae34-764c082cb401,Hofmann,micro,1 Dettendorfer Straße,,,Gutenstetten,Bayern,91468,Germany,,http://www.hofmann-bier.de,10.6565412,49.6188969
-4fe7f2e8-8dfd-4c9d-8296-9350d676f77c,Hofmark,brewpub,15 Hofmarkstraße,,,Traitsching,Bayern,93455,Germany,+49 9971 3301,http://www.hofmark-bier.de,12.6396994,49.1668282
-c7123859-522c-415d-8669-ca521c4fd55c,Hofmühl,brewpub,10 Hofmühlstraße,,,Eichstätt,Bayern,85072,Germany,+49 8421 980820,http://www.hofmuehl.de,11.1681128,48.8936305
-e3a53892-360f-48c2-a328-2a2eacb687fa,Hoh,brewpub,4 Köttensdorf,,,Scheßlitz,Bayern,96110,Germany,+49 9542 627,https://facebook.com/people/Brauerei-Hoh/100063520905616/,11.0200426,49.9552026
+f7042903-4248-4a1a-9548-c9e4dfd4a074,Giesinger Bräu,brewpub,Martin-Luther-Straße 2,,,München,Bayern,81539,Germany,+49 89 55062184,http://www.giesinger-braeu.de,11.576744,48.1155998
+2c36de9a-41c0-433e-adfe-ccb87cc8d460,Glentleitner Wirtschaft,brewpub,An der Glentleiten 1,,,Schlehdorf,Bayern,82444,Germany,,http://www.glentleitner-wirtschaft.de,11.285346,47.6644515
+12575c3b-4e14-4ad0-9741-71585750bd23,Glossner,brewpub,Deininger Weg 88,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 2340,http://www.glossner.de,11.472773,49.262772
+4264296e-4266-4892-bf45-785663145ab3,Goikelbräu,brewpub,Zum Sommerhof 2,,,Lohr am Main,Bayern,97816,Germany,+49 9359 9097840,http://www.goikelbraeu.de,9.656018,50.01212169999999
+6c5917bc-c6f3-4225-9628-a3e493835c9a,Goldener Engel,brewpub,Raiffeisenstraße 4,,,Waldstetten,Bayern,89367,Germany,+49 8223 1274,http://www.engelbrauerei.de,10.2944521,48.3491813
+7af10aee-fdf1-40ae-a3f0-dedd721ea3c4,Goldener Löwe,brewpub,Drügendorf 26,,,Eggolsheim,Bayern,91330,Germany,+49 9545 8583,http://www.brauerei-foerst.de,11.1167625,49.8070265
+079c76a2-0adc-4716-9424-01d5bf8b9fc4,Göller,brewpub,Scheßlitzer Straße 7,,,Memmelsdorf,Bayern,96117,Germany,+49 9505 1745,http://www.goeller-brauerei.de,10.971651,49.94078769999999
+1a7c8d69-8295-47a0-97f1-bd8b0d0f2bbd,Goss,brewpub,Regensburger Straße 16,,,Deuerling,Bayern,93180,Germany,+49 9498 1512,http://www.brauerei-goss.de/,11.9076069,49.0350368
+88a65fa2-1755-43e5-9d7d-945b855b5ac5,Gradl,brewpub,Leups 6,,,Pegnitz,Bayern,91257,Germany,+49 9246 247,http://www.leupser.de/,11.5245981,49.81298409999999
+9f8f664a-b8ba-4a38-98df-5350db505512,Graf Arco,brewpub,Hauptstraße 14,,,Eichendorf,Bayern,94428,Germany,+49 9952 280,http://www.graf-arco.de,12.8368395,48.6341354
+f035b6f3-2125-452a-9615-31d503a6b3f0,Graminger Weissbräu,brewpub,Graming 79,,,Altötting,Bayern,84503,Germany,+49 8671 96140,http://www.graminger-weissbraeu.de,12.6668034,48.211029
+d60cfa3a-683e-4b17-b05d-41d66250bb56,Grasser,brewpub,Huppendorf 25,,,Königsfeld,Bayern,96167,Germany,+49 9207 270,http://www.huppendorfer-bier.de,11.150008,49.9320062
+5c848c89-5fcd-427c-9fe0-50a1f250f54c,Greif,brewpub,Serlbacher Straße 10,,,Forchheim,Bayern,91301,Germany,+49 9191 727920,http://www.brauerei-greif.de,11.0591894,49.7256641
+5b9acb35-0669-4869-ad0b-93add02c0f9b,Greifenklau,brewpub,Laurenziplatz 20,,,Bamberg,Bayern,96049,Germany,+49 951 53219,http://www.greifenklau.de,10.8821241,49.8836721
+5069335c-64b5-41ed-98f2-0db395c70441,Griesbräu,brewpub,Obermarkt 37,,,Murnau am Staffelsee,Bayern,82418,Germany,+49 8841 1422,http://www.griesbraeu.de,11.200572,47.6799353
+f8972817-a555-491e-b1d8-4cfd00fe87f4,Griess,brewpub,Magdalenenstraße 6,,,Strullendorf,Bayern,96129,Germany,+49 9505 1624,http://www.brauerei-griess.de,11.0113069,49.8805286
+304286b4-c9e7-4fba-824c-3531dcafcf7e,Grosch,brewpub,Coburger Straße 3,,,Rödental,Bayern,96472,Germany,,http://www.der-grosch.de,11.0266661,50.2877473
+24e35e4c-a64e-4a30-a577-a7c9e16d4015,Gundel,brewpub,Nördlinger Straße 15,,,Kammerstein,Bayern,91126,Germany,+49 9178 1504,http://www.brauerei-gundel.de,10.9280372,49.2744636
+6a6bb1e6-889e-47bc-9f33-05460243274b,Günther-Bräu,brewpub,In der Au 27,,,Burgkunstadt,Bayern,96224,Germany,+49 9572 386650,http://www.guenther-braeu.de,11.24823,50.13639999999999
+5a290fbb-5e8e-4f52-9d04-dea0c165c09c,Gut Forsting,brewpub,Münchner Straße 23,,,Pfaffing,Bayern,83539,Germany,+49 8094 1011,http://www.brauerei-gut-forsting.de,12.0891,48.08125
+2525ce71-1da1-4677-85a7-5723ac441d9a,Gutmann,brewpub,Am Kreuzberg 1,,,Titting,Bayern,85135,Germany,+49 8423 99660,http://www.brauerei-gutmann.de,11.2079458,48.99454919999999
+c593265c-7421-43d3-8cd6-11f21e3dc173,Gutsbräu,brewpub,Scheibe 1,,,Salzweg,Bayern,94121,Germany,+49 8505 93410,http://www.gutsbraeu.de,13.479179,48.635466
+895c2c82-8003-424b-a7a5-306755dfcde7,Haberstumpf,brewpub,Bergstraße 31,,,Trebgast,Bayern,95367,Germany,+49 9227 351,http://www.brauerei-haberstumpf.de,11.5457537,50.0723274
+cf96fce3-b0ee-438b-a4c4-d2223f583392,Hacklberg,brewpub,Bräuhausplatz 3,,,Passau,Bayern,94034,Germany,+49 851 50150,http://www.hacklberg.de,13.4434237,48.57780899999999
+82a821c6-b99d-401e-ba39-f79a2ae5e942,Haderner Bräu,brewpub,Großhaderner Straße 56a,,,München,Bayern,81375,Germany,+49 89 92581988,http://www.haderner.de,11.4822463,48.1226804
+4f3bbd77-eae6-4111-a75f-6c101dc6abe8,Haidbräu,brewpub,Admiralbogen 41,,,München,Bayern,80939,Germany,+49 89 54047373,http://www.awo-muenchen.de/psychiatrie/awo-muenchen-conceptliving-gmbh/taetigkeitsfelder-und-standorte/haidbraeu/,11.6142492,48.2102829
+f080a133-0ee0-4772-a947-d80bd8f898a0,Häpfenbräu,brewpub,Am Bahnhof 4,,,Rammingen,Bayern,86871,Germany,+49 1512 9777903,http://www.braustadel-rammingen.de,10.5650688,48.0641512
+e5bf58bd-89b2-4dfc-a4c5-a412f9c35aaa,Hartl Bräu,micro,Industriestraße 13,,,Lappersdorf,Bayern,93138,Germany,+49 941 2800666,https://www.hausler-lappersdorf.de/,12.0910414,49.0584314
+98362eae-ed4c-4fb1-952c-673181ba4132,Hartl's Hausbrauerei,micro,Duringstraße 5,,,Türkenfeld,Bayern,82299,Germany,+49 8193 999517,http://www.gasthof-hartl.de,11.0859833,48.1075236
+f284736b-5d5b-41b0-a667-38316f62bed7,Hartleb,brewpub,Herrenstraße 9,,,Maroldsweisach,Bayern,96126,Germany,+49 9532 240,https://de-de.facebook.com/pages/Hartleb-Irmgard-Gastst%C3%A4tte-Brauerei/158561980838544,10.6607834,50.1966511
+f8642be5-23b2-47e7-8e9d-44fd7972cd6b,Hartmann,brewpub,Fränkische-Schweiz-Straße 26,,,Scheßlitz,Bayern,96110,Germany,+49 9542 920300,http://www.brauerei-hartmann.de,11.0898405,49.9791286
+e99ec846-7b9c-45f5-aea7-3c5c51dbe181,Hasen-Bräu,brewpub,Berliner Allee 36,,,Augsburg,Bayern,86153,Germany,+49 821 32990,http://www.kaelberhalle.de,10.9181108,48.3726464
+68db59f2-309e-4e26-b8d0-baca8c0b07f1,Hauf,brewpub,Heininger Straße 28,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 57520,http://www.hauf-bier.de,10.34418,49.06744
+dd157db9-d742-4efd-94bc-b8710f84870b,Hauff-Bräu,brewpub,Heininger Straße 28,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 57520,http://www.hauff-braeu.de,10.34418,49.06744
+980edf15-e774-404a-a687-d9fe557a0bef,Hausbräu,brewpub,Ruhlstraße 6,,,Stegaurach,Bayern,96135,Germany,+49 951 299709,http://www.hausbraeu-stegaurach.de,10.8551978,49.8606134
+3e446925-b16c-4854-b905-a5646e7727eb,Hausbrauerei Höpfl,brewpub,Steinfelder Straße 17,,,Steinfeld,Bayern,97854,Germany,+49 9396 1532,http://www.hausbrauerei-hoepfl.de,9.6287065,49.944489
+5cfe0eb0-5479-4e64-9f78-d7d708854a82,Hebendanz,brewpub,Sattlertorstraße 14,,,Forchheim,Bayern,91301,Germany,+49 9191 9790500,http://www.brauerei-hebendanz.de,11.0567992,49.7202231
+3cd041d8-c2f7-4a4b-9b76-8e1a68e22aae,Heberbräu,brewpub,Auerbacher Straße 14,,,Kirchenthumbach,Bayern,91281,Germany,+49 9647 929718,http://www.heberbraeu.de,11.72389,49.74596
+9cee6e35-2c75-4f92-8b64-904d6fc11f6f,Hechtbräu,brewpub,Zimmern 59,,,Pappenheim,Bayern,91788,Germany,+49 9143 212569,http://www.hechtbraeu-zimmern.de,10.98369,48.92698
+7162c7e4-aba2-4f1e-bd17-15c985e19f41,Heckel,brewpub,Vorstadt 3,,,Waischenfeld,Bayern,91344,Germany,+49 9202 493,https://www.facebook.com/share/p/189zjDdNch/,11.3463649,49.8451251
+41d6185d-91a4-4cf5-bcf2-a46c1ebf7c95,Heimat- & Bauernkriegsmuseum,micro,Stadtberg 1,,,Leipheim,Bayern,89340,Germany,+49 8221 72095,http://www.leipheim.de/index.php?selected_page_id=1622,10.2195256,48.4497821
+52547766-f12c-441d-961d-e1a3e6e4ff97,Heimbergers Craftbeer,brewpub,Flemingstraße 25,,,Hösbach,Bayern,63836,Germany,+49 6021 550872,http://www.facebook.com/craftladen/,9.194619699999999,50.0035237
+a8a839e8-7958-4cd9-809f-e8053ab61fe5,Heinen's Craft Beer,brewpub,Flemingstraße 25,,,Hösbach,Bayern,63836,Germany,+49 6021 550872,http://www.facebook.com/DieterHeinenBrauerei/,9.194619699999999,50.0035237
+c50d2241-90db-46c8-a858-d587d1c41b62,Held-Bräu,brewpub,Oberailsfeld 19,,,Ahorntal,Bayern,95491,Germany,+49 9242 295,http://www.held-braeu.de,11.35353,49.81245999999999
+ad6b75a4-4e80-4519-9cc2-6033ae03ad7c,Heldrich,brewpub,Sulzbacher Straße 3,,,Edelsfeld,Bayern,92265,Germany,+49 9665 441,http://www.fc-edelsfeld.de/,11.696092,49.5769402
+2f06d681-136c-4b5c-aa65-8f05b7443d09,Heller,brewpub,Oberer Stephansberg 27,,,Bamberg,Bayern,96049,Germany,+49 951 56060,http://www.smokebeer.com,10.8872004,49.8863561
+b1bf179e-200b-40a4-8a37-c627418e9884,Hellmuth,brewpub,Wiesen 14,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 4395,http://www.gasthaus-hellmuth.de,10.9499288,50.0961345
+1a5a3fad-4a6a-4264-a2bf-7905360d0a11,Hembach,closed,Siemensstraße 4,,,Rednitzhembach,Bayern,91126,Germany,+49 179 9471670,,11.0490865,49.3128237
+693e7819-b228-4607-8fb0-be1b32506628,Hennemann,brewpub,Sambach 33,,,Pommersfelden,Bayern,96178,Germany,+49 9502 4307,http://www.brauerei-hennemann.com,10.8419583,49.7808831
+3945e88e-f2fc-4c32-a6e0-0521c527ef37,Herold,closed,Marktstraße 29,,,Pegnitz,Bayern,91257,Germany,+49 9241 3311,http://www.beckn-bier.de,11.5102068,49.79403490000001
+1c3881d7-8f89-4595-a3ff-9d726d8cab09,Herr Max & Frau Hopfen,closed,Schloßweg 1,,,Holzgünz,Bayern,87752,Germany,+49 8393 9437870,http://www.herrmaxundfrauhopfen.de,10.2598894,48.0221381
+49fe05ef-66d5-41f5-a555-977814ce1924,Herrmann,brewpub,Brückenstraße 3,,,Burgebrach,Bayern,96138,Germany,+49 9546 372,http://www.brauerei-herrmann.franken-regio.de,10.7309815,49.8456206
+74e95ac8-7d48-48e1-90fb-34b38fa3cd9b,Herrmannsdorfer Schweinsbräu,brewpub,Herrmannsdorf 7,,,Glonn,Bayern,85625,Germany,+49 8093 909445,http://www.herrmannsdorfer.de,11.8980804,47.9933215
+180bf93e-96a5-481e-9c3a-38a321013b0f,Herrnbräu,brewpub,Manchinger Straße 95,,,Ingolstadt,Bayern,85053,Germany,+49 841 6310,http://www.herrnbraeu.de,11.4656471,48.7484823
+80a3e6bc-291a-46f4-9ddc-e76282d3ffbf,Herzogliches Brauhaus,brewpub,Schloßplatz 1,,,Tegernsee,Bayern,83684,Germany,+49 8022 18020,http://www.braeustueberl.com,11.7564449,47.70781059999999
+90a3f492-8ef7-4f15-9829-6bd2bc91af1d,Herzogsberg Bräu,brewpub,St.-Martin-Straße 6,,,Velburg,Bayern,92355,Germany,+49 9182 170,https://www.winkler-braeu.de/?utm_source=google&utm_medium=organic&utm_campaign=google_mybusiness&utm_term=hotel,11.628994,49.23766999999999
+133b9d57-f826-42f1-8f5b-93a2e24da16a,Hetzel,brewpub,A Frauendorf 11,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 6435,http://www.brauerei-hetzel.de/,11.06148,50.07127999999999
+54420e8a-9593-4bfd-ac20-952e64d1791b,Higgins Ale Works,brewpub,Karlstraße 122,,,München,Bayern,80335,Germany,+49 1525 7513113,http://www.higginsaleworks.com,11.5523408,48.1473322
+4aa22d3a-6809-47f1-bb45-d498c0855fe5,Hintereder,brewpub,Chammünster 48,,,Cham,Bayern,93413,Germany,+49 9971 3625,,12.694225,49.21099599999999
+17479050-c70b-41c0-97e4-7e89800ffdda,Hinterhofbräu,brewpub,Auenstraße 2a,,,Aichach,Bayern,86551,Germany,+49 174 3265962,http://www.hinterhofbraeu-aichach.de,11.1345363,48.462405
+c241cc7c-c14f-46a1-8d68-efb214ee784e,Hirschbräu Gaissmaier,brewpub,Ulmer Straße 1,,,Leipheim,Bayern,89340,Germany,+49 8221 71411,,10.2185459,48.4491348
+b11bc011-1eef-4384-b07e-bffc01cd5a51,Hochholzer Brauhaus,closed,Hochholz 4a,,,Solnhofen,Bayern,91807,Germany,+49 9145 837237,http://www.hochholzer-brauhaus.de,11.0294007,48.9007699
+2696375a-6ffb-4517-a609-f38c02bf6927,Hofbräu,brewpub,Stadionstraße 3,,,Abensberg,Bayern,93326,Germany,+49 9443 905666,http://www.hofbraeu.com,11.851301,48.8170359
+ecc6e778-ac00-4883-bd8c-3e6865a7ff5e,Hofbräu Oberle,brewpub,Am Deckersweiher 24,,,Erlangen,Bayern,91056,Germany,,http://www.fischerei-oberle.de,10.9352579,49.6004303
+c50351c1-18bc-4f45-9c45-9791f731f481,Hofbrauhaus,brewpub,Bräuhausstraße 15,,,Berchtesgaden,Bayern,83471,Germany,+49 8652 96640,http://www.hofbrauhaus-berchtesgaden.de,13.00716,47.63447
+5c104766-1433-4194-8975-e17fa2044905,Hofbräuhaus,brewpub,Hofgasse 6,,,Traunstein,Bayern,83278,Germany,+49 861 988660,http://www.hb-ts.de,12.6507064,47.868965
+1095a960-4475-4a1c-ae34-764c082cb401,Hofmann,micro,Dettendorfer Straße 1,,,Gutenstetten,Bayern,91468,Germany,,http://www.hofmann-bier.de,10.6565412,49.6188969
+4fe7f2e8-8dfd-4c9d-8296-9350d676f77c,Hofmark,brewpub,Hofmarkstraße 15,,,Traitsching,Bayern,93455,Germany,+49 9971 3301,http://www.hofmark-bier.de,12.6396994,49.1668282
+c7123859-522c-415d-8669-ca521c4fd55c,Hofmühl,brewpub,Hofmühlstraße 10,,,Eichstätt,Bayern,85072,Germany,+49 8421 980820,http://www.hofmuehl.de,11.1681128,48.8936305
+e3a53892-360f-48c2-a328-2a2eacb687fa,Hoh,brewpub,Köttensdorf 4,,,Scheßlitz,Bayern,96110,Germany,+49 9542 627,https://facebook.com/people/Brauerei-Hoh/100063520905616/,11.0200426,49.9552026
 c874aff5-cef8-4e65-beff-e516aeb6e7e8,Hohe-Wart-Bräu,brewpub,,,,Hohe Wart,Bayern,63875,Germany,+49 6021 33980,http://www.hohewart-haus.de,9.2574728,49.9178822
-60fc1d3e-9baa-4594-b470-1ddbcd74f008,Höhn,brewpub,11 Hauptstraße,,,Memmelsdorf,Bayern,96117,Germany,+49 951 406140,http://www.gasthof-hoehn.de,10.9527064,49.9325905
-bcb6bf66-2993-47d9-954b-f4747ca2c59a,Holzhauser,brewpub,8 Hauptstraße,,,Igling,Bayern,86859,Germany,+49 8241 4758,http://www.holzhauser-brauerei-gasthaus.de,10.7767543,48.0471359
-0e88701d-40e0-47a3-a76e-0bee5ea7a67d,Hölzlein,brewpub,13 Ellertalstraße,,,Litzendorf,Bayern,96123,Germany,+49 9505 357,http://www.brauerei-hoelzlein.de,11.044932,49.9165066
-fe7672c1-6d21-414c-a60d-bbb7eb4776a4,Homburger Bräuscheuere,brewpub,6 Zeller Tor,,,Triefenstein,Bayern,97855,Germany,+49 9395 876882,http://www.braeuscheuere.de,9.6232378,49.7927571
-2167a161-0731-45e5-bfaf-5c983ed76669,Hönicka-Bräu,brewpub,31 Hofer Straße,,,Wunsiedel,Bayern,95632,Germany,+49 9232 2044,http://www.hoenicka.de/start.htm,11.9961568,50.0415749
-e8ec9985-695f-4f4a-9b0a-c75ef15d7395,Hönig,brewpub,15 Ellerbergstraße,,,Litzendorf,Bayern,96123,Germany,+49 9505 391,http://www.brauerei-hoenig.de,11.0742343,49.9188376
-edbca112-5f80-420c-834d-1a9f8688bc14,Honig Bräu,closed,200 Frankenstraße,,,Nürnberg,Bayern,90461,Germany,,http://www.honig-braeu.de,11.0947853,49.4305623
-36bd1d2b-aa4d-4007-9962-c415e119d13e,Hopf,brewpub,8 Schützenstraße,,,Miesbach,Bayern,83714,Germany,+49 8025 29590,http://www.hopfweisse.de,11.83114,47.79396
-34bdfdb4-6fe5-4f1f-ad10-494afc7cb9ff,Hopfenfreunde,brewpub,12 Platanenweg,,,Fürth,Bayern,90765,Germany,+49 176 43618002,http://www.brauhaus-hopfenfreunde.de,10.98203,49.5071
-014ae6ea-861b-418f-9e32-3263b1b4e49e,Hopfenhäcker,brewpub,78 Unterhachinger Straße,,,München,Bayern,81737,Germany,,http://www.hopfenhaecker.de,11.6248474,48.0940883
-59053860-b6aa-449e-a9d1-adbabdada88b,Hopfenhäusla,brewpub,22 Schützenstraße,,,Münchberg,Bayern,95213,Germany,+49 9251 4371347,http://www.hopfenhaeusla.de,11.7947498,50.1993628
-077e96c0-bca9-4e00-8a2e-01074d86c52a,Hopfentroll,brewpub,5 Wintersbach,,,Weilbach,Bayern,63937,Germany,+49 1573 1693777,http://www.facebook.com/Hopfentroll-192096707964981/,9.2028793,49.66835
-d53dffbb-0dd5-4378-9e89-2fa1f94d64e4,Horneck,brewpub,7 Horneck,,,Elsendorf,Bayern,84094,Germany,+49 8753 503,http://www.brauerei-horneck.de,11.8513198,48.70104329999999
-248bc078-ca7f-46ca-a407-44225e692536,Hösl,brewpub,1 Bahnhofstraße,,,Mitterteich,Bayern,95666,Germany,+49 9633 92220,http://www.hoeslbier.de,12.24247,49.95008
-ad57ded9-b4ab-41d1-8204-3921db6616ab,Hübner,brewpub,28 Hauptstraße,,,Wattendorf,Bayern,96196,Germany,+49 9504 207,http://www.brauerei-huebner.de,11.1262986,50.0324973
-7667eb49-cb7b-4ade-8999-742ac20a4055,Hübner-Bräu,brewpub,69 Steinfeld,,,Stadelhofen,Bayern,96187,Germany,,http://www.huebner-braeu.de,11.1546838,49.9780658
-ea171fc7-97b3-4869-bc42-ae1a8ecff57a,Hufeisen,brewpub,36 Hauptstraße,,,Pottenstein,Bayern,91278,Germany,+49 9243 260,http://www.hufeisen-braeu.de,11.4104511,49.77111499999999
-4d66a68e-889c-4271-9779-c8817be4c853,Hummel,brewpub,9 Lindenstraße,,,Memmelsdorf,Bayern,96117,Germany,+49 9542 1247,http://www.brauerei-hummel.de,10.9583182,49.959515
-7054d20b-b10a-4876-9372-1d037d969397,Hümmer Bräu,closed,22 Bamberger Straße,,,Breitengüßbach,Bayern,96149,Germany,+49 9544 20344,http://www.pensionkarin.de,10.8853528,49.96954419999999
-f5fc4b9a-01fb-4d06-9a71-7ebf76a9e82b,Hütten,brewpub,6-8 Hütten,,,Warmensteinach,Bayern,95485,Germany,+49 9277 312,http://www.brauerei-huetten.de,11.8121829,50.00534769999999
-c01d5e4f-db12-4c95-a691-2626afff39d1,Hutthurmer,brewpub,8 Bräugasse,,,Hutthurm,Bayern,94116,Germany,+49 8505 8695810,http://www.hutthurmer.de,13.4713747,48.6741366
-495db1a6-382a-4b79-8909-1f405d454a23,Inselbräu,brewpub,28 Frauenchiemsee,,,Frauenchiemsee,Bayern,83256,Germany,+49 8054 902088,http://www.inselbraeu-frauenchiemsee.de,12.4255211,47.8741132
-e954f96e-0f25-4c11-9a12-fb9130ab6e69,Institut Romeis,micro,21 Schlimpfhofer Straße,,,Oberthulba,Bayern,97723,Germany,+49 9736 75160,http://www.institutsbrauerei.de,9.9683553,50.2065518
-050dc670-a2e1-4dd6-b5a2-fc050e2f94b2,Irseer Klosterbräu,brewpub,1-3 Klosterring,,,Irsee,Bayern,87660,Germany,+49 8341 432200,http://www.irsee.com,10.5755602,47.9091403
-fd4ae60f-fcc5-47da-8d84-78fd3af1290e,Isartaler Brauhaus,brewpub,23b Kreuzeckstraße,,,Pullach im Isartal,Bayern,82049,Germany,+49 89 798961,http://www.isartaler-brauhaus.de,11.5311041,48.0709648
-7a94a013-e7d1-4dd1-9e19-818cc85a176c,Jacob,brewpub,2 Ludwigsheide,,,Bodenwöhr,Bayern,92439,Germany,+49 9434 94100,http://www.brauerei-jacob.de,12.3050392,49.2711318
-17e4b190-86ef-4a71-97e3-e35ddd6b75c5,Joferbräu,brewpub,6 Mainburger Straße,,,Aiglsbach,Bayern,84089,Germany,+49 8753 8126,http://www.joferbraeu.de,11.7136215,48.6914249
-222a3ade-c662-4439-bf80-504ef372cf18,Juliusbräu,brewpub,135B Augsburger Straße,,,Neuburg an der Donau,Bayern,86633,Germany,+49 8431 2069,http://www.neuwirt-neuburg.de,11.1812,48.72699
-295bfd97-20cc-4b4a-932a-fbc146067a2f,Jura-Bräu,brewpub,8 Am Buchauer Berg,,,Pegnitz,Bayern,91257,Germany,+49 9241 2019,http://www.jura-braeu.de,11.5429,49.758585
-5c27d4f5-03e1-4afc-aec6-bf3a20bb6284,Kaiser-Bräu,brewpub,1 Oberer Markt,,,Neuhaus an der Pegnitz,Bayern,91284,Germany,+49 9156 880,http://www.kaiser-braeu.de,11.5495378,49.6281413
-2854d9f1-6c5b-46a1-b169-472015ec9eeb,Kaiserdom,brewpub,9 Breitäckerstraße,,,Bamberg,Bayern,96049,Germany,+49 951 60450,http://www.kaiserdom.de,10.85236,49.90425
-fe7b8c83-cc23-41ea-9fbf-993d278979a6,Kaiserhof,brewpub,1 Friesener Straße,,,Kronach,Bayern,96317,Germany,+49 9261 628000,http://www.kaiserhofbraeu.de,11.327765,50.241246
-b4924c5f-3213-4565-a50e-34cd6d2b2e6f,Kaltentaler Brauhaus,brewpub,12 Blonhofener Straße,,,Kaltental,Bayern,87662,Germany,+49 8345 1565,http://www.kaltentaler-brauhaus.de,10.75334,47.91126999999999
-a225ae70-e1cc-49c1-b22d-43706af9cded,Kalvarienbergbräu,brewpub,3 Hafnerweg,,,Marklkofen,Bayern,84163,Germany,+49 1512 2907482,http://www.facebook.com/kalvarienbergbraeu,12.547864,48.5676964
-be3b6cbf-6b8e-480d-8fc2-70bf1e3734b3,Kanone,brewpub,1a Brückenstraße,,,Schnaittach,Bayern,91220,Germany,+49 9153 366,http://www.brauerei-kanone.de,11.3385956,49.5714005
-53b98572-b064-4043-a485-91d17db3d098,Kapplerbräu,brewpub,8 Nerbstraße,,,Altomünster,Bayern,85250,Germany,+49 8254 777,http://www.kapplerbraeu.de,11.25766,48.38724
-5dc48a5d-01eb-4826-be59-c5c357e6e09c,Karg,brewpub,27 Untermarkt,,,Murnau am Staffelsee,Bayern,82418,Germany,+49 8841 1268,http://www.brauerei-karg.de,11.2016458,47.6767159
-00e1b34e-1082-411b-808e-51d85bff935e,Karmeliten,brewpub,21 Senefelderstraße,,,Straubing,Bayern,94315,Germany,+49 9421 78190,http://www.karmeliten-brauerei.de,12.62189,48.88795
-8ed2d985-a269-4f56-b324-215c044ee948,Karmeliter-Bräu,closed,7 Ludwig-Elsbett-Straße,,,Salz,Bayern,97616,Germany,+49 9771 1323,http://www.karmeliter-braeu.de,10.1919788,50.2960498
-79037d41-38b6-4ef2-b361-04efe0e222fa,Kathi-Bräu,brewpub,1 Heckenhof,,,Aufseß,Bayern,91347,Germany,+49 9198 277,https://www.kathibraeu.de/,11.2447417,49.8793306
-e70e01df-5cdf-458a-9dc5-6df9e42146af,Katzerer,brewpub,2 Sondersfeld,,,Freystadt,Bayern,92342,Germany,+49 9185 903813,http://www.sondersfeld.de/katzerer.htm,11.3884519,49.2151607
-22b413fe-a9af-4f5e-a26f-5bfb9b656682,Kauzen,brewpub,17 Uffenheimer Straße,,,Ochsenfurt,Bayern,97199,Germany,+49 9331 87250,http://www.kauzen.de,10.0711964,49.659691
-c96f2cb2-4aca-4a96-b032-d8dce77f52b0,Ke,brewpub,2 Alfred-Stumpf-Straße,,,Lohr am Main,Bayern,97816,Germany,+49 9352 7328,http://www.keiler-brauhaus.de,9.571358199999999,49.9947533
-8c8bd0ad-fcc8-47ac-89a1-c71a8245f3a0,Keesmann,brewpub,5 Wunderburg,,,Bamberg,Bayern,96050,Germany,+49 951 981980,http://www.keesmann-braeu.de,10.9056038,49.8904222
-f52d8c62-2f5a-4dca-9e90-b5a4e36c3deb,KellerBräu Dorfen,brewpub,2 Jahnstraße,,,Dorfen,Bayern,84405,Germany,+49 8081 8143,https://www.instagram.com/kellerbraeu_dorfen/,12.1517057,48.2757604
-29f70ef7-ca88-4183-9f3c-45771f57ff2e,Kellerbrauerei Prittlbach,brewpub,6 Angerstraße,,,Hebertshausen,Bayern,85241,Germany,+49 8131 338448,http://www.kellerbrauerei-prittlbach.de,11.44477,48.2865
-7b346fe5-6b3d-4a35-b562-c3b77db9391f,Kesselbräu,brewpub,13 Leithenbukweg,,,Marktsteft,Bayern,97342,Germany,+49 9332 50630,https://www.kesselring-bier.de/,10.1376365,49.6994147
-f16be512-5f4d-4c98-b568-c4be9b2ff34c,Kesselring,brewpub,13 Leithenbukweg,,,Marktsteft,Bayern,97342,Germany,+49 9332 50630,http://www.kesselring-bier.de,10.1376365,49.6994147
-9f608762-2758-4ca4-b6d7-da8b45ec9259,Kini Bier,brewpub,34 Deutschenbaurstraße,,,Augsburg,Bayern,86157,Germany,+49 821 524255,http://www.kini.beer,10.8687582,48.3688732
-596fa47f-2072-4c7d-8892-23c0f43ce3da,Kirnachstuben,brewpub,38 Hauptstraße,,,Ruderatshofen,Bayern,87674,Germany,+49 8343 340,http://www.kirnachstuben.de,10.58466,47.81804
-0102aec0-8de7-4e68-99f5-5ef3fc798541,Kleinbrauerei Rain,bar,52 Hauptstraße,,,Rain,Bayern,86641,Germany,,http://www.kleinbrauerei-rain.de,10.9156483,48.690323
-c9bdae9c-fda2-4e74-b2b0-b757a00a0145,Kleines Brauhaus,brewpub,21 Senefelderstraße,,,Straubing,Bayern,94315,Germany,+49 9421 78190,https://www.karmeliten-brauerei.de/,12.62189,48.88795
-cfe647e7-92b2-447d-a602-db72b29a3962,Kleines Pleinfelder Brauhaus,brewpub,19 Egloffsteiner Straße,,,Pretzfeld,Bayern,91362,Germany,+49 9194 725025,http://www.landhotel-sonnenhof.de,11.1756891,49.7559717
-5a5035a5-3d55-476c-a0da-bf6fe6989098,Klett-Bräu,brewpub,8 Johann-Dachauer-Straße,,,Konzell,Bayern,94357,Germany,+49 9963 805,http://www.bier.by/brauerei-guide/klett-brau-1.3495815,12.7130995,49.0723503
-f779ee97-4d52-4792-a27d-7f916c8be618,Klier Bräu,brewpub,23a Reuteweg,,,Blaichach,Bayern,87544,Germany,+49 8321 608657,http://www.klier-bier.de,10.2490773,47.5420542
-ff726816-c4ce-4900-93b7-1d18030e301d,Klingenbrunn,brewpub,15 Frauenauer Straße,,,Spiegelau,Bayern,94518,Germany,+49 8553 6018,,13.32121,48.9204
-664949a1-0815-420b-b46d-dba796abc00c,Klosterbräu,brewpub,1-3 Obere Mühlbrücke,,,Bamberg,Bayern,96049,Germany,+49 951 52265,http://www.klosterbraeu.de,10.887197,49.889257
-478a5b5d-3c9c-4128-987c-fb14fa00e107,Klosterbrauerei,brewpub,1 Kaiser-Ludwig-Platz,,,Ettal,Bayern,82488,Germany,+49 8822 746450,http://www.ettaler.info,11.0948932,47.5702104
-736c96a2-9c53-42a2-80de-fc88a3270602,Klosterbrauerei Andechs,brewpub,2 Bergstraße,,,Andechs,Bayern,82346,Germany,+49 8152 3760,http://www.andechs.de,11.1850171,47.9762819
-edae5392-6ee7-40ba-850e-0b049d29bc27,Klosterbrauerei Dietl,brewpub,20 Baumburg,,,Altenmarkt an der Alz,Bayern,83352,Germany,+49 8621 98260,http://www.baumburger.de,12.5311766,47.998781
-f5e94eb7-4b3d-4f42-85ea-b8335889df1a,Klosterbräuhaus,brewpub,2 Dominikus-Ringeisen-Straße,,,Ursberg,Bayern,86513,Germany,+49 8281 99890,http://www.klosterbraeuhaus.de,10.4451218,48.26554489999999
-7bd12803-6b5d-418c-9243-6c46921c0cf6,Kneitinger,brewpub,3 Arnulfsplatz,,,Regensburg,Bayern,93047,Germany,+49 941 52455,http://www.kneitinger.de,12.0890713,49.0197079
-e0a2a6c4-3c7f-436e-a532-642674fcfb41,Knoblach,brewpub,1 Kremmeldorfer Straße,,,Litzendorf,Bayern,96123,Germany,+49 9505 267,http://www.brauerei-knoblach.de,11.0061771,49.9261067
-60310902-998f-4c6b-88b4-983a7b392900,Kohlenmühle,brewpub,53 Bamberger Straße,,,Neustadt an der Aisch,Bayern,91413,Germany,+49 9161 662270,http://www.kohlenmuehle.de,10.6145628,49.5839028
-75956613-ee66-495a-8c93-8de2ed7fa722,Kolb,brewpub,24 Illertisser Straße,,,Roggenburg,Bayern,89297,Germany,+49 7300 301,http://www.brauerei-kolb.de,10.2208057,48.2653822
-51d97425-2e9e-4545-81b6-99c810b280ad,Kommunbräu,brewpub,17 Grünwehr,,,Kulmbach,Bayern,95326,Germany,+49 9221 84490,http://www.kommunbraeu.de,11.4653096,50.11075899999999
-6dd9b403-f0fa-4854-9247-a9c8809217de,Kommunbräu Rehau,micro,1 Fabrikstraße,,,Rehau,Bayern,95111,Germany,,http://www..kommunbraeu-rehau.de,12.0355156,50.2497598
-6727090e-8476-4b82-a83a-f1a9b2426e7e,Kommunbrauerei,brewpub,13 Vorstadt,,,Mitterteich,Bayern,95666,Germany,,http://www.mitterteich.de/home/einrichtungen/verteiler_1/verteiler_5/verteiler_5.htm,12.2408871,49.9499268
-5a7fd707-4e34-4f55-b464-1078c06f3302,Kommunbrauhaus,brewpub,105 Maximiliansplatz,,,Seßlach,Bayern,96145,Germany,+49 9569 452,http://www.gasthof-reinwand.de/brauhaus.htm,10.8415585,50.1877035
-63995c47-27eb-4ec8-ad49-21324c2040c9,König Ludwig Br. Holzkirchen,brewpub,41 Augsburger Straße,,,Fürstenfeldbruck,Bayern,82256,Germany,+49 8141 2430,http://www.oberbraeu-holzkirchen.de,11.251905,48.1828857
-c5195e07-5f1b-4b08-b676-af33c4f80e88,König von Flandern,brewpub,25 Maximilianstraße,,,Augsburg,Bayern,86150,Germany,+49 821 20709818,http://www.koenigvonflandern.de,10.8985536,48.36745730000001
-00157704-9821-43e7-9ed9-7fbe58f040f6,Kössel-Bräu,brewpub,17 Mariahilfer Straße,,,Eisenberg,Bayern,87637,Germany,+49 8364 8556,http://www.koessel-braeu.de,10.6128103,47.6103922
-dd2b8448-8b93-4ca3-bb10-ee3fd9c48ec2,Kraus,brewpub,11 Luitpoldstraße,,,Hirschaid,Bayern,96114,Germany,+49 9543 84440,http://www.brauerei-kraus.de,10.987145,49.8158179
+60fc1d3e-9baa-4594-b470-1ddbcd74f008,Höhn,brewpub,Hauptstraße 11,,,Memmelsdorf,Bayern,96117,Germany,+49 951 406140,http://www.gasthof-hoehn.de,10.9527064,49.9325905
+bcb6bf66-2993-47d9-954b-f4747ca2c59a,Holzhauser,brewpub,Hauptstraße 8,,,Igling,Bayern,86859,Germany,+49 8241 4758,http://www.holzhauser-brauerei-gasthaus.de,10.7767543,48.0471359
+0e88701d-40e0-47a3-a76e-0bee5ea7a67d,Hölzlein,brewpub,Ellertalstraße 13,,,Litzendorf,Bayern,96123,Germany,+49 9505 357,http://www.brauerei-hoelzlein.de,11.044932,49.9165066
+fe7672c1-6d21-414c-a60d-bbb7eb4776a4,Homburger Bräuscheuere,brewpub,Zeller Tor 6,,,Triefenstein,Bayern,97855,Germany,+49 9395 876882,http://www.braeuscheuere.de,9.6232378,49.7927571
+2167a161-0731-45e5-bfaf-5c983ed76669,Hönicka-Bräu,brewpub,Hofer Straße 31,,,Wunsiedel,Bayern,95632,Germany,+49 9232 2044,http://www.hoenicka.de/start.htm,11.9961568,50.0415749
+e8ec9985-695f-4f4a-9b0a-c75ef15d7395,Hönig,brewpub,Ellerbergstraße 15,,,Litzendorf,Bayern,96123,Germany,+49 9505 391,http://www.brauerei-hoenig.de,11.0742343,49.9188376
+edbca112-5f80-420c-834d-1a9f8688bc14,Honig Bräu,closed,Frankenstraße 200,,,Nürnberg,Bayern,90461,Germany,,http://www.honig-braeu.de,11.0947853,49.4305623
+36bd1d2b-aa4d-4007-9962-c415e119d13e,Hopf,brewpub,Schützenstraße 8,,,Miesbach,Bayern,83714,Germany,+49 8025 29590,http://www.hopfweisse.de,11.83114,47.79396
+34bdfdb4-6fe5-4f1f-ad10-494afc7cb9ff,Hopfenfreunde,brewpub,Platanenweg 12,,,Fürth,Bayern,90765,Germany,+49 176 43618002,http://www.brauhaus-hopfenfreunde.de,10.98203,49.5071
+014ae6ea-861b-418f-9e32-3263b1b4e49e,Hopfenhäcker,brewpub,Unterhachinger Straße 78,,,München,Bayern,81737,Germany,,http://www.hopfenhaecker.de,11.6248474,48.0940883
+59053860-b6aa-449e-a9d1-adbabdada88b,Hopfenhäusla,brewpub,Schützenstraße 22,,,Münchberg,Bayern,95213,Germany,+49 9251 4371347,http://www.hopfenhaeusla.de,11.7947498,50.1993628
+077e96c0-bca9-4e00-8a2e-01074d86c52a,Hopfentroll,brewpub,Wintersbach 5,,,Weilbach,Bayern,63937,Germany,+49 1573 1693777,http://www.facebook.com/Hopfentroll-192096707964981/,9.2028793,49.66835
+d53dffbb-0dd5-4378-9e89-2fa1f94d64e4,Horneck,brewpub,Horneck 7,,,Elsendorf,Bayern,84094,Germany,+49 8753 503,http://www.brauerei-horneck.de,11.8513198,48.70104329999999
+248bc078-ca7f-46ca-a407-44225e692536,Hösl,brewpub,Bahnhofstraße 1,,,Mitterteich,Bayern,95666,Germany,+49 9633 92220,http://www.hoeslbier.de,12.24247,49.95008
+ad57ded9-b4ab-41d1-8204-3921db6616ab,Hübner,brewpub,Hauptstraße 28,,,Wattendorf,Bayern,96196,Germany,+49 9504 207,http://www.brauerei-huebner.de,11.1262986,50.0324973
+7667eb49-cb7b-4ade-8999-742ac20a4055,Hübner-Bräu,brewpub,Steinfeld 69,,,Stadelhofen,Bayern,96187,Germany,,http://www.huebner-braeu.de,11.1546838,49.9780658
+ea171fc7-97b3-4869-bc42-ae1a8ecff57a,Hufeisen,brewpub,Hauptstraße 36,,,Pottenstein,Bayern,91278,Germany,+49 9243 260,http://www.hufeisen-braeu.de,11.4104511,49.77111499999999
+4d66a68e-889c-4271-9779-c8817be4c853,Hummel,brewpub,Lindenstraße 9,,,Memmelsdorf,Bayern,96117,Germany,+49 9542 1247,http://www.brauerei-hummel.de,10.9583182,49.959515
+7054d20b-b10a-4876-9372-1d037d969397,Hümmer Bräu,closed,Bamberger Straße 22,,,Breitengüßbach,Bayern,96149,Germany,+49 9544 20344,http://www.pensionkarin.de,10.8853528,49.96954419999999
+f5fc4b9a-01fb-4d06-9a71-7ebf76a9e82b,Hütten,brewpub,Hütten 6-8,,,Warmensteinach,Bayern,95485,Germany,+49 9277 312,http://www.brauerei-huetten.de,11.8121829,50.00534769999999
+c01d5e4f-db12-4c95-a691-2626afff39d1,Hutthurmer,brewpub,Bräugasse 8,,,Hutthurm,Bayern,94116,Germany,+49 8505 8695810,http://www.hutthurmer.de,13.4713747,48.6741366
+495db1a6-382a-4b79-8909-1f405d454a23,Inselbräu,brewpub,Frauenchiemsee 28,,,Frauenchiemsee,Bayern,83256,Germany,+49 8054 902088,http://www.inselbraeu-frauenchiemsee.de,12.4255211,47.8741132
+e954f96e-0f25-4c11-9a12-fb9130ab6e69,Institut Romeis,micro,Schlimpfhofer Straße 21,,,Oberthulba,Bayern,97723,Germany,+49 9736 75160,http://www.institutsbrauerei.de,9.9683553,50.2065518
+050dc670-a2e1-4dd6-b5a2-fc050e2f94b2,Irseer Klosterbräu,brewpub,Klosterring 1-3,,,Irsee,Bayern,87660,Germany,+49 8341 432200,http://www.irsee.com,10.5755602,47.9091403
+fd4ae60f-fcc5-47da-8d84-78fd3af1290e,Isartaler Brauhaus,brewpub,Kreuzeckstraße 23b,,,Pullach im Isartal,Bayern,82049,Germany,+49 89 798961,http://www.isartaler-brauhaus.de,11.5311041,48.0709648
+7a94a013-e7d1-4dd1-9e19-818cc85a176c,Jacob,brewpub,Ludwigsheide 2,,,Bodenwöhr,Bayern,92439,Germany,+49 9434 94100,http://www.brauerei-jacob.de,12.3050392,49.2711318
+17e4b190-86ef-4a71-97e3-e35ddd6b75c5,Joferbräu,brewpub,Mainburger Straße 6,,,Aiglsbach,Bayern,84089,Germany,+49 8753 8126,http://www.joferbraeu.de,11.7136215,48.6914249
+222a3ade-c662-4439-bf80-504ef372cf18,Juliusbräu,brewpub,Augsburger Straße 135B,,,Neuburg an der Donau,Bayern,86633,Germany,+49 8431 2069,http://www.neuwirt-neuburg.de,11.1812,48.72699
+295bfd97-20cc-4b4a-932a-fbc146067a2f,Jura-Bräu,brewpub,Am Buchauer Berg 8,,,Pegnitz,Bayern,91257,Germany,+49 9241 2019,http://www.jura-braeu.de,11.5429,49.758585
+5c27d4f5-03e1-4afc-aec6-bf3a20bb6284,Kaiser-Bräu,brewpub,Oberer Markt 1,,,Neuhaus an der Pegnitz,Bayern,91284,Germany,+49 9156 880,http://www.kaiser-braeu.de,11.5495378,49.6281413
+2854d9f1-6c5b-46a1-b169-472015ec9eeb,Kaiserdom,brewpub,Breitäckerstraße 9,,,Bamberg,Bayern,96049,Germany,+49 951 60450,http://www.kaiserdom.de,10.85236,49.90425
+fe7b8c83-cc23-41ea-9fbf-993d278979a6,Kaiserhof,brewpub,Friesener Straße 1,,,Kronach,Bayern,96317,Germany,+49 9261 628000,http://www.kaiserhofbraeu.de,11.327765,50.241246
+b4924c5f-3213-4565-a50e-34cd6d2b2e6f,Kaltentaler Brauhaus,brewpub,Blonhofener Straße 12,,,Kaltental,Bayern,87662,Germany,+49 8345 1565,http://www.kaltentaler-brauhaus.de,10.75334,47.91126999999999
+a225ae70-e1cc-49c1-b22d-43706af9cded,Kalvarienbergbräu,brewpub,Hafnerweg 3,,,Marklkofen,Bayern,84163,Germany,+49 1512 2907482,http://www.facebook.com/kalvarienbergbraeu,12.547864,48.5676964
+be3b6cbf-6b8e-480d-8fc2-70bf1e3734b3,Kanone,brewpub,Brückenstraße 1a,,,Schnaittach,Bayern,91220,Germany,+49 9153 366,http://www.brauerei-kanone.de,11.3385956,49.5714005
+53b98572-b064-4043-a485-91d17db3d098,Kapplerbräu,brewpub,Nerbstraße 8,,,Altomünster,Bayern,85250,Germany,+49 8254 777,http://www.kapplerbraeu.de,11.25766,48.38724
+5dc48a5d-01eb-4826-be59-c5c357e6e09c,Karg,brewpub,Untermarkt 27,,,Murnau am Staffelsee,Bayern,82418,Germany,+49 8841 1268,http://www.brauerei-karg.de,11.2016458,47.6767159
+00e1b34e-1082-411b-808e-51d85bff935e,Karmeliten,brewpub,Senefelderstraße 21,,,Straubing,Bayern,94315,Germany,+49 9421 78190,http://www.karmeliten-brauerei.de,12.62189,48.88795
+8ed2d985-a269-4f56-b324-215c044ee948,Karmeliter-Bräu,closed,Ludwig-Elsbett-Straße 7,,,Salz,Bayern,97616,Germany,+49 9771 1323,http://www.karmeliter-braeu.de,10.1919788,50.2960498
+79037d41-38b6-4ef2-b361-04efe0e222fa,Kathi-Bräu,brewpub,Heckenhof 1,,,Aufseß,Bayern,91347,Germany,+49 9198 277,https://www.kathibraeu.de/,11.2447417,49.8793306
+e70e01df-5cdf-458a-9dc5-6df9e42146af,Katzerer,brewpub,Sondersfeld 2,,,Freystadt,Bayern,92342,Germany,+49 9185 903813,http://www.sondersfeld.de/katzerer.htm,11.3884519,49.2151607
+22b413fe-a9af-4f5e-a26f-5bfb9b656682,Kauzen,brewpub,Uffenheimer Straße 17,,,Ochsenfurt,Bayern,97199,Germany,+49 9331 87250,http://www.kauzen.de,10.0711964,49.659691
+c96f2cb2-4aca-4a96-b032-d8dce77f52b0,Ke,brewpub,Alfred-Stumpf-Straße 2,,,Lohr am Main,Bayern,97816,Germany,+49 9352 7328,http://www.keiler-brauhaus.de,9.571358199999999,49.9947533
+8c8bd0ad-fcc8-47ac-89a1-c71a8245f3a0,Keesmann,brewpub,Wunderburg 5,,,Bamberg,Bayern,96050,Germany,+49 951 981980,http://www.keesmann-braeu.de,10.9056038,49.8904222
+f52d8c62-2f5a-4dca-9e90-b5a4e36c3deb,KellerBräu Dorfen,brewpub,Jahnstraße 2,,,Dorfen,Bayern,84405,Germany,+49 8081 8143,https://www.instagram.com/kellerbraeu_dorfen/,12.1517057,48.2757604
+29f70ef7-ca88-4183-9f3c-45771f57ff2e,Kellerbrauerei Prittlbach,brewpub,Angerstraße 6,,,Hebertshausen,Bayern,85241,Germany,+49 8131 338448,http://www.kellerbrauerei-prittlbach.de,11.44477,48.2865
+7b346fe5-6b3d-4a35-b562-c3b77db9391f,Kesselbräu,brewpub,Leithenbukweg 13,,,Marktsteft,Bayern,97342,Germany,+49 9332 50630,https://www.kesselring-bier.de/,10.1376365,49.6994147
+f16be512-5f4d-4c98-b568-c4be9b2ff34c,Kesselring,brewpub,Leithenbukweg 13,,,Marktsteft,Bayern,97342,Germany,+49 9332 50630,http://www.kesselring-bier.de,10.1376365,49.6994147
+9f608762-2758-4ca4-b6d7-da8b45ec9259,Kini Bier,brewpub,Deutschenbaurstraße 34,,,Augsburg,Bayern,86157,Germany,+49 821 524255,http://www.kini.beer,10.8687582,48.3688732
+596fa47f-2072-4c7d-8892-23c0f43ce3da,Kirnachstuben,brewpub,Hauptstraße 38,,,Ruderatshofen,Bayern,87674,Germany,+49 8343 340,http://www.kirnachstuben.de,10.58466,47.81804
+0102aec0-8de7-4e68-99f5-5ef3fc798541,Kleinbrauerei Rain,bar,Hauptstraße 52,,,Rain,Bayern,86641,Germany,,http://www.kleinbrauerei-rain.de,10.9156483,48.690323
+c9bdae9c-fda2-4e74-b2b0-b757a00a0145,Kleines Brauhaus,brewpub,Senefelderstraße 21,,,Straubing,Bayern,94315,Germany,+49 9421 78190,https://www.karmeliten-brauerei.de/,12.62189,48.88795
+cfe647e7-92b2-447d-a602-db72b29a3962,Kleines Pleinfelder Brauhaus,brewpub,Egloffsteiner Straße 19,,,Pretzfeld,Bayern,91362,Germany,+49 9194 725025,http://www.landhotel-sonnenhof.de,11.1756891,49.7559717
+5a5035a5-3d55-476c-a0da-bf6fe6989098,Klett-Bräu,brewpub,Johann-Dachauer-Straße 8,,,Konzell,Bayern,94357,Germany,+49 9963 805,http://www.bier.by/brauerei-guide/klett-brau-1.3495815,12.7130995,49.0723503
+f779ee97-4d52-4792-a27d-7f916c8be618,Klier Bräu,brewpub,Reuteweg 23a,,,Blaichach,Bayern,87544,Germany,+49 8321 608657,http://www.klier-bier.de,10.2490773,47.5420542
+ff726816-c4ce-4900-93b7-1d18030e301d,Klingenbrunn,brewpub,Frauenauer Straße 15,,,Spiegelau,Bayern,94518,Germany,+49 8553 6018,,13.32121,48.9204
+664949a1-0815-420b-b46d-dba796abc00c,Klosterbräu,brewpub,Obere Mühlbrücke 1-3,,,Bamberg,Bayern,96049,Germany,+49 951 52265,http://www.klosterbraeu.de,10.887197,49.889257
+478a5b5d-3c9c-4128-987c-fb14fa00e107,Klosterbrauerei,brewpub,Kaiser-Ludwig-Platz 1,,,Ettal,Bayern,82488,Germany,+49 8822 746450,http://www.ettaler.info,11.0948932,47.5702104
+736c96a2-9c53-42a2-80de-fc88a3270602,Klosterbrauerei Andechs,brewpub,Bergstraße 2,,,Andechs,Bayern,82346,Germany,+49 8152 3760,http://www.andechs.de,11.1850171,47.9762819
+edae5392-6ee7-40ba-850e-0b049d29bc27,Klosterbrauerei Dietl,brewpub,Baumburg 20,,,Altenmarkt an der Alz,Bayern,83352,Germany,+49 8621 98260,http://www.baumburger.de,12.5311766,47.998781
+f5e94eb7-4b3d-4f42-85ea-b8335889df1a,Klosterbräuhaus,brewpub,Dominikus-Ringeisen-Straße 2,,,Ursberg,Bayern,86513,Germany,+49 8281 99890,http://www.klosterbraeuhaus.de,10.4451218,48.26554489999999
+7bd12803-6b5d-418c-9243-6c46921c0cf6,Kneitinger,brewpub,Arnulfsplatz 3,,,Regensburg,Bayern,93047,Germany,+49 941 52455,http://www.kneitinger.de,12.0890713,49.0197079
+e0a2a6c4-3c7f-436e-a532-642674fcfb41,Knoblach,brewpub,Kremmeldorfer Straße 1,,,Litzendorf,Bayern,96123,Germany,+49 9505 267,http://www.brauerei-knoblach.de,11.0061771,49.9261067
+60310902-998f-4c6b-88b4-983a7b392900,Kohlenmühle,brewpub,Bamberger Straße 53,,,Neustadt an der Aisch,Bayern,91413,Germany,+49 9161 662270,http://www.kohlenmuehle.de,10.6145628,49.5839028
+75956613-ee66-495a-8c93-8de2ed7fa722,Kolb,brewpub,Illertisser Straße 24,,,Roggenburg,Bayern,89297,Germany,+49 7300 301,http://www.brauerei-kolb.de,10.2208057,48.2653822
+51d97425-2e9e-4545-81b6-99c810b280ad,Kommunbräu,brewpub,Grünwehr 17,,,Kulmbach,Bayern,95326,Germany,+49 9221 84490,http://www.kommunbraeu.de,11.4653096,50.11075899999999
+6dd9b403-f0fa-4854-9247-a9c8809217de,Kommunbräu Rehau,micro,Fabrikstraße 1,,,Rehau,Bayern,95111,Germany,,http://www..kommunbraeu-rehau.de,12.0355156,50.2497598
+6727090e-8476-4b82-a83a-f1a9b2426e7e,Kommunbrauerei,brewpub,Vorstadt 13,,,Mitterteich,Bayern,95666,Germany,,http://www.mitterteich.de/home/einrichtungen/verteiler_1/verteiler_5/verteiler_5.htm,12.2408871,49.9499268
+5a7fd707-4e34-4f55-b464-1078c06f3302,Kommunbrauhaus,brewpub,Maximiliansplatz 105,,,Seßlach,Bayern,96145,Germany,+49 9569 452,http://www.gasthof-reinwand.de/brauhaus.htm,10.8415585,50.1877035
+63995c47-27eb-4ec8-ad49-21324c2040c9,König Ludwig Br. Holzkirchen,brewpub,Augsburger Straße 41,,,Fürstenfeldbruck,Bayern,82256,Germany,+49 8141 2430,http://www.oberbraeu-holzkirchen.de,11.251905,48.1828857
+c5195e07-5f1b-4b08-b676-af33c4f80e88,König von Flandern,brewpub,Maximilianstraße 25,,,Augsburg,Bayern,86150,Germany,+49 821 20709818,http://www.koenigvonflandern.de,10.8985536,48.36745730000001
+00157704-9821-43e7-9ed9-7fbe58f040f6,Kössel-Bräu,brewpub,Mariahilfer Straße 17,,,Eisenberg,Bayern,87637,Germany,+49 8364 8556,http://www.koessel-braeu.de,10.6128103,47.6103922
+dd2b8448-8b93-4ca3-bb10-ee3fd9c48ec2,Kraus,brewpub,Luitpoldstraße 11,,,Hirschaid,Bayern,96114,Germany,+49 9543 84440,http://www.brauerei-kraus.de,10.987145,49.8158179
 13a9865e-335a-4a3d-a23d-acc4547e44fb,Kreisheimatstube,micro,Schwaninger-Straße 18,,,Ellzee,Bayern,89352,Germany,,,10.2945984,48.3164598
-0da08afd-c3f2-4812-a421-7694b66ef1b1,Krieger,brewpub,6 Oberer Stadtplatz,,,Landau an der Isar,Bayern,94405,Germany,+49 9951 6049144,http://www.brauerei-krieger.de,12.6908333,48.6697222
-bf09f033-65db-4428-a3ce-fd84bf7aad38,Kronburger,brewpub,21 Hauptstraße,,,Kronburg,Bayern,87758,Germany,+49 8394 237,http://www.brauerei-kronburg.de,10.15767,47.90434
-b8c30da4-fe68-4063-9a9a-8ae9f9274032,Kronprinz,brewpub,109 Gaustadter Hauptstraße,,,Bamberg,Bayern,96049,Germany,+49 951 96430514,http://www.kronprinz.beer,10.8649128,49.9026341
-cb21d89c-6aac-4534-b905-ab2250550efb,Krug-Bräu,brewpub,1 Breitenlesau,,,Waischenfeld,Bayern,91344,Germany,+49 9202 835,http://www.krug-braeu.de,11.2918161,49.86180479999999
-0f4d3c35-fe1e-4112-b3b0-68567627c721,Kuchlbauer,brewpub,5 - 9 Römerstraße,,,Abensberg,Bayern,93326,Germany,+49 9443 91010,http://www.kuchlbauer.de,11.84277,48.81684
-b0120898-a489-42e1-b22b-b7abab8fdd61,Kühbacher,brewpub,2 Großhausener Straße,,,Kühbach,Bayern,86556,Germany,+49 8251 89660,http://www.brauereikuehbach.de,11.1827919,48.4914609
-98631295-561e-47f4-a184-82a5d31b3845,Kulmbacher,brewpub,1 EKU-Straße,,,Kulmbach,Bayern,95326,Germany,+49 9221 7050,http://www.kulmbacher.de,11.4446048,50.1091194
-c7ba16ba-03e4-4dd0-8d9f-9558643eaf55,Kummert,brewpub,11 Raigeringer Straße,,,Amberg,Bayern,92224,Germany,+49 9621 15259,http://www.zumkummertbraeu.de,11.8731036,49.4442215
-e58762d2-72fc-4b11-9375-ab3c39bd6302,Kundmüller,brewpub,13 Weiher,,,Viereth-Trunstadt,Bayern,96191,Germany,+49 9503 4338,http://www.kundmueller.de,10.7517576,49.91301259999999
-e4038ffb-a1dc-4cd2-8876-65c3037d82d9,Kürzdörfer,brewpub,8 Brauhausgasse,,,Creußen,Bayern,95473,Germany,+49 160 91978835,http://www.brauerei-kuerzdoerfer.de,11.534404,49.8301649
-d1fc0ee6-fb08-4093-a674-d216e6a9529e,Lampl-Bräu,micro,2 Elsenheimerstraße,,,Wolnzach,Bayern,85283,Germany,+49 8442 7574,http://www.hopfenmuseum.de/,11.6277754,48.6040692
-6ee22be0-e70e-4394-b4fb-20b8d3f988b1,Landgasthof Hubertus,brewpub,2 Wenglinger Straße,,,Ruderatshofen,Bayern,87674,Germany,+49 8341 81976,http://www.apfeltranger-bier.de,10.5893173,47.8383544
-3c5db192-cd49-405c-aa5f-9b10f0050062,Landhausbräu Koller,brewpub,5 Hergertswiesen,,,Eurasburg,Bayern,86495,Germany,+49 8208 225,http://landhausbraeu-koller.de,11.117172,48.330994
-f9e9ee97-18e8-4ed9-a964-40a5a2af965e,Landshuter Brauhaus,brewpub,60 Opalstraße,,,Altdorf,Bayern,84032,Germany,+49 871 9239428,http://www.landshuter-brauhaus.de,12.0866409,48.5437579
-2ec1c955-396c-43f4-92e9-0cac92339b8d,Landwehr-Bräu,brewpub,31 Reichelshofen,,,Steinsfeld,Bayern,91628,Germany,+49 9865 9890,http://www.landwehr-braeu.de,10.21264,49.4400059
-97832eaa-ae4b-40bc-bba9-fb0d2b1615f0,Lang,brewpub,17 Hauptstraße,,,Jandelsbrunn,Bayern,94118,Germany,+49 8583 608880,http://www.jandelsbrunner.de,13.6900581,48.7304973
-2b25f54e-713a-454a-9a50-84e77fb13230,Lang-Bräu,brewpub,2 Langgasse,,,Freyung,Bayern,94078,Germany,+49 8551 57760,http://www.lang-braeu-freyung.de,13.5485892,48.80873560000001
-d4fec385-ddc0-4e1b-9baa-e23949375a92,Laufener Braukuchl,brewpub,2 Schloßplatz,,,Laufen,Bayern,83410,Germany,+49 178 8198232,http://www.braukuchl.at,12.9366478,47.9382076
-e995e042-cd1f-4fc4-b766-e874b89da75a,Lausbiggl Bräu,closed,70 Kleinhohenried,,,Karlshuld,Bayern,86668,Germany,+49 8454 962279,http://www.lausbiggl-braeu.de,11.3296376,48.66970629999999
-ee9bfdee-8bd5-4d5a-a387-cd817b0feb70,Leicht,closed,1 Pferdsfeld,,,Ebensfeld,Bayern,96250,Germany,,,10.9914904,50.0800473
-e3c935ad-7e88-41e2-b536-7d7636bf40af,Leidmann,brewpub,1 Bräustraße,,,Unterneukirchen,Bayern,84579,Germany,+49 8634 8087,http://www.brauerei-leidmann.de/,12.6188731,48.1627027
-fbfc8208-8406-4396-84b9-cadb550fbb67,Leikeim,brewpub,4 Gewerbegebiet,,,Altenkunstadt,Bayern,96264,Germany,+49 9572 75050,http://www.leikeim.info,11.2377195,50.1244964
-ddfd8974-6a37-4acd-8579-1a9bb81f23bc,Libertus Craft Brewing,micro,11 Brückenauer Straße,,,Hammelburg,Bayern,97762,Germany,+49 9732 780099,http://www.libertus.beer,9.8785101,50.14678019999999
-bd43b54b-1335-4296-9334-97bf5f49098c,Lieberth,brewpub,2 Forchheimer Straße,,,Hallerndorf,Bayern,91352,Germany,+49 9545 8558,https://www.bierland-franken.de/brauereien/brauerei-lieberth/,10.9821338,49.7590635
-c18c6e72-932a-47ad-8d4f-ac7b4a7c3866,Lindenbrauerei,brewpub,21 Memminger Straße,,,Mindelheim,Bayern,87719,Germany,+49 8261 1402,http://www.lindenbrauerei-mindelheim.de/,10.4795992,48.045184
-f06e3715-61ab-4342-9045-e12d203eb8b9,Lindner-Bräu,brewpub,4 Weißenregener Straße,,,Bad Kötzting,Bayern,93444,Germany,+49 9941 1429,http://www.lindner-bier.de,12.8561031,49.1707375
-13afc034-49a2-4e7e-8a38-7c2e4ec2c28b,Lindwurm Bräu,brewpub,38 Frauentorstraße,,,Augsburg,Bayern,86152,Germany,+49 821 2970718,http://www.lindwurmbraeu.de,10.8954085,48.37616939999999
-059ac5d1-5cc3-410c-ada0-31163c0f89b3,Loscher,brewpub,21-23 Steigerwaldstraße,,,Münchsteinach,Bayern,91481,Germany,+49 9166 607,http://www.brauerei-loscher.de,10.5923185,49.64103309999999
-e084562e-7948-440e-9982-27133334eb40,Löwenbräu,brewpub,7 Nymphenburger Straße,,,München,Bayern,80335,Germany,+49 800 52205203,http://www.loewenbraeu.de,11.5564377,48.1474919
-385e11bd-985c-478e-b466-f491a6b25535,Mager,brewpub,17 Hauptstraße,,,Pottenstein,Bayern,91278,Germany,+49 9243 333,http://www.brauerei-mager.de,11.4084087,49.7709936
-22e8a009-0692-4e89-8648-2d31d6a49fcc,Mahr's Bräu,brewpub,10 Wunderburg,,,Bamberg,Bayern,96050,Germany,+49 951 915170,http://www.mahrs.de,10.9064529,49.8900301
-9b69fed6-0942-4d56-9482-2c1607192d71,Maierbier,brewpub,9 Industriestraße,,,Nördlingen,Bayern,86720,Germany,+49 9081 6041246,http://www.maierbier.com,10.5073701,48.86273
-23730613-dd42-4d0c-921e-702c68793421,Maierbräu,brewpub,2 Marktplatz,,,Altomünster,Bayern,85250,Germany,+49 8254 1279,http://www.maierbraeu.de,11.2559713,48.3875096
-bb04e665-c9d9-4517-8ca9-1542d3ad1919,Main BräuWerk,brewpub,1 Andreas-Maisel-Weg,,,Bayreuth,Bayern,95445,Germany,+49 921 401234,http://www.wfbm-burgkunstadt.de,11.5670627,49.9455328
-b96cc561-ea32-4b72-9bc1-6c2e633306ce,Mainlust,brewpub,9 Hauptstraße,,,Viereth-Trunstadt,Bayern,96191,Germany,+49 9503 7444,http://www.mainlust.com,10.7784643,49.9233862
-9dc63df3-3d9e-4d08-8003-841ba73b82b1,Maisach,brewpub,24 Hauptstraße,,,Maisach,Bayern,82216,Germany,+49 8141 395570,http://www.brauerei-maisach.de,11.2635393,48.2169755
-52423022-448d-4fe2-aaee-aff41740b20a,Maisel,brewpub,9 Hindenburgstraße,,,Bayreuth,Bayern,95445,Germany,+49 921 4010,http://www.maisel.com,11.56588,49.94773000000001
-91b6300b-f5f7-42fc-bf07-7efb19f4369f,Malerbräu,brewpub,9a Kirchstraße,,,Schwarzach bei Nabburg,Bayern,92548,Germany,,https://malerfinder.de/schwarzach-bei-nabburg/7143-malerbraeu,12.1661943,49.4087391
-3e1f1db5-c70d-45d1-925a-398f792cd107,Mangfallbräu,closed,124 Sudetenstraße,,,Bruckmühl,Bayern,83052,Germany,+49 160 91796721,http://www.mangfallbraeu.de,11.9360283,47.8724678
-b88473e1-a679-440a-b496-ff8076fd105e,Mariensteiner Brauhaus,brewpub,10 Paul-Deuringer-Weg,,,Waakirchen,Bayern,83666,Germany,+49 8021 5042783,http://www.mariensteiner-brauhaus.de,11.6838707,47.751508
-8114770d-71df-44b4-aecd-9caf02cc1492,Märkl,micro,16 Hauptstraße,,,Freudenberg,Bayern,92272,Germany,+49 9627 260,http://www.freudenberger-bier.de,11.9782006,49.4787662
-8c1ef771-cb6a-401e-863d-cc8d9da53e40,Martin,brewpub,1 Zur Brauerei,,,Ebensfeld,Bayern,96250,Germany,+49 9573 1899,http://www.gasthof-martin-unterneuses.de,10.9749772,50.0814773
-082496ba-19ea-49d9-91b6-29f612cb75ae,Martinsbräu,brewpub,4 Georg-Mayr-Straße,,,Marktheidenfeld,Bayern,97828,Germany,+49 9391 50080,http://www.martinsbraeu.de,9.6010046,49.848793
-1446f9a6-b2fc-4fe1-9259-ffdefbb6ea45,Maxbrauerei,closed,14 St.-Lorenz-Straße,,,Altenstadt,Bayern,86972,Germany,+49 160 8258198,http://www.maxbrauerei.de,10.874761,47.82583700000001
-8edaf3b0-b8e3-4216-8449-35f09f8db0f8,Meckatzer Löwenbräu,brewpub,10 Meckatz,,,Heimenkirch,Bayern,88178,Germany,+49 8381 5040,http://www.meckatzer.de,9.8884815,47.6308829
-42d3affa-b790-480b-a21b-aa2c1b70ccfd,Meinel-Bräu,brewpub,1 Absolviagasse,,,Hof,Bayern,95028,Germany,+49 9281 3514,http://www.meinel-braeu.de,11.9171736,50.3262089
-af25f977-940a-4351-b385-f84964b95bba,Meister,brewpub,8 Unterzaunsbach,,,Pretzfeld,Bayern,91362,Germany,+49 9194 9126,http://www.meisterbräu.de,11.223108,49.737739
-23f3d01b-947d-4728-a054-5287e89dc43f,Memminger,closed,68 Dr.Karl Lenz Straße,,,Memmingen,Bayern,87700,Germany,+49 8331 85660,http://www.memminger-brauerei.de,10.1685041,47.99612279999999
-beef0311-8b83-4f33-9a57-09999649b0f1,Metzgerbräu Reichert,brewpub,2 Stublanger Straße,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 6304,http://www.metzgerbraeu.com,11.0683965,50.0859585
-58739cde-5655-4962-9ae9-2276c2329b59,Meusel-Bräu,brewpub,27 Dreuschendorf,,,Buttenheim,Bayern,96155,Germany,+49 9545 7424,,11.0588964,49.808165
-463de2b2-9afb-4f9b-abfc-9aae38da09d2,Michlbräu,brewpub,52 Wiggensbacher Straße,,,Kempten (Allgäu),Bayern,87439,Germany,+49 831 51210210,http://www.frischesbiermichlbier.de,10.29041,47.75384
-bcad5d55-e688-4b20-9b71-a4f7a4cb87ef,Mittenwald,brewpub,13 Innsbrucker Straße,,,Mittenwald,Bayern,82481,Germany,+49 8823 1007,http://www.brauerei-mittenwald.de,11.2601147,47.4367467
-22127ebd-b769-4784-aaf9-2bb9659b45e2,Mr Kennedy,closed,22 Brunnengäßchen,,,Nürnberg,Bayern,90403,Germany,,http://www.mr-kennedy.de,11.0784656,49.4568006
-47c2ab8c-5596-47cd-9d48-78f3c9553b47,Mühlbauer,brewpub,10 Further Straße,,,Arnschwang,Bayern,93473,Germany,+49 9977 221,http://www.brauerei-muehlbauer.de,12.8174717,49.27444759999999
-4bcf1c93-b875-458f-ad49-0c360b11b4df,Mühlenbräu,brewpub,7 Neukreuthstraße,,,Stegaurach,Bayern,96135,Germany,+49 951 29119,https://www.facebook.com/profile.php?id=100057388782239,10.8115141,49.868087
-bab683cb-3856-4364-a168-6a86e6ab3301,Müller,brewpub,1 Würzburger Straße,,,Stegaurach,Bayern,96135,Germany,+49 951 29191,http://www.debringer-bier.de,10.85744,49.85779
-55b7d8fb-ddb2-42db-af71-85c0b8733ae4,Müller-Bräu,brewpub,2 Hauptplatz,,,Pfaffenhofen an der Ilm,Bayern,85276,Germany,+49 8441 4009110,http://www.schmausenkeller.de,11.5088026,48.529943
-15cffc5a-cd12-4a9c-b0f3-2d7faf727dc9,Müllerbräu,brewpub,2 Burghauser Straße,,,Neuötting,Bayern,84524,Germany,+49 8671 2332,http://www.muellerbraeu.de,12.6909796,48.2400172
-36246ecd-2af3-44fb-b1b3-c802b6dd1e6e,Murmann,brewpub,6 Coburger Straße,,,Untersiemau,Bayern,96253,Germany,+49 9565 811,http://www.brauerei-murmann.de,10.9726705,50.1944248
-cf6b21d5-1bc9-46fe-8849-4cb5566afc88,Museumsbrauerei,micro,20 Hofer Straße,,,Kulmbach,Bayern,95326,Germany,+49 9221 80514,http://www.brauerei-vielau.com,11.4697406,50.114645
+0da08afd-c3f2-4812-a421-7694b66ef1b1,Krieger,brewpub,Oberer Stadtplatz 6,,,Landau an der Isar,Bayern,94405,Germany,+49 9951 6049144,http://www.brauerei-krieger.de,12.6908333,48.6697222
+bf09f033-65db-4428-a3ce-fd84bf7aad38,Kronburger,brewpub,Hauptstraße 21,,,Kronburg,Bayern,87758,Germany,+49 8394 237,http://www.brauerei-kronburg.de,10.15767,47.90434
+b8c30da4-fe68-4063-9a9a-8ae9f9274032,Kronprinz,brewpub,Gaustadter Hauptstraße 109,,,Bamberg,Bayern,96049,Germany,+49 951 96430514,http://www.kronprinz.beer,10.8649128,49.9026341
+cb21d89c-6aac-4534-b905-ab2250550efb,Krug-Bräu,brewpub,Breitenlesau 1,,,Waischenfeld,Bayern,91344,Germany,+49 9202 835,http://www.krug-braeu.de,11.2918161,49.86180479999999
+0f4d3c35-fe1e-4112-b3b0-68567627c721,Kuchlbauer,brewpub,- 9 Römerstraße 5,,,Abensberg,Bayern,93326,Germany,+49 9443 91010,http://www.kuchlbauer.de,11.84277,48.81684
+b0120898-a489-42e1-b22b-b7abab8fdd61,Kühbacher,brewpub,Großhausener Straße 2,,,Kühbach,Bayern,86556,Germany,+49 8251 89660,http://www.brauereikuehbach.de,11.1827919,48.4914609
+98631295-561e-47f4-a184-82a5d31b3845,Kulmbacher,brewpub,EKU-Straße 1,,,Kulmbach,Bayern,95326,Germany,+49 9221 7050,http://www.kulmbacher.de,11.4446048,50.1091194
+c7ba16ba-03e4-4dd0-8d9f-9558643eaf55,Kummert,brewpub,Raigeringer Straße 11,,,Amberg,Bayern,92224,Germany,+49 9621 15259,http://www.zumkummertbraeu.de,11.8731036,49.4442215
+e58762d2-72fc-4b11-9375-ab3c39bd6302,Kundmüller,brewpub,Weiher 13,,,Viereth-Trunstadt,Bayern,96191,Germany,+49 9503 4338,http://www.kundmueller.de,10.7517576,49.91301259999999
+e4038ffb-a1dc-4cd2-8876-65c3037d82d9,Kürzdörfer,brewpub,Brauhausgasse 8,,,Creußen,Bayern,95473,Germany,+49 160 91978835,http://www.brauerei-kuerzdoerfer.de,11.534404,49.8301649
+d1fc0ee6-fb08-4093-a674-d216e6a9529e,Lampl-Bräu,micro,Elsenheimerstraße 2,,,Wolnzach,Bayern,85283,Germany,+49 8442 7574,http://www.hopfenmuseum.de/,11.6277754,48.6040692
+6ee22be0-e70e-4394-b4fb-20b8d3f988b1,Landgasthof Hubertus,brewpub,Wenglinger Straße 2,,,Ruderatshofen,Bayern,87674,Germany,+49 8341 81976,http://www.apfeltranger-bier.de,10.5893173,47.8383544
+3c5db192-cd49-405c-aa5f-9b10f0050062,Landhausbräu Koller,brewpub,Hergertswiesen 5,,,Eurasburg,Bayern,86495,Germany,+49 8208 225,http://landhausbraeu-koller.de,11.117172,48.330994
+f9e9ee97-18e8-4ed9-a964-40a5a2af965e,Landshuter Brauhaus,brewpub,Opalstraße 60,,,Altdorf,Bayern,84032,Germany,+49 871 9239428,http://www.landshuter-brauhaus.de,12.0866409,48.5437579
+2ec1c955-396c-43f4-92e9-0cac92339b8d,Landwehr-Bräu,brewpub,Reichelshofen 31,,,Steinsfeld,Bayern,91628,Germany,+49 9865 9890,http://www.landwehr-braeu.de,10.21264,49.4400059
+97832eaa-ae4b-40bc-bba9-fb0d2b1615f0,Lang,brewpub,Hauptstraße 17,,,Jandelsbrunn,Bayern,94118,Germany,+49 8583 608880,http://www.jandelsbrunner.de,13.6900581,48.7304973
+2b25f54e-713a-454a-9a50-84e77fb13230,Lang-Bräu,brewpub,Langgasse 2,,,Freyung,Bayern,94078,Germany,+49 8551 57760,http://www.lang-braeu-freyung.de,13.5485892,48.80873560000001
+d4fec385-ddc0-4e1b-9baa-e23949375a92,Laufener Braukuchl,brewpub,Schloßplatz 2,,,Laufen,Bayern,83410,Germany,+49 178 8198232,http://www.braukuchl.at,12.9366478,47.9382076
+e995e042-cd1f-4fc4-b766-e874b89da75a,Lausbiggl Bräu,closed,Kleinhohenried 70,,,Karlshuld,Bayern,86668,Germany,+49 8454 962279,http://www.lausbiggl-braeu.de,11.3296376,48.66970629999999
+ee9bfdee-8bd5-4d5a-a387-cd817b0feb70,Leicht,closed,Pferdsfeld 1,,,Ebensfeld,Bayern,96250,Germany,,,10.9914904,50.0800473
+e3c935ad-7e88-41e2-b536-7d7636bf40af,Leidmann,brewpub,Bräustraße 1,,,Unterneukirchen,Bayern,84579,Germany,+49 8634 8087,http://www.brauerei-leidmann.de/,12.6188731,48.1627027
+fbfc8208-8406-4396-84b9-cadb550fbb67,Leikeim,brewpub,Gewerbegebiet 4,,,Altenkunstadt,Bayern,96264,Germany,+49 9572 75050,http://www.leikeim.info,11.2377195,50.1244964
+ddfd8974-6a37-4acd-8579-1a9bb81f23bc,Libertus Craft Brewing,micro,Brückenauer Straße 11,,,Hammelburg,Bayern,97762,Germany,+49 9732 780099,http://www.libertus.beer,9.8785101,50.14678019999999
+bd43b54b-1335-4296-9334-97bf5f49098c,Lieberth,brewpub,Forchheimer Straße 2,,,Hallerndorf,Bayern,91352,Germany,+49 9545 8558,https://www.bierland-franken.de/brauereien/brauerei-lieberth/,10.9821338,49.7590635
+c18c6e72-932a-47ad-8d4f-ac7b4a7c3866,Lindenbrauerei,brewpub,Memminger Straße 21,,,Mindelheim,Bayern,87719,Germany,+49 8261 1402,http://www.lindenbrauerei-mindelheim.de/,10.4795992,48.045184
+f06e3715-61ab-4342-9045-e12d203eb8b9,Lindner-Bräu,brewpub,Weißenregener Straße 4,,,Bad Kötzting,Bayern,93444,Germany,+49 9941 1429,http://www.lindner-bier.de,12.8561031,49.1707375
+13afc034-49a2-4e7e-8a38-7c2e4ec2c28b,Lindwurm Bräu,brewpub,Frauentorstraße 38,,,Augsburg,Bayern,86152,Germany,+49 821 2970718,http://www.lindwurmbraeu.de,10.8954085,48.37616939999999
+059ac5d1-5cc3-410c-ada0-31163c0f89b3,Loscher,brewpub,Steigerwaldstraße 21-23,,,Münchsteinach,Bayern,91481,Germany,+49 9166 607,http://www.brauerei-loscher.de,10.5923185,49.64103309999999
+e084562e-7948-440e-9982-27133334eb40,Löwenbräu,brewpub,Nymphenburger Straße 7,,,München,Bayern,80335,Germany,+49 800 52205203,http://www.loewenbraeu.de,11.5564377,48.1474919
+385e11bd-985c-478e-b466-f491a6b25535,Mager,brewpub,Hauptstraße 17,,,Pottenstein,Bayern,91278,Germany,+49 9243 333,http://www.brauerei-mager.de,11.4084087,49.7709936
+22e8a009-0692-4e89-8648-2d31d6a49fcc,Mahr's Bräu,brewpub,Wunderburg 10,,,Bamberg,Bayern,96050,Germany,+49 951 915170,http://www.mahrs.de,10.9064529,49.8900301
+9b69fed6-0942-4d56-9482-2c1607192d71,Maierbier,brewpub,Industriestraße 9,,,Nördlingen,Bayern,86720,Germany,+49 9081 6041246,http://www.maierbier.com,10.5073701,48.86273
+23730613-dd42-4d0c-921e-702c68793421,Maierbräu,brewpub,Marktplatz 2,,,Altomünster,Bayern,85250,Germany,+49 8254 1279,http://www.maierbraeu.de,11.2559713,48.3875096
+bb04e665-c9d9-4517-8ca9-1542d3ad1919,Main BräuWerk,brewpub,Andreas-Maisel-Weg 1,,,Bayreuth,Bayern,95445,Germany,+49 921 401234,http://www.wfbm-burgkunstadt.de,11.5670627,49.9455328
+b96cc561-ea32-4b72-9bc1-6c2e633306ce,Mainlust,brewpub,Hauptstraße 9,,,Viereth-Trunstadt,Bayern,96191,Germany,+49 9503 7444,http://www.mainlust.com,10.7784643,49.9233862
+9dc63df3-3d9e-4d08-8003-841ba73b82b1,Maisach,brewpub,Hauptstraße 24,,,Maisach,Bayern,82216,Germany,+49 8141 395570,http://www.brauerei-maisach.de,11.2635393,48.2169755
+52423022-448d-4fe2-aaee-aff41740b20a,Maisel,brewpub,Hindenburgstraße 9,,,Bayreuth,Bayern,95445,Germany,+49 921 4010,http://www.maisel.com,11.56588,49.94773000000001
+91b6300b-f5f7-42fc-bf07-7efb19f4369f,Malerbräu,brewpub,Kirchstraße 9a,,,Schwarzach bei Nabburg,Bayern,92548,Germany,,https://malerfinder.de/schwarzach-bei-nabburg/7143-malerbraeu,12.1661943,49.4087391
+3e1f1db5-c70d-45d1-925a-398f792cd107,Mangfallbräu,closed,Sudetenstraße 124,,,Bruckmühl,Bayern,83052,Germany,+49 160 91796721,http://www.mangfallbraeu.de,11.9360283,47.8724678
+b88473e1-a679-440a-b496-ff8076fd105e,Mariensteiner Brauhaus,brewpub,Paul-Deuringer-Weg 10,,,Waakirchen,Bayern,83666,Germany,+49 8021 5042783,http://www.mariensteiner-brauhaus.de,11.6838707,47.751508
+8114770d-71df-44b4-aecd-9caf02cc1492,Märkl,micro,Hauptstraße 16,,,Freudenberg,Bayern,92272,Germany,+49 9627 260,http://www.freudenberger-bier.de,11.9782006,49.4787662
+8c1ef771-cb6a-401e-863d-cc8d9da53e40,Martin,brewpub,Zur Brauerei 1,,,Ebensfeld,Bayern,96250,Germany,+49 9573 1899,http://www.gasthof-martin-unterneuses.de,10.9749772,50.0814773
+082496ba-19ea-49d9-91b6-29f612cb75ae,Martinsbräu,brewpub,Georg-Mayr-Straße 4,,,Marktheidenfeld,Bayern,97828,Germany,+49 9391 50080,http://www.martinsbraeu.de,9.6010046,49.848793
+1446f9a6-b2fc-4fe1-9259-ffdefbb6ea45,Maxbrauerei,closed,St.-Lorenz-Straße 14,,,Altenstadt,Bayern,86972,Germany,+49 160 8258198,http://www.maxbrauerei.de,10.874761,47.82583700000001
+8edaf3b0-b8e3-4216-8449-35f09f8db0f8,Meckatzer Löwenbräu,brewpub,Meckatz 10,,,Heimenkirch,Bayern,88178,Germany,+49 8381 5040,http://www.meckatzer.de,9.8884815,47.6308829
+42d3affa-b790-480b-a21b-aa2c1b70ccfd,Meinel-Bräu,brewpub,Absolviagasse 1,,,Hof,Bayern,95028,Germany,+49 9281 3514,http://www.meinel-braeu.de,11.9171736,50.3262089
+af25f977-940a-4351-b385-f84964b95bba,Meister,brewpub,Unterzaunsbach 8,,,Pretzfeld,Bayern,91362,Germany,+49 9194 9126,http://www.meisterbräu.de,11.223108,49.737739
+23f3d01b-947d-4728-a054-5287e89dc43f,Memminger,closed,Dr.Karl Lenz Straße 68,,,Memmingen,Bayern,87700,Germany,+49 8331 85660,http://www.memminger-brauerei.de,10.1685041,47.99612279999999
+beef0311-8b83-4f33-9a57-09999649b0f1,Metzgerbräu Reichert,brewpub,Stublanger Straße 2,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 6304,http://www.metzgerbraeu.com,11.0683965,50.0859585
+58739cde-5655-4962-9ae9-2276c2329b59,Meusel-Bräu,brewpub,Dreuschendorf 27,,,Buttenheim,Bayern,96155,Germany,+49 9545 7424,,11.0588964,49.808165
+463de2b2-9afb-4f9b-abfc-9aae38da09d2,Michlbräu,brewpub,Wiggensbacher Straße 52,,,Kempten (Allgäu),Bayern,87439,Germany,+49 831 51210210,http://www.frischesbiermichlbier.de,10.29041,47.75384
+bcad5d55-e688-4b20-9b71-a4f7a4cb87ef,Mittenwald,brewpub,Innsbrucker Straße 13,,,Mittenwald,Bayern,82481,Germany,+49 8823 1007,http://www.brauerei-mittenwald.de,11.2601147,47.4367467
+22127ebd-b769-4784-aaf9-2bb9659b45e2,Mr Kennedy,closed,Brunnengäßchen 22,,,Nürnberg,Bayern,90403,Germany,,http://www.mr-kennedy.de,11.0784656,49.4568006
+47c2ab8c-5596-47cd-9d48-78f3c9553b47,Mühlbauer,brewpub,Further Straße 10,,,Arnschwang,Bayern,93473,Germany,+49 9977 221,http://www.brauerei-muehlbauer.de,12.8174717,49.27444759999999
+4bcf1c93-b875-458f-ad49-0c360b11b4df,Mühlenbräu,brewpub,Neukreuthstraße 7,,,Stegaurach,Bayern,96135,Germany,+49 951 29119,https://www.facebook.com/profile.php?id=100057388782239,10.8115141,49.868087
+bab683cb-3856-4364-a168-6a86e6ab3301,Müller,brewpub,Würzburger Straße 1,,,Stegaurach,Bayern,96135,Germany,+49 951 29191,http://www.debringer-bier.de,10.85744,49.85779
+55b7d8fb-ddb2-42db-af71-85c0b8733ae4,Müller-Bräu,brewpub,Hauptplatz 2,,,Pfaffenhofen an der Ilm,Bayern,85276,Germany,+49 8441 4009110,http://www.schmausenkeller.de,11.5088026,48.529943
+15cffc5a-cd12-4a9c-b0f3-2d7faf727dc9,Müllerbräu,brewpub,Burghauser Straße 2,,,Neuötting,Bayern,84524,Germany,+49 8671 2332,http://www.muellerbraeu.de,12.6909796,48.2400172
+36246ecd-2af3-44fb-b1b3-c802b6dd1e6e,Murmann,brewpub,Coburger Straße 6,,,Untersiemau,Bayern,96253,Germany,+49 9565 811,http://www.brauerei-murmann.de,10.9726705,50.1944248
+cf6b21d5-1bc9-46fe-8849-4cb5566afc88,Museumsbrauerei,micro,Hofer Straße 20,,,Kulmbach,Bayern,95326,Germany,+49 9221 80514,http://www.brauerei-vielau.com,11.4697406,50.114645
 a903e5b8-cab9-4b02-a94c-b2e02e45945e,Nanni Bräu,micro,Freiahorn 27,,,Ahorn,Bayern,95491,Germany,,https://www.facebook.com/NanniBrau,,
-7d47a3ec-f1a1-40f8-b03b-47c9cfeb8cba,Neder,brewpub,10 Sattlertorstraße,,,Forchheim,Bayern,91301,Germany,+49 9191 2400,http://www.neder-brauerei.de/,11.0570169,49.7202013
-9e4f66ec-996a-405c-8d9f-83d500137b0c,Neumarkter Lammsbräu,brewpub,1 Amberger Straße,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 4040,http://www.lammsbraeu.de,11.4610797,49.2841251
-7802834f-001d-41a3-916e-494504b55b24,Nikl Bräu,brewpub,19 Egloffsteiner Straße,,,Pretzfeld,Bayern,91362,Germany,+49 9194 725025,http://www.brauerei-nikl.de,11.1756891,49.7559717
-0f1b9191-57f8-4436-8167-beadbcee674d,Nirschl Bräu,brewpub,1 Birkenstraße,,,Isen,Bayern,84424,Germany,+49 173 7786104,http://www.nirschlbraeu.wordpress.com,12.0285113,48.16937610000001
-0bf4065d-b3e3-4380-8ba1-793ec1eb2cf6,Nittenau,brewpub,4 Wulkersdorfer Straße,,,Nittenau,Bayern,93149,Germany,+49 9436 8209,http://www.nittenauer-bier.de,12.2730054,49.1899604
-3b330573-82d1-4910-ae2c-72998b7816b5,Nordbräu,brewpub,5 Gutsstraße,,,Ingolstadt,Bayern,85055,Germany,+49 841 955960,http://www.nordbraeu.de,11.4393096,48.7941191
-370301a2-f9b9-41be-a5f3-c4ab031b52ec,Nothhaft,brewpub,30 Ottostraße,,,Marktredwitz,Bayern,95615,Germany,+49 9231 2077,http://www.brauerei-nothhaft.de,12.086418,49.999215
-46a68827-b688-4352-9c34-7734dc0507cc,Nürnberger Burgbräu,brewpub,2 Hallplatz,,,Nürnberg,Bayern,90402,Germany,+49 911 24464433,http://tucher-mautkeller.de/,11.0790935,49.4494178
-cccd5c19-8298-4067-9646-d0c9a9ac8fd0,Oberaudorfer Privatbrauerei,brewpub,5 Tiroler Straße,,,Oberaudorf,Bayern,83080,Germany,+49 8033 9250,http://www.oberaudorfer.de,12.1779421,47.6472738
-28869a82-0891-4550-96b3-6157cb73cc53,Oechsner,brewpub,2 Klinge,,,Ochsenfurt,Bayern,97199,Germany,+49 9331 87660,http://www.oechsner.de,10.06016,49.66276
+7d47a3ec-f1a1-40f8-b03b-47c9cfeb8cba,Neder,brewpub,Sattlertorstraße 10,,,Forchheim,Bayern,91301,Germany,+49 9191 2400,http://www.neder-brauerei.de/,11.0570169,49.7202013
+9e4f66ec-996a-405c-8d9f-83d500137b0c,Neumarkter Lammsbräu,brewpub,Amberger Straße 1,,,Neumarkt in der Oberpfalz,Bayern,92318,Germany,+49 9181 4040,http://www.lammsbraeu.de,11.4610797,49.2841251
+7802834f-001d-41a3-916e-494504b55b24,Nikl Bräu,brewpub,Egloffsteiner Straße 19,,,Pretzfeld,Bayern,91362,Germany,+49 9194 725025,http://www.brauerei-nikl.de,11.1756891,49.7559717
+0f1b9191-57f8-4436-8167-beadbcee674d,Nirschl Bräu,brewpub,Birkenstraße 1,,,Isen,Bayern,84424,Germany,+49 173 7786104,http://www.nirschlbraeu.wordpress.com,12.0285113,48.16937610000001
+0bf4065d-b3e3-4380-8ba1-793ec1eb2cf6,Nittenau,brewpub,Wulkersdorfer Straße 4,,,Nittenau,Bayern,93149,Germany,+49 9436 8209,http://www.nittenauer-bier.de,12.2730054,49.1899604
+3b330573-82d1-4910-ae2c-72998b7816b5,Nordbräu,brewpub,Gutsstraße 5,,,Ingolstadt,Bayern,85055,Germany,+49 841 955960,http://www.nordbraeu.de,11.4393096,48.7941191
+370301a2-f9b9-41be-a5f3-c4ab031b52ec,Nothhaft,brewpub,Ottostraße 30,,,Marktredwitz,Bayern,95615,Germany,+49 9231 2077,http://www.brauerei-nothhaft.de,12.086418,49.999215
+46a68827-b688-4352-9c34-7734dc0507cc,Nürnberger Burgbräu,brewpub,Hallplatz 2,,,Nürnberg,Bayern,90402,Germany,+49 911 24464433,http://tucher-mautkeller.de/,11.0790935,49.4494178
+cccd5c19-8298-4067-9646-d0c9a9ac8fd0,Oberaudorfer Privatbrauerei,brewpub,Tiroler Straße 5,,,Oberaudorf,Bayern,83080,Germany,+49 8033 9250,http://www.oberaudorfer.de,12.1779421,47.6472738
+28869a82-0891-4550-96b3-6157cb73cc53,Oechsner,brewpub,Klinge 2,,,Ochsenfurt,Bayern,97199,Germany,+49 9331 87660,http://www.oechsner.de,10.06016,49.66276
 c065942f-3ef0-46da-836d-27058d117177,Oettinger,brewpub,Otto-Kollmar-Straße 1,,,Oettingen in Bayern,Bayern,86732,Germany,+49 9082 7080,https://www.oettinger-bier.de/,10.5989037,48.9381829
-4e2deb11-6155-4f52-a7f4-642dc1ef923f,Orca Brau,brewpub,24 Am Steinacher Kreuz,,,Nürnberg,Bayern,90427,Germany,+49 911 30709979,http://www.orcabrau.de,11.0084791,49.5110023
-82eded27-42d8-4f6f-9e70-8e8c91c6999f,Ostheimer Bürgerbräu,brewpub,11 Ludwig-Jahn-Straße,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.ostheimer-buergerbraeu.de,10.2276809,50.4542921
-db1e5b0d-78bc-4ca4-85f0-1735db432b7a,Ott,brewpub,6 Oberleinleiter,,,Heiligenstadt in Oberfranken,Bayern,91332,Germany,+49 9198 271,http://www.brauerei-ott.de,11.1295254,49.8827807
-4d620819-e321-472a-969d-9347c855b666,Ottenbräu,brewpub,2A Schulhausplatz,,,Abensberg,Bayern,93326,Germany,+49 9443 1348,,11.8435354,48.8175621
-59b8d88c-8628-46d1-bf5e-999cd8e158b4,Paulaner,brewpub,5 Kapuzinerplatz,,,München,Bayern,80337,Germany,+49 89 5446117,http://www.paulaner.de,11.5588321,48.1263049
-0f4b98a6-bc69-4e33-8138-28b75a6ad3c2,Paulaner,brewpub,5 Kapuzinerplatz,,,München,Bayern,80337,Germany,+49 89 5446117,http://www.paulaner-brauhaus.de/,11.5588321,48.1263049
-d0d4092c-8672-4b56-b672-13174b7852f6,Paulaner Bräuhaus,brewpub,5 Kapuzinerplatz,,,München,Bayern,80337,Germany,+49 89 5446117,http://www.paulaner-braeuhaus.de,11.5588321,48.1263049
-f07f2301-939a-412b-8822-db632c0d32ac,Paulaner Nockherberg,brewpub,77 Hochstraße,,,München,Bayern,81541,Germany,+49 89 4599130,http://www.paulaner-nockherberg.com,11.5832042,48.1215216
-42496a83-4060-4a7a-a85c-c38227676421,Pax Bräu,brewpub,7 Rathgeberstraße,,,Oberelsbach,Bayern,97656,Germany,+49 178 8068958,http://www.pax-braeu.de,10.11762,50.4415802
-4e1972a7-018d-4f54-8bee-4f92b5dd6ff8,Penning,brewpub,19 Egloffsteiner Straße,,,Pretzfeld,Bayern,91362,Germany,+49 9194 725025,http://www.brauerei-nikl.de/,11.1756891,49.7559717
-f37cc38c-7b26-4fc3-9fb3-0487fcdbf75d,Pfarrbräu,brewpub,8 Am Dorfplatz,,,Karlstadt,Bayern,97753,Germany,+49 9396 995956,http://www.pfarrbraeu.de,9.707406599999999,49.93295639999999
-65539197-5fdb-475c-aebf-e2703263f580,Pfister,brewpub,22 Eggerbachstraße,,,Eggolsheim,Bayern,91330,Germany,+49 9545 94260,http://www.brauerei-pfister.de,11.0921691,49.7877501
-c0e4b43e-88ad-4790-ba4e-c4ca09cf4cd9,Pflüglerbräu,brewpub,24 Grünecker Straße,,,Neufahrn bei Freising,Bayern,85375,Germany,+49 176 21521678,http://www.pflueglerbraeu.de,11.6794669,48.3146644
-c26f1bd2-102e-4f41-9243-ba720a282837,Pillmeier Bräu,brewpub,28 Rottenburger Straße,,,Langquaid,Bayern,84085,Germany,+49 179 9079111,http://www.pillmeier-braeu.jimdo.com,12.0487966,48.819107
-3bcf6ddd-a2fe-4c24-bcc3-773ad398cf55,Plank,brewpub,1 Marktplatz,,,Laaber,Bayern,93164,Germany,+49 9498 8707,http://www.brauerei-plank.de,11.8860761,49.06519309999999
+4e2deb11-6155-4f52-a7f4-642dc1ef923f,Orca Brau,brewpub,Am Steinacher Kreuz 24,,,Nürnberg,Bayern,90427,Germany,+49 911 30709979,http://www.orcabrau.de,11.0084791,49.5110023
+82eded27-42d8-4f6f-9e70-8e8c91c6999f,Ostheimer Bürgerbräu,brewpub,Ludwig-Jahn-Straße 11,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.ostheimer-buergerbraeu.de,10.2276809,50.4542921
+db1e5b0d-78bc-4ca4-85f0-1735db432b7a,Ott,brewpub,Oberleinleiter 6,,,Heiligenstadt in Oberfranken,Bayern,91332,Germany,+49 9198 271,http://www.brauerei-ott.de,11.1295254,49.8827807
+4d620819-e321-472a-969d-9347c855b666,Ottenbräu,brewpub,Schulhausplatz 2A,,,Abensberg,Bayern,93326,Germany,+49 9443 1348,,11.8435354,48.8175621
+59b8d88c-8628-46d1-bf5e-999cd8e158b4,Paulaner,brewpub,Kapuzinerplatz 5,,,München,Bayern,80337,Germany,+49 89 5446117,http://www.paulaner.de,11.5588321,48.1263049
+0f4b98a6-bc69-4e33-8138-28b75a6ad3c2,Paulaner,brewpub,Kapuzinerplatz 5,,,München,Bayern,80337,Germany,+49 89 5446117,http://www.paulaner-brauhaus.de/,11.5588321,48.1263049
+d0d4092c-8672-4b56-b672-13174b7852f6,Paulaner Bräuhaus,brewpub,Kapuzinerplatz 5,,,München,Bayern,80337,Germany,+49 89 5446117,http://www.paulaner-braeuhaus.de,11.5588321,48.1263049
+f07f2301-939a-412b-8822-db632c0d32ac,Paulaner Nockherberg,brewpub,Hochstraße 77,,,München,Bayern,81541,Germany,+49 89 4599130,http://www.paulaner-nockherberg.com,11.5832042,48.1215216
+42496a83-4060-4a7a-a85c-c38227676421,Pax Bräu,brewpub,Rathgeberstraße 7,,,Oberelsbach,Bayern,97656,Germany,+49 178 8068958,http://www.pax-braeu.de,10.11762,50.4415802
+4e1972a7-018d-4f54-8bee-4f92b5dd6ff8,Penning,brewpub,Egloffsteiner Straße 19,,,Pretzfeld,Bayern,91362,Germany,+49 9194 725025,http://www.brauerei-nikl.de/,11.1756891,49.7559717
+f37cc38c-7b26-4fc3-9fb3-0487fcdbf75d,Pfarrbräu,brewpub,Am Dorfplatz 8,,,Karlstadt,Bayern,97753,Germany,+49 9396 995956,http://www.pfarrbraeu.de,9.707406599999999,49.93295639999999
+65539197-5fdb-475c-aebf-e2703263f580,Pfister,brewpub,Eggerbachstraße 22,,,Eggolsheim,Bayern,91330,Germany,+49 9545 94260,http://www.brauerei-pfister.de,11.0921691,49.7877501
+c0e4b43e-88ad-4790-ba4e-c4ca09cf4cd9,Pflüglerbräu,brewpub,Grünecker Straße 24,,,Neufahrn bei Freising,Bayern,85375,Germany,+49 176 21521678,http://www.pflueglerbraeu.de,11.6794669,48.3146644
+c26f1bd2-102e-4f41-9243-ba720a282837,Pillmeier Bräu,brewpub,Rottenburger Straße 28,,,Langquaid,Bayern,84085,Germany,+49 179 9079111,http://www.pillmeier-braeu.jimdo.com,12.0487966,48.819107
+3bcf6ddd-a2fe-4c24-bcc3-773ad398cf55,Plank,brewpub,Marktplatz 1,,,Laaber,Bayern,93164,Germany,+49 9498 8707,http://www.brauerei-plank.de,11.8860761,49.06519309999999
 e0346ca0-ae8b-466c-bb2f-49c6a4d43d58,Plötz Bräu 2,brewpub,Bachstraße 10,,,Peißenberg,Bayern,82380,Germany,,http://www.imbierium.de,11.0756776,47.80558550000001
-5c8c925d-0d35-4782-a820-0c133da7407b,Pöllinger,brewpub,65 Moosburger Straße,,,Pfeffenhausen,Bayern,84076,Germany,+49 8782 96060,http://www.brauerei-poellinger.de,11.9654149,48.6577919
-1eb5a213-7eeb-4ebb-bec0-ef26d1c39bf7,Post,brewpub,10 Herrenstraße,,,Bad Kötzting,Bayern,93444,Germany,+49 9941 6628,http://www.posthotel-bad-koetzting.de,12.8562707,49.1748354
-8df40fcc-acd8-4a93-8db2-ee9e5d8d1431,Postbräu,brewpub,4 Schreieggstraße,,,Thannhausen,Bayern,86470,Germany,+49 8281 9050,,10.4730013,48.2830028
-3203dbc7-b8a2-4ffa-b6de-4d801f104b85,Postbrauerei,closed,25 Hauptstraße,,,Nesselwang,Bayern,87484,Germany,+49 8361 30960,http://www.post-brauerei-nesselwang.de,10.4992983,47.6219996
-701d19f3-d2be-4743-81e7-c073d6f4807e,Prechtel,brewpub,24 Hauptstraße,,,Uehlfeld,Bayern,91486,Germany,+49 9163 228,http://www.brauerei-prechtel.de,10.7233111,49.6711076
-6ab58a8c-54cb-4923-a1a2-1f96915ee375,Prößlbräu,brewpub,2-3 Dominikanerinnenstraße,,,Pettendorf,Bayern,93186,Germany,+49 9404 1822,http://www.proesslbraeu.de,12.01604,49.04289
-ed2b7edc-ff50-4d31-a554-26c8790e5877,Püls Bräu,brewpub,41 Burgkunstadter Straße,,,Weismain,Bayern,96260,Germany,+49 9575 92290,http://www.weismainer.de,11.2390768,50.0877567
-b153e238-c68a-403f-b263-578a2c272afd,Püttner,brewpub,11 Hauptstraße,,,Schlammersdorf,Bayern,95519,Germany,+49 9205 292,http://www.brauerei-puettner.de,11.734016,49.801994
-cc6ccacd-e5ba-4bb7-ae6c-c868daf7976a,Pyraser,brewpub,26 Pyras,,,Thalmässing,Bayern,91177,Germany,+49 9174 47470,http://www.pyraser.de,11.2166155,49.14920859999999
-7d5bba32-0822-473d-80af-343ab686323f,Raab,brewpub,11 Johannisstraße,,,Hofheim in Unterfranken,Bayern,97461,Germany,+49 9523 95270,http://www.brauerei-raab.de,10.5243331,50.1404329
-57cf544e-1d80-4f89-a50c-8f51f3ee4fc1,Radbrauerei Bucher,brewpub,8 Peter-Henlein-Straße,,,Günzburg,Bayern,89312,Germany,+49 8221 207720,http://www.guenzburger-weizen.de,10.2743448,48.4743652
-88fe3afd-2c42-45fb-ad3e-cdc86e57c63a,Rapp,brewpub,14 Augsburger Straße,,,Kutzenhausen,Bayern,86500,Germany,+49 8238 3090,http://www.brauerei-rapp.de,10.6982336,48.3420791
-317772c0-50e6-48b5-965d-a06442f3a436,Reblitz,brewpub,1 Am Mahlberg,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 96500,http://www.brauerei-gasthof-reblitz.de,10.9654743,50.1160717
-d96b5e7f-da23-46ea-9b4b-30c30eb7115b,Regensburger Weissbräuhaus,brewpub,6 Schwarze-Bären-Straße,,,Regensburg,Bayern,93047,Germany,+49 941 6003210,http://www.regensburger-weissbrauhaus.de,12.098827,49.017843
-d4e9521e-ec70-4506-9e99-423131688e7e,Reh,brewpub,36 Ellertalstraße,,,Litzendorf,Bayern,96123,Germany,+49 9505 210,http://www.reh-bier.de,11.0503522,49.9161267
-ae5ae09b-cc96-4fce-9444-b20a0387ed7b,Reichold,brewpub,24 Hochstahl,,,Aufseß,Bayern,91347,Germany,+49 9204 271,http://www.reichold.de,11.2676156,49.8842253
-980a1248-49eb-466b-850c-822b33798cb9,Reindler,brewpub,5 Brauhausweg,,,Leutershausen,Bayern,91578,Germany,+49 9823 203,http://www.brauerei-reindler.de,10.3902469,49.31172
-546b5567-0b39-4df7-82c6-2ba50946b027,Reiter-Bräu,brewpub,4 Untere Hauptstraße,,,Wartenberg,Bayern,85456,Germany,+49 8762 73580,http://www.reiter-braeu.de,11.9890107,48.4053815
-729b44b1-185f-4c3a-b868-566a788ff9df,Reith / Zehetmeier,brewpub,2 Schloßbräugasse,,,Au in der Hallertau,Bayern,84072,Germany,+49 8752 86320,http://www.auerbier.de/,11.7423778,48.55838610000001
-29048db0-2224-475d-9964-c8f65f21ac07,Reitinger,closed,26 Hauptstraße,,,Oberroth,Bayern,89294,Germany,+49 8333 1213,https://www.hotel-ami.com/h-16822-D/brauerei-gasthof-reitinger-in-oberroth.htm,10.1913501,48.17359
-6c26f8c3-eafd-48f9-bffd-af58d51be8df,Reuter,brewpub,2 Birkenweg,,,Hausen,Bayern,97647,Germany,+49 9779 81010,http://www.rotherbraeu.de/,10.1199053,50.4900111
-7379b193-7d30-4bda-8770-0aa227d78c3e,Rhanerbräu,brewpub,9 Rhan,,,Schönthal,Bayern,93488,Germany,+49 9978 80110,http://www.rhaner.de,12.617426,49.3360716
-106d709b-1c6b-426c-b90e-0a39b901e64c,Rhönpiraten,brewpub,11 Ludwig-Jahn-Straße,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.rhoenpiraten.de,10.2276809,50.4542921
-8af6323d-5560-4af8-a635-94404865e8df,Riedenburger,brewpub,5 Hammerweg,,,Riedenburg,Bayern,93339,Germany,+49 9442 99160,http://www.riedenburger.de,11.69002,48.96232999999999
-3a0cf8f0-cfd1-4c6c-9724-4d2e7ca7e7a9,Riedl,brewpub,2 Kirchenstraße,,,Plößberg,Bayern,95703,Germany,+49 9636 236,https://www.brauerei-riedl.de/,12.3093475,49.7834475
-9aa01c38-2a09-454a-9e72-7f0ae5a41965,Riegele,brewpub,26 Frölichstraße,,,Augsburg,Bayern,86150,Germany,+49 821 32090,http://www.riegele.de,10.8848364,48.3673543
-2f850b63-62a6-42d1-a50c-989ecfd6dfc2,Riemhofer,brewpub,45 Austraße,,,Riedenburg,Bayern,93339,Germany,+49 9442 91980,http://www.brauerei-riemhofer.de,11.67933,48.96700000000001
-61a3f938-bf4d-42de-9bc0-9a85e1f3ac21,Ritter St. Georgen,brewpub,1 Marktplatz,,,Nennslingen,Bayern,91790,Germany,+49 9147 246,http://www.ritter-bier.de,11.13231,49.04722
-06033f8e-b9ff-4e97-bed3-39c9cc0de76f,Rittmayer,brewpub,5 Aischer Hauptstraße,,,Adelsdorf,Bayern,91325,Germany,+49 9195 7222,http://www.rittmayer-aisch.de,10.8892534,49.7196807
-4773fb2f-a47c-492d-90b0-e33046a44896,Roberts Genuss Bräu,brewpub,6 Kirchplatz,,,Weißenhorn,Bayern,89264,Germany,+49 7309 9290110,http://www.genusspur-catering.de,10.1588417,48.3042434
-ca92955a-c165-4fc5-a71f-844b0404c1fa,Rockermeier,brewpub,3 Bachstraße,,,Geisenfeld,Bayern,85290,Germany,+49 8452 608,http://www.landgasthof-rockermeier.de,11.6792862,48.6745433
-42647737-45e1-49b9-a1ee-f1dc0d384220,Röhrl,brewpub,13 Heerstraße,,,Straubing,Bayern,94315,Germany,+49 9421 99370,http://www.roehrlbraeu.de,12.57858,48.88153
+5c8c925d-0d35-4782-a820-0c133da7407b,Pöllinger,brewpub,Moosburger Straße 65,,,Pfeffenhausen,Bayern,84076,Germany,+49 8782 96060,http://www.brauerei-poellinger.de,11.9654149,48.6577919
+1eb5a213-7eeb-4ebb-bec0-ef26d1c39bf7,Post,brewpub,Herrenstraße 10,,,Bad Kötzting,Bayern,93444,Germany,+49 9941 6628,http://www.posthotel-bad-koetzting.de,12.8562707,49.1748354
+8df40fcc-acd8-4a93-8db2-ee9e5d8d1431,Postbräu,brewpub,Schreieggstraße 4,,,Thannhausen,Bayern,86470,Germany,+49 8281 9050,,10.4730013,48.2830028
+3203dbc7-b8a2-4ffa-b6de-4d801f104b85,Postbrauerei,closed,Hauptstraße 25,,,Nesselwang,Bayern,87484,Germany,+49 8361 30960,http://www.post-brauerei-nesselwang.de,10.4992983,47.6219996
+701d19f3-d2be-4743-81e7-c073d6f4807e,Prechtel,brewpub,Hauptstraße 24,,,Uehlfeld,Bayern,91486,Germany,+49 9163 228,http://www.brauerei-prechtel.de,10.7233111,49.6711076
+6ab58a8c-54cb-4923-a1a2-1f96915ee375,Prößlbräu,brewpub,Dominikanerinnenstraße 2-3,,,Pettendorf,Bayern,93186,Germany,+49 9404 1822,http://www.proesslbraeu.de,12.01604,49.04289
+ed2b7edc-ff50-4d31-a554-26c8790e5877,Püls Bräu,brewpub,Burgkunstadter Straße 41,,,Weismain,Bayern,96260,Germany,+49 9575 92290,http://www.weismainer.de,11.2390768,50.0877567
+b153e238-c68a-403f-b263-578a2c272afd,Püttner,brewpub,Hauptstraße 11,,,Schlammersdorf,Bayern,95519,Germany,+49 9205 292,http://www.brauerei-puettner.de,11.734016,49.801994
+cc6ccacd-e5ba-4bb7-ae6c-c868daf7976a,Pyraser,brewpub,Pyras 26,,,Thalmässing,Bayern,91177,Germany,+49 9174 47470,http://www.pyraser.de,11.2166155,49.14920859999999
+7d5bba32-0822-473d-80af-343ab686323f,Raab,brewpub,Johannisstraße 11,,,Hofheim in Unterfranken,Bayern,97461,Germany,+49 9523 95270,http://www.brauerei-raab.de,10.5243331,50.1404329
+57cf544e-1d80-4f89-a50c-8f51f3ee4fc1,Radbrauerei Bucher,brewpub,Peter-Henlein-Straße 8,,,Günzburg,Bayern,89312,Germany,+49 8221 207720,http://www.guenzburger-weizen.de,10.2743448,48.4743652
+88fe3afd-2c42-45fb-ad3e-cdc86e57c63a,Rapp,brewpub,Augsburger Straße 14,,,Kutzenhausen,Bayern,86500,Germany,+49 8238 3090,http://www.brauerei-rapp.de,10.6982336,48.3420791
+317772c0-50e6-48b5-965d-a06442f3a436,Reblitz,brewpub,Am Mahlberg 1,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 96500,http://www.brauerei-gasthof-reblitz.de,10.9654743,50.1160717
+d96b5e7f-da23-46ea-9b4b-30c30eb7115b,Regensburger Weissbräuhaus,brewpub,Schwarze-Bären-Straße 6,,,Regensburg,Bayern,93047,Germany,+49 941 6003210,http://www.regensburger-weissbrauhaus.de,12.098827,49.017843
+d4e9521e-ec70-4506-9e99-423131688e7e,Reh,brewpub,Ellertalstraße 36,,,Litzendorf,Bayern,96123,Germany,+49 9505 210,http://www.reh-bier.de,11.0503522,49.9161267
+ae5ae09b-cc96-4fce-9444-b20a0387ed7b,Reichold,brewpub,Hochstahl 24,,,Aufseß,Bayern,91347,Germany,+49 9204 271,http://www.reichold.de,11.2676156,49.8842253
+980a1248-49eb-466b-850c-822b33798cb9,Reindler,brewpub,Brauhausweg 5,,,Leutershausen,Bayern,91578,Germany,+49 9823 203,http://www.brauerei-reindler.de,10.3902469,49.31172
+546b5567-0b39-4df7-82c6-2ba50946b027,Reiter-Bräu,brewpub,Untere Hauptstraße 4,,,Wartenberg,Bayern,85456,Germany,+49 8762 73580,http://www.reiter-braeu.de,11.9890107,48.4053815
+729b44b1-185f-4c3a-b868-566a788ff9df,Reith / Zehetmeier,brewpub,Schloßbräugasse 2,,,Au in der Hallertau,Bayern,84072,Germany,+49 8752 86320,http://www.auerbier.de/,11.7423778,48.55838610000001
+29048db0-2224-475d-9964-c8f65f21ac07,Reitinger,closed,Hauptstraße 26,,,Oberroth,Bayern,89294,Germany,+49 8333 1213,https://www.hotel-ami.com/h-16822-D/brauerei-gasthof-reitinger-in-oberroth.htm,10.1913501,48.17359
+6c26f8c3-eafd-48f9-bffd-af58d51be8df,Reuter,brewpub,Birkenweg 2,,,Hausen,Bayern,97647,Germany,+49 9779 81010,http://www.rotherbraeu.de/,10.1199053,50.4900111
+7379b193-7d30-4bda-8770-0aa227d78c3e,Rhanerbräu,brewpub,Rhan 9,,,Schönthal,Bayern,93488,Germany,+49 9978 80110,http://www.rhaner.de,12.617426,49.3360716
+106d709b-1c6b-426c-b90e-0a39b901e64c,Rhönpiraten,brewpub,Ludwig-Jahn-Straße 11,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.rhoenpiraten.de,10.2276809,50.4542921
+8af6323d-5560-4af8-a635-94404865e8df,Riedenburger,brewpub,Hammerweg 5,,,Riedenburg,Bayern,93339,Germany,+49 9442 99160,http://www.riedenburger.de,11.69002,48.96232999999999
+3a0cf8f0-cfd1-4c6c-9724-4d2e7ca7e7a9,Riedl,brewpub,Kirchenstraße 2,,,Plößberg,Bayern,95703,Germany,+49 9636 236,https://www.brauerei-riedl.de/,12.3093475,49.7834475
+9aa01c38-2a09-454a-9e72-7f0ae5a41965,Riegele,brewpub,Frölichstraße 26,,,Augsburg,Bayern,86150,Germany,+49 821 32090,http://www.riegele.de,10.8848364,48.3673543
+2f850b63-62a6-42d1-a50c-989ecfd6dfc2,Riemhofer,brewpub,Austraße 45,,,Riedenburg,Bayern,93339,Germany,+49 9442 91980,http://www.brauerei-riemhofer.de,11.67933,48.96700000000001
+61a3f938-bf4d-42de-9bc0-9a85e1f3ac21,Ritter St. Georgen,brewpub,Marktplatz 1,,,Nennslingen,Bayern,91790,Germany,+49 9147 246,http://www.ritter-bier.de,11.13231,49.04722
+06033f8e-b9ff-4e97-bed3-39c9cc0de76f,Rittmayer,brewpub,Aischer Hauptstraße 5,,,Adelsdorf,Bayern,91325,Germany,+49 9195 7222,http://www.rittmayer-aisch.de,10.8892534,49.7196807
+4773fb2f-a47c-492d-90b0-e33046a44896,Roberts Genuss Bräu,brewpub,Kirchplatz 6,,,Weißenhorn,Bayern,89264,Germany,+49 7309 9290110,http://www.genusspur-catering.de,10.1588417,48.3042434
+ca92955a-c165-4fc5-a71f-844b0404c1fa,Rockermeier,brewpub,Bachstraße 3,,,Geisenfeld,Bayern,85290,Germany,+49 8452 608,http://www.landgasthof-rockermeier.de,11.6792862,48.6745433
+42647737-45e1-49b9-a1ee-f1dc0d384220,Röhrl,brewpub,Heerstraße 13,,,Straubing,Bayern,94315,Germany,+49 9421 99370,http://www.roehrlbraeu.de,12.57858,48.88153
 a29186d8-8b5f-4222-bc6e-304a2eeb071f,Roppelt,brewpub,Stiebarlimbach,,,Hallerndorf,Bayern,91352,Germany,+49 9195 7263,http://www.brauerei-roppelt.de,10.9494461,49.7565902
-2565d3a1-5580-480c-a369-0055d0aab9b4,Rosenauer Hofbräu,brewpub,22 Rosenau,,,Marktgraitz,Bayern,96257,Germany,+49 9574 5083222,http://www.rosenauer-hofbraeu.de,11.2019975,50.1807393
-7b74e189-696b-473d-b69c-7b0fd478d65e,Rössle-Bräu,brewpub,32 St.-Antonius-Straße,,,Jengen,Bayern,86860,Germany,+49 8246 755,http://www.roessle-braeu.de,10.7354516,47.987873
-0ba65f21-24c1-4e47-a5d1-62348c584f7f,Roth,brewpub,24 Obere Straße,,,Schweinfurt,Bayern,97421,Germany,+49 9721 1034,http://www.rothbier.com,10.2336983,50.0468939
-8068756b-2fae-4986-9114-a53af772b42c,Rothenbach,brewpub,70 Im Tal,,,Aufseß,Bayern,91347,Germany,+49 9198 92920,http://www.aufsesser.de,11.2291679,49.8838806
-65708643-172e-4f35-bb32-82409bf24c37,Rother Bräu,brewpub,2 Birkenweg,,,Hausen,Bayern,97647,Germany,+49 9779 81010,http://www.rotherbraeu.de,10.1199053,50.4900111
-f8d16115-57bb-440a-9f4a-3bd65bb5211b,Rothmooser,brewpub,2 Rothmoos,,,Halfing,Bayern,83128,Germany,+49 8055 90660,http://www.rothmooser.de,12.2357676,47.9541377
-f9c26b1f-0970-4239-a791-465074187aab,RS Bräu,brewpub,2 Grimoldsrieder Straße,,,Walkertshofen,Bayern,86877,Germany,+49 8239 507,http://www.rs-braeu.de,10.592074,48.2263527
-83a00b58-c7d3-4438-bbd2-998fa57f59b9,Sauer,brewpub,5 Sutte,,,Strullendorf,Bayern,96129,Germany,+49 9543 1578,http://www.brauerei-sauer.de,10.9969444,49.8677778
-c5f8973a-80d3-46ed-a9f9-7505add49754,Schäffler,brewpub,17 Hauptstraße,,,Missen-Wilhams,Bayern,87547,Germany,+49 8320 92011,http://www.schaeffler-braeu.de,10.127268,47.59733199999999
-76ea6b38-9787-493a-896c-fc41af435647,Schanzenbräu,brewpub,3 Proeslerstraße,,,Nürnberg,Bayern,90431,Germany,+49 911 8100690,http://www.schanzenbraeu.de,11.0031957,49.44843669999999
-e30bd687-5222-42b7-bec0-e8a41db4bd2f,Scharpf,brewpub,16 Heilgersdorfer Hauptstraße,,,Seßlach,Bayern,96145,Germany,+49 9569 1232,http://www.scharpf-heilgersdorf.de,10.8275098,50.1638417
-34cffa20-e2e2-4af2-b3f7-7b98bda14d0c,Schattenhofer Bräu,brewpub,44 Hauptstraße,,,Beilngries,Bayern,92339,Germany,+49 8461 7004370,http://www.schattenhofer.com,11.47227,49.03604
-0188814e-1e9e-467a-89ee-a35bf36b81e0,Scherdel,brewpub,14 Unterkotzauer Weg,,,Hof,Bayern,95028,Germany,+49 9281 8960,http://www.scherdelbier.de,11.91155,50.32314
-76ae66a2-69a7-4465-b728-1c03b62c3a15,Scheuerer,brewpub,7 Bräugasse,,,Moosbach,Bayern,92709,Germany,+49 9656 209,http://www.moosbacher.com,12.409741,49.58964899999999
-c184b3d7-ed7f-4649-846a-f78324bd27cb,Scheunenbrauerei Langlotz / Erwisch Bräu,brewpub,13 Charlotte-von-Kalb-Straße,,,Saal an der Saale,Bayern,97633,Germany,+49 9762 9292,http://www.privatbrauerei-lang.de/,10.3868705,50.3372676
-70a3ee55-6a4f-4698-866b-34ae463992c9,Schiller-Bräu,brewpub,23 Schillerstraße,,,München,Bayern,80336,Germany,+49 89 890584820,http://www.schiller-braeu.de,11.5611313,48.136712
-ee81c52a-a00f-467f-a11a-b7b86ea40eb0,Schimpfle,brewpub,16 Hauptstraße,,,Gessertshausen,Bayern,86459,Germany,+49 8238 96370,http://www.brauerei-schimpfle.de,10.7333826,48.3310352
-2683ecdb-0a9d-4e81-aa14-9f0f0de12170,Schleicher,brewpub,22 Coburger Straße,,,Itzgrund,Bayern,96274,Germany,+49 9533 229,http://www.brauerei-schleicher.de,10.878375,50.1244568
-c757d9ef-6a87-4047-b416-df31e260063d,Schloderer,brewpub,4 Rathausstraße,,,Amberg,Bayern,92224,Germany,+49 9621 420707,http://www.schlodererbraeu.de,11.858948,49.445184
-d2efbf5a-ff17-4df9-90f9-ebaf3ece8fe8,Schlossbräu,brewpub,1 Hofmark,,,Drachselsried,Bayern,94256,Germany,+49 9945 94070,http://www.schlossbraeu.de,13.0134406,49.10568079999999
-c2ea556d-a9ea-46ba-a45d-b871e600dff3,Schloßbrauerei,brewpub,13 Naabecker Straße,,,Schwandorf,Bayern,92421,Germany,+49 9431 1326,http://www.naabecker.de,12.06674,49.29356
-9b3b6cdf-eec5-408d-946e-d5177bd70dcf,Schloßbrauerei Dorfner,brewpub,6 Mühlstraße,,,Hirschau,Bayern,92242,Germany,+49 9622 2212,http://www.dorfner-schlossbrauerei.de,11.95064,49.5448
-ceee5844-1879-4219-8ce3-11a1c5ae03fd,Schloßbrauerei Kaltenberg,brewpub,41 Augsburger Straße,,,Fürstenfeldbruck,Bayern,82256,Germany,+49 8141 2430,http://www.koenig-ludwig.com,11.251905,48.1828857
-8a1cda36-821b-485c-b4ad-473bf0f6fcc7,Schloßbrauerei Odelzhausen,brewpub,1 Am Schloßberg,,,Odelzhausen,Bayern,85235,Germany,+49 8134 99870,http://www.schlossgut-odelzhausen.de,11.2035635,48.3142564
-f4e21dd1-2ea0-43a1-a2a1-a835cf0503ce,Schloßbrauerei Schwarzfischer,brewpub,1 Oberzeller Straße,,,Zell,Bayern,93199,Germany,+49 9468 325,http://www.schlossbrauerei-schwarzfischer.de,12.4108333,49.14333329999999
-ec389b9b-fba6-4fb8-b3f6-07eda2d47d50,Schlossbrauhaus,brewpub,5 Gipsmühlweg,,,Schwangau,Bayern,87645,Germany,+49 8362 9264680,http://www.schlossbrauhaus.de,10.7350308,47.57434079999999
-368b8e14-d712-4ca2-ad32-7e13ac365a5e,Schlössle,brewpub,3 Schlössleweg,,,Neu-Ulm,Bayern,89231,Germany,+49 731 77390,http://www.schloessle.com,10.0202367,48.403188
-44aa49ff-fc30-4d44-b252-ee375098d0a5,Schmid,brewpub,24 Weißenhorner Straße,,,Roggenburg,Bayern,89297,Germany,+49 7300 303,http://www.brauerei-biberach.de,10.2205288,48.2875902
-a3d6ef96-e9c3-4b2b-8a77-56cd53c1ae2d,Schmidmayer-Bräu,brewpub,3 Hopfenstraße,,,Siegenburg,Bayern,93354,Germany,+49 9444 972146,http://www.spezialitaetenbrauerei.de,11.84949,48.75380999999999
-acf011dc-fc9e-4cea-8589-d10bcf0ab092,Schmölzer Dorfbrauerei,brewpub,4 Johann-Georg-Herzog-Straße,,,Küps,Bayern,96328,Germany,+49 1512 0748374,http://www.schmoelzer-dorfbrauerei.jimdo.com,11.2556379,50.2137408
-cf1b6b9f-a0ea-4600-9aa3-2a67e74fa7d6,Schneider,brewpub,10 Altmühlgasse,,,Essing,Bayern,93343,Germany,+49 9447 91800,http://www.brauereigasthof-schneider.de,11.788359,48.93542
-fa2d83ab-fbac-4907-9dad-852a87a793ad,Schnellinger,brewpub,1A Rosenweg,,,Schwarzenfeld,Bayern,92521,Germany,+49 9435 502530,http://www.schnellinger-bräu.de,12.1106357,49.3789956
-51d35046-bded-401b-abff-87295e494651,Schnitzlbaumer,brewpub,11A Taubenmarkt,13,,Traunstein,Bayern,83278,Germany,+49 861 986650,http://www.schnitzlbaumer.de,12.648451,47.870183
-edb0778b-3575-4ce8-9e48-2a3ab0448394,Schober,brewpub,2 Saarbrückener Straße,,,Zirndorf,Bayern,90513,Germany,+49 911 604658,,10.9609851,49.4447341
-1356209d-fce4-40d9-ac86-16267721f144,Schongauer Brauhaus,brewpub,13 Altenstadter Straße,,,Schongau,Bayern,86956,Germany,+49 8861 9336222,http://www.schongauer-brauhaus.de,10.8919314,47.8165452
-2496f6e4-d7d4-4b2f-ac67-3f9457b2e34b,Schönram,brewpub,17 Salzburger Straße,,,Petting,Bayern,83367,Germany,+49 8686 98800,http://www.brauerei-schoenram.de,12.8496895,47.8858016
-09971575-7caf-4719-b7d0-8275ba244282,Schorer,brewpub,2 Grimoldsrieder Straße,,,Walkertshofen,Bayern,86877,Germany,+49 8239 507,http://www.staudenbraeu.de/,10.592074,48.2263527
-ce25f5dc-993a-421d-929d-01e6e6edf37c,Schorschbräu,brewpub,7 Richard-Stücklen-Straße,,,Gunzenhausen,Bayern,91710,Germany,+49 9831 1868,http://www.schorschbraeu.de,10.7410598,49.1097233
-224cb6bd-14a9-4177-8746-6dd947e61e76,Schroll,brewpub,41 Nankendorf,,,Waischenfeld,Bayern,91344,Germany,+49 9204 248,http://www.brauerei-schroll.de,11.3374488,49.8649362
-ebcc6057-51ef-4cff-b948-7e6581737a2b,Schrüfer,brewpub,31 Hauptstraße,,,Priesendorf,Bayern,96170,Germany,+49 9549 317,,10.7113971,49.9063017
-799ca8e6-8f4c-434f-a36a-b1512cf35aa4,Schübel,brewpub,12 Knollenstraße,,,Stadtsteinach,Bayern,95346,Germany,+49 9225 956482,http://www.schuebel-braeu.de,11.5039443,50.1605224
-491731b5-27da-4746-b8d0-8f9df4e5d416,Schuller,brewpub,14 St.-Lorenz-Straße,,,Berching,Bayern,92334,Germany,+49 8462 302,http://www.hotel-krone-berching.de,11.4441,49.10499
-3b398199-0f41-449d-9120-3f17a3141e1e,Schwanenbräu,brewpub,1 Kellerberg,,,Burgebrach,Bayern,96138,Germany,+49 9546 306,http://www.schwanawirt.de,10.7364989,49.82229419999999
-9e880a4e-689b-4025-bdfa-b8f96f6f111c,Schwarzbräu,brewpub,6 Marktplatz,,,Zusmarshausen,Bayern,86441,Germany,+49 8291 880,http://www.schwarzbraeu.de,10.597849,48.39946
-61a46e8e-f33c-4c86-b9b5-7b66d260f1c6,Schweiger,brewpub,26 Ebersberger Straße,,,Markt Schwaben,Bayern,85570,Germany,+49 8121 221815,http://www.schweiger-bier.de,11.8690664,48.1874822
-47c641ee-8799-475f-ae03-92341efaca82,Schwindbräu,brewpub,117 Schweinheimer Straße,,,Aschaffenburg,Bayern,63743,Germany,+49 6021 930092,http://www.schwindbraeu.de,9.1627602,49.9598997
-6cd33e05-1a1f-406f-9f72-b0079923084d,Seelmann,brewpub,18 Zettmannsdorfer Hauptstraße,,,Schönbrunn im Steigerwald,Bayern,96185,Germany,+49 9546 595990,http://www.brauerei-seelmann.de,10.6553988,49.8665976
+2565d3a1-5580-480c-a369-0055d0aab9b4,Rosenauer Hofbräu,brewpub,Rosenau 22,,,Marktgraitz,Bayern,96257,Germany,+49 9574 5083222,http://www.rosenauer-hofbraeu.de,11.2019975,50.1807393
+7b74e189-696b-473d-b69c-7b0fd478d65e,Rössle-Bräu,brewpub,St.-Antonius-Straße 32,,,Jengen,Bayern,86860,Germany,+49 8246 755,http://www.roessle-braeu.de,10.7354516,47.987873
+0ba65f21-24c1-4e47-a5d1-62348c584f7f,Roth,brewpub,Obere Straße 24,,,Schweinfurt,Bayern,97421,Germany,+49 9721 1034,http://www.rothbier.com,10.2336983,50.0468939
+8068756b-2fae-4986-9114-a53af772b42c,Rothenbach,brewpub,Im Tal 70,,,Aufseß,Bayern,91347,Germany,+49 9198 92920,http://www.aufsesser.de,11.2291679,49.8838806
+65708643-172e-4f35-bb32-82409bf24c37,Rother Bräu,brewpub,Birkenweg 2,,,Hausen,Bayern,97647,Germany,+49 9779 81010,http://www.rotherbraeu.de,10.1199053,50.4900111
+f8d16115-57bb-440a-9f4a-3bd65bb5211b,Rothmooser,brewpub,Rothmoos 2,,,Halfing,Bayern,83128,Germany,+49 8055 90660,http://www.rothmooser.de,12.2357676,47.9541377
+f9c26b1f-0970-4239-a791-465074187aab,RS Bräu,brewpub,Grimoldsrieder Straße 2,,,Walkertshofen,Bayern,86877,Germany,+49 8239 507,http://www.rs-braeu.de,10.592074,48.2263527
+83a00b58-c7d3-4438-bbd2-998fa57f59b9,Sauer,brewpub,Sutte 5,,,Strullendorf,Bayern,96129,Germany,+49 9543 1578,http://www.brauerei-sauer.de,10.9969444,49.8677778
+c5f8973a-80d3-46ed-a9f9-7505add49754,Schäffler,brewpub,Hauptstraße 17,,,Missen-Wilhams,Bayern,87547,Germany,+49 8320 92011,http://www.schaeffler-braeu.de,10.127268,47.59733199999999
+76ea6b38-9787-493a-896c-fc41af435647,Schanzenbräu,brewpub,Proeslerstraße 3,,,Nürnberg,Bayern,90431,Germany,+49 911 8100690,http://www.schanzenbraeu.de,11.0031957,49.44843669999999
+e30bd687-5222-42b7-bec0-e8a41db4bd2f,Scharpf,brewpub,Heilgersdorfer Hauptstraße 16,,,Seßlach,Bayern,96145,Germany,+49 9569 1232,http://www.scharpf-heilgersdorf.de,10.8275098,50.1638417
+34cffa20-e2e2-4af2-b3f7-7b98bda14d0c,Schattenhofer Bräu,brewpub,Hauptstraße 44,,,Beilngries,Bayern,92339,Germany,+49 8461 7004370,http://www.schattenhofer.com,11.47227,49.03604
+0188814e-1e9e-467a-89ee-a35bf36b81e0,Scherdel,brewpub,Unterkotzauer Weg 14,,,Hof,Bayern,95028,Germany,+49 9281 8960,http://www.scherdelbier.de,11.91155,50.32314
+76ae66a2-69a7-4465-b728-1c03b62c3a15,Scheuerer,brewpub,Bräugasse 7,,,Moosbach,Bayern,92709,Germany,+49 9656 209,http://www.moosbacher.com,12.409741,49.58964899999999
+c184b3d7-ed7f-4649-846a-f78324bd27cb,Scheunenbrauerei Langlotz / Erwisch Bräu,brewpub,Charlotte-von-Kalb-Straße 13,,,Saal an der Saale,Bayern,97633,Germany,+49 9762 9292,http://www.privatbrauerei-lang.de/,10.3868705,50.3372676
+70a3ee55-6a4f-4698-866b-34ae463992c9,Schiller-Bräu,brewpub,Schillerstraße 23,,,München,Bayern,80336,Germany,+49 89 890584820,http://www.schiller-braeu.de,11.5611313,48.136712
+ee81c52a-a00f-467f-a11a-b7b86ea40eb0,Schimpfle,brewpub,Hauptstraße 16,,,Gessertshausen,Bayern,86459,Germany,+49 8238 96370,http://www.brauerei-schimpfle.de,10.7333826,48.3310352
+2683ecdb-0a9d-4e81-aa14-9f0f0de12170,Schleicher,brewpub,Coburger Straße 22,,,Itzgrund,Bayern,96274,Germany,+49 9533 229,http://www.brauerei-schleicher.de,10.878375,50.1244568
+c757d9ef-6a87-4047-b416-df31e260063d,Schloderer,brewpub,Rathausstraße 4,,,Amberg,Bayern,92224,Germany,+49 9621 420707,http://www.schlodererbraeu.de,11.858948,49.445184
+d2efbf5a-ff17-4df9-90f9-ebaf3ece8fe8,Schlossbräu,brewpub,Hofmark 1,,,Drachselsried,Bayern,94256,Germany,+49 9945 94070,http://www.schlossbraeu.de,13.0134406,49.10568079999999
+c2ea556d-a9ea-46ba-a45d-b871e600dff3,Schloßbrauerei,brewpub,Naabecker Straße 13,,,Schwandorf,Bayern,92421,Germany,+49 9431 1326,http://www.naabecker.de,12.06674,49.29356
+9b3b6cdf-eec5-408d-946e-d5177bd70dcf,Schloßbrauerei Dorfner,brewpub,Mühlstraße 6,,,Hirschau,Bayern,92242,Germany,+49 9622 2212,http://www.dorfner-schlossbrauerei.de,11.95064,49.5448
+ceee5844-1879-4219-8ce3-11a1c5ae03fd,Schloßbrauerei Kaltenberg,brewpub,Augsburger Straße 41,,,Fürstenfeldbruck,Bayern,82256,Germany,+49 8141 2430,http://www.koenig-ludwig.com,11.251905,48.1828857
+8a1cda36-821b-485c-b4ad-473bf0f6fcc7,Schloßbrauerei Odelzhausen,brewpub,Am Schloßberg 1,,,Odelzhausen,Bayern,85235,Germany,+49 8134 99870,http://www.schlossgut-odelzhausen.de,11.2035635,48.3142564
+f4e21dd1-2ea0-43a1-a2a1-a835cf0503ce,Schloßbrauerei Schwarzfischer,brewpub,Oberzeller Straße 1,,,Zell,Bayern,93199,Germany,+49 9468 325,http://www.schlossbrauerei-schwarzfischer.de,12.4108333,49.14333329999999
+ec389b9b-fba6-4fb8-b3f6-07eda2d47d50,Schlossbrauhaus,brewpub,Gipsmühlweg 5,,,Schwangau,Bayern,87645,Germany,+49 8362 9264680,http://www.schlossbrauhaus.de,10.7350308,47.57434079999999
+368b8e14-d712-4ca2-ad32-7e13ac365a5e,Schlössle,brewpub,Schlössleweg 3,,,Neu-Ulm,Bayern,89231,Germany,+49 731 77390,http://www.schloessle.com,10.0202367,48.403188
+44aa49ff-fc30-4d44-b252-ee375098d0a5,Schmid,brewpub,Weißenhorner Straße 24,,,Roggenburg,Bayern,89297,Germany,+49 7300 303,http://www.brauerei-biberach.de,10.2205288,48.2875902
+a3d6ef96-e9c3-4b2b-8a77-56cd53c1ae2d,Schmidmayer-Bräu,brewpub,Hopfenstraße 3,,,Siegenburg,Bayern,93354,Germany,+49 9444 972146,http://www.spezialitaetenbrauerei.de,11.84949,48.75380999999999
+acf011dc-fc9e-4cea-8589-d10bcf0ab092,Schmölzer Dorfbrauerei,brewpub,Johann-Georg-Herzog-Straße 4,,,Küps,Bayern,96328,Germany,+49 1512 0748374,http://www.schmoelzer-dorfbrauerei.jimdo.com,11.2556379,50.2137408
+cf1b6b9f-a0ea-4600-9aa3-2a67e74fa7d6,Schneider,brewpub,Altmühlgasse 10,,,Essing,Bayern,93343,Germany,+49 9447 91800,http://www.brauereigasthof-schneider.de,11.788359,48.93542
+fa2d83ab-fbac-4907-9dad-852a87a793ad,Schnellinger,brewpub,Rosenweg 1A,,,Schwarzenfeld,Bayern,92521,Germany,+49 9435 502530,http://www.schnellinger-bräu.de,12.1106357,49.3789956
+51d35046-bded-401b-abff-87295e494651,Schnitzlbaumer,brewpub,Taubenmarkt 11A,13,,Traunstein,Bayern,83278,Germany,+49 861 986650,http://www.schnitzlbaumer.de,12.648451,47.870183
+edb0778b-3575-4ce8-9e48-2a3ab0448394,Schober,brewpub,Saarbrückener Straße 2,,,Zirndorf,Bayern,90513,Germany,+49 911 604658,,10.9609851,49.4447341
+1356209d-fce4-40d9-ac86-16267721f144,Schongauer Brauhaus,brewpub,Altenstadter Straße 13,,,Schongau,Bayern,86956,Germany,+49 8861 9336222,http://www.schongauer-brauhaus.de,10.8919314,47.8165452
+2496f6e4-d7d4-4b2f-ac67-3f9457b2e34b,Schönram,brewpub,Salzburger Straße 17,,,Petting,Bayern,83367,Germany,+49 8686 98800,http://www.brauerei-schoenram.de,12.8496895,47.8858016
+09971575-7caf-4719-b7d0-8275ba244282,Schorer,brewpub,Grimoldsrieder Straße 2,,,Walkertshofen,Bayern,86877,Germany,+49 8239 507,http://www.staudenbraeu.de/,10.592074,48.2263527
+ce25f5dc-993a-421d-929d-01e6e6edf37c,Schorschbräu,brewpub,Richard-Stücklen-Straße 7,,,Gunzenhausen,Bayern,91710,Germany,+49 9831 1868,http://www.schorschbraeu.de,10.7410598,49.1097233
+224cb6bd-14a9-4177-8746-6dd947e61e76,Schroll,brewpub,Nankendorf 41,,,Waischenfeld,Bayern,91344,Germany,+49 9204 248,http://www.brauerei-schroll.de,11.3374488,49.8649362
+ebcc6057-51ef-4cff-b948-7e6581737a2b,Schrüfer,brewpub,Hauptstraße 31,,,Priesendorf,Bayern,96170,Germany,+49 9549 317,,10.7113971,49.9063017
+799ca8e6-8f4c-434f-a36a-b1512cf35aa4,Schübel,brewpub,Knollenstraße 12,,,Stadtsteinach,Bayern,95346,Germany,+49 9225 956482,http://www.schuebel-braeu.de,11.5039443,50.1605224
+491731b5-27da-4746-b8d0-8f9df4e5d416,Schuller,brewpub,St.-Lorenz-Straße 14,,,Berching,Bayern,92334,Germany,+49 8462 302,http://www.hotel-krone-berching.de,11.4441,49.10499
+3b398199-0f41-449d-9120-3f17a3141e1e,Schwanenbräu,brewpub,Kellerberg 1,,,Burgebrach,Bayern,96138,Germany,+49 9546 306,http://www.schwanawirt.de,10.7364989,49.82229419999999
+9e880a4e-689b-4025-bdfa-b8f96f6f111c,Schwarzbräu,brewpub,Marktplatz 6,,,Zusmarshausen,Bayern,86441,Germany,+49 8291 880,http://www.schwarzbraeu.de,10.597849,48.39946
+61a46e8e-f33c-4c86-b9b5-7b66d260f1c6,Schweiger,brewpub,Ebersberger Straße 26,,,Markt Schwaben,Bayern,85570,Germany,+49 8121 221815,http://www.schweiger-bier.de,11.8690664,48.1874822
+47c641ee-8799-475f-ae03-92341efaca82,Schwindbräu,brewpub,Schweinheimer Straße 117,,,Aschaffenburg,Bayern,63743,Germany,+49 6021 930092,http://www.schwindbraeu.de,9.1627602,49.9598997
+6cd33e05-1a1f-406f-9f72-b0079923084d,Seelmann,brewpub,Zettmannsdorfer Hauptstraße 18,,,Schönbrunn im Steigerwald,Bayern,96185,Germany,+49 9546 595990,http://www.brauerei-seelmann.de,10.6553988,49.8665976
 5a46b4f4-5d91-47db-a567-9c4b0af578a7,Seinsheimer-Kellerbräu,brewpub,Am Rathaus,,,Seinsheim,Bayern,97342,Germany,+49 171 7063636,http://www.seinsheimer-kellerbier.de,10.2225452,49.6410116
-adf47933-f19d-4cc6-a6b4-63f7ea53b069,Sigwart,closed,10 Roßmühle,,,Weißenburg in Bayern,Bayern,91781,Germany,+49 9141 85750,http://www.brauerei-sigwart.de,10.9750088,49.0312566
-9a8d18f8-5d65-47fd-9324-3117d7982d53,Simmerberger,brewpub,2 Ellhofer Straße,,,Weiler-Simmerberg,Bayern,88171,Germany,+49 8387 1016,http://www.braeustatt-simmerberg.de,9.9451787,47.5867932
-aebc095e-4ef1-470e-a19f-7d48e226f2bf,Simmseer Braumanufaktur,brewpub,42 Krottenhausmühlstraße,,,Stephanskirchen,Bayern,83071,Germany,+49 8036 9096606,http://www.simmseer.de,12.1901766,47.8500375
-d271ef30-0334-4a69-a8d3-434615b8cc33,Simon,brewpub,12 Heroldstraße,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 9123 2323,http://www.brauerei-simon.de,11.2798793,49.5153352
-399093ac-9c09-4e7c-922a-cbe76b97b40b,Sitter-Bräu,micro,12 Riedelsbach,,,Neureichenau,Bayern,94089,Germany,+49 8583 96040,http://www.gut-riedelsbach.de,13.78764,48.7502
-ee99faf4-6b45-4891-a76d-3d1cae24c0e5,Sonnen-Bräu,brewpub,4 Zaugendorfer Straße,,,Rattelsdorf,Bayern,96179,Germany,+49 9533 981017,http://www.gasthaus-schmitt.de,10.8639895,50.0612606
-e5a80737-9526-42e3-a0a2-10c3b5c3ca6c,Sonnenbräu,brewpub,20 Nailaer Straße,,,Lichtenberg,Bayern,95192,Germany,+49 9288 304,http://www.facebook.com/SB.LBG/,11.67558,50.38074599999999
-9efc5558-16e8-499c-a71f-d8814095f541,Späth-Bräu,brewpub,3 Pfarrweg,,,Lohberg,Bayern,93470,Germany,+49 9943 7799880,http://www.osser-bier.de,13.1055045,49.1746408
-1db8bb97-e0ed-4150-8c7e-1f58930526ed,Sperber-Bräu,brewpub,14 Rosenberger Straße,,,Sulzbach-Rosenberg,Bayern,92237,Germany,+49 9661 87090,http://www.sperberbraeu.de,11.7409574,49.5042589
-61a05c41-1b3f-48d6-a165-4cc99755fd92,Spessart,brewpub,2 Junkergasse,,,Kreuzwertheim,Bayern,97892,Germany,+49 9342 85700,http://www.spessart-specht.de,9.5166732,49.7633681
-28a2aec4-2003-445e-ab8c-0283be4b3840,Spezial,brewpub,10 Obere Königstraße,,,Bamberg,Bayern,96052,Germany,+49 951 24304,http://www.brauerei-spezial.de,10.8928067,49.8968596
-3b19f01c-cb46-41fd-aa66-3c634f12e6c9,Spezial-Brauerei,brewpub,15-17 Hauptstraße,,,Schierling,Bayern,84069,Germany,+49 9451 3012,http://www.schierlinger-pils.de,12.1374225,48.837841
-ed417aab-8197-42e9-8435-757dddfddbb6,Spitalbrauerei,brewpub,1-3 Am Brückenfuß,,,Regensburg,Bayern,93059,Germany,+49 941 83006155,http://www.spitalbrauerei.de,12.0959952,49.0241423
-6606c44b-dbfb-4fff-9350-f5e1cec8fed5,St. Georgen,brewpub,12 Marktstraße,,,Buttenheim,Bayern,96155,Germany,+49 9545 4460,http://www.kellerbier.de,11.032226,49.8017243
-451761d2-0b1c-46a3-9245-4ae94323d0e0,Stadelbräu,brewpub,6 Marktplatz,,,Zusmarshausen,Bayern,86441,Germany,+49 8291 880,http://www.stadel-braeu.de,10.597849,48.39946
-fcd5c594-aa40-4e24-8c84-7f290515c5fa,Stadlbräu,brewpub,19 Kybergstraße,,,Oberhaching,Bayern,82041,Germany,+49 89 95447565,http://www.bayerische-brauhaus-consulting.de,11.5913115,48.0258995
-de500343-4276-4d65-8173-04361c1b0b42,Stadtbrauerei,brewpub,3 Brauereigasse,,,Spalt,Bayern,91174,Germany,+49 9175 79610,http://www.spalter-bier.de,10.92523,49.17434
-076bf1f8-a5f2-483c-961a-9972379b6b1d,Stadter,brewpub,26 Hauptstraße,,,Aufseß,Bayern,91347,Germany,+49 9274 8193,http://www.brauerei-stadter.de,11.2354334,49.9140886
-621b3b13-1ff7-4bdb-b0fa-49e68fdf6638,Staffelberg-Bräu,brewpub,7 Mühlteich,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 5925,http://www.staffelberg-braeu.de,11.0241054,50.07883289999999
-274d2e24-a423-4f8a-a0cb-9a6f792b552e,Stallbauer,brewpub,12 Wiesmühl,,,Engelsberg,Bayern,84549,Germany,,http://www.brauerei-stallbauer.de,12.566108,48.105877
-788e1155-5d7d-41b1-88ef-0ff719ae4a1f,Stanglbräu,brewpub,11 Dorfstraße,,,Hausen,Bayern,93345,Germany,+49 9448 91830,http://www.stanglbraeu.de,11.9861373,48.8449076
-0c7cacb7-0660-48db-ae72-a03db3f5a871,Stark,brewpub,4 Alte Straße,,,Wertingen,Bayern,86637,Germany,+49 8272 2214,http://www.landgasthof-stark.de,10.6955137,48.5561409
-c2c30af5-936f-4bf3-853d-9917f215ea41,Stärker,brewpub,6 Brückenauer Straße,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.staerkerbraeu.de,9.771565299999999,50.3953363
-d50e9a12-6091-4163-a75a-fc795c64a4e8,Starnberger Brauhaus,brewpub,3 Alte Weilheimer Straße,,,Feldafing,Bayern,82340,Germany,+49 8151 446100,http://www.brauerei.bayern,11.2674236,47.9531593
-c7af7f47-0d77-44ec-884d-3ea3993cbe37,Stefansbräu,brewpub,1 Wilhelmshöhe,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 582393,http://www.dinkelbrauer.de,10.3351237,49.0763876
-935d7138-fde6-4503-8793-52528192b1ca,Steinbach Bräu,brewpub,4 Vierzigmannstraße,,,Erlangen,Bayern,91054,Germany,+49 9131 895912,http://www.steinbach-braeu.de,11.0050399,49.6029026
-937df3a6-f86d-4304-9398-5b5fc79124e1,Sterk,brewpub,2 Hofmark,,,Amberg,Bayern,92224,Germany,+49 9621 914323,http://www.brauerei-sterk.de,11.8962189,49.45828059999999
-adc55e01-81d5-40fa-838d-dc199a38d45c,Stern-Bräu,brewpub,1 Weinberg,,,Schlüsselfeld,Bayern,96132,Germany,+49 9552 320,http://www.brauerei-scheubel.de,10.6194738,49.7615938
-2f33bde0-06ba-44c6-a093-404c9a86ddee,Stiagnbräu,brewpub,22A Ottersried,,,Rohrbach,Bayern,85296,Germany,+49 8442 7596,http://m.facebook.com/pages/Stiangbr%C3%A4u-Undaschria/180559465331490,11.5395656,48.6172608
-0ab02914-918f-4a48-a4d9-8aa85b1f24a4,Stierberg,brewpub,12 Stierberg,,,Obertaufkirchen,Bayern,84419,Germany,+49 8082 1851,http://www.brauerei-stierberg.de,12.2831909,48.2433528
-62077fcf-2f26-4f80-8654-c03f10c4d0a5,Stöckel,brewpub,4 Hintergereuth,,,Ahorntal,Bayern,95491,Germany,+49 9246 275,http://www.stoeckel-braeu.de,11.45417,49.85093999999999
-b4e37ba7-8c36-4073-90c6-cbcd93a24368,Storchenbräu,brewpub,5 Kirchplatz,,,Pfaffenhausen,Bayern,87772,Germany,+49 8265 7022,http://www.storchenbraeu.de,10.4552377,48.12041079999999
-62234bf8-c7c1-4d1b-929c-77fded8da80e,Stöttner,brewpub,9 Marktplatz,,,Mallersdorf-Pfaffenberg,Bayern,84066,Germany,+49 8772 96080,http://www.stoettner.de,12.2279254,48.76931039999999
-16e94bf2-0004-4691-9833-33d5262ecb26,Strauß,brewpub,19 An der Rohrach,,,Treuchtlingen,Bayern,91757,Germany,+49 9142 8389,http://www.wettelsheimer-bier.de,10.88626,48.98164
-4b3379b0-25b1-480b-959e-f560e8fb6325,Streck,brewpub,11 Ludwig-Jahn-Straße,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.streck-bier.de,10.2276809,50.4542921
-22d708e4-1241-4a0a-b19c-d69c6f5efec5,StreuBräu,brewpub,18 Sprottauer Straße,,,Nürnberg,Bayern,90475,Germany,+49 911 69947798,http://www.streubraeu.de,11.165589,49.414772
-b948513b-995c-4c55-902c-7db9fa8242f9,Streutaler Brauhaus,brewpub,11 Ludwig-Jahn-Straße,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.facebook.com/StreutalerBrauhaus/,10.2276809,50.4542921
-1ae5fdb2-3a90-4207-9afc-2dbe72fc92c3,Sudhang,brewpub,7 Am Südhang,,,Amberg,Bayern,92224,Germany,+49 9621 9707956,http://sudhang.de,11.8817761,49.449165
-0c46badb-a58f-4a0a-927e-3f11ac7f935d,Sudhaus Schwarzach,brewpub,12 Marktplatz,,,Schwarzach,Bayern,94374,Germany,+49 9962 90000,http://www.sudhaus-schwarzach.de,12.8105926,48.9145066
-cbc20fd1-0251-4020-924e-1450b389d4a2,Thomann,brewpub,5 Altmainstraße,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 9688300,http://www.gasthaus-thomann.de,10.9517464,50.0962857
-580a1fa3-5346-4aff-842b-73e693e9b877,Thomasbräu,brewpub,7 Hofmarkstraße,,,Tiefenbach,Bayern,94113,Germany,,http://www.facebook.com/ThomasBräu-667120813429108/,13.38913,48.64628
-90b33a29-0477-49ac-83e9-7a3bee28113f,Thorbräu,brewpub,9 Wertachbrucker-Tor-Straße,,,Augsburg,Bayern,86152,Germany,+49 821 36561,http://www.thorbraeu.de,10.8889472,48.3761372
-f448225e-1a51-405e-b08c-d7cb2994ed29,Tobiasbräu,closed,11 Ried,,,Markt Indersdorf,Bayern,85229,Germany,+49 8136 806719,http://www.tobiasbraeu.de,11.3795185,48.3411421
-bff63db9-37e1-452b-a2c2-c795d7a5b1f4,Tölzer Binderbräu,brewpub,12 Ludwigstraße,,,Bad Tölz,Bayern,83646,Germany,+49 8041 2609,http://www.toelzer-binderbraeu.de,11.5491049,47.7594822
-85272a41-90b3-4ef0-840e-dec939e747f3,Tölzer Mühlfeldbräu,brewpub,4 Bahnhofstraße,,,Bad Tölz,Bayern,83646,Germany,+49 8041 7960571,http://www.gasthaus-toelz.de,11.5667685,47.7616369
-992b7bff-6459-4ced-a004-0ddc0b9c9a0a,Trunk,brewpub,3 Vierzehnheiligen,,,Bad Staffelstein,Bayern,96231,Germany,+49 9571 3488,http://www.brauerei-trunk.de/,11.055603,50.114827
-e3319e1c-135b-4ee3-a32f-db1784b3e09c,Tucher,brewpub,10 Tucherstraße,,,Fürth,Bayern,90763,Germany,+49 911 97760,http://www.tucher.de,10.9962088,49.4417522
-aed2849c-12ba-43f8-bf74-2bd200e2c6c9,Tucher Altes Sudhaus,brewpub,4 Am Alten Sudhaus,,,Nürnberg,Bayern,90409,Germany,+49 911 37677893,http://www.tucher.de,11.0838161,49.46471649999999
-8650ec41-ff53-4921-82ee-5ac66e79c2ae,Turmbräu,brewpub,1 Spitalgasse,,,Rothenburg ob der Tauber,Bayern,91541,Germany,+49 9861 9369380,http://www.turmbraeu.com,10.180387,49.3738505
-bf109dc1-5b3b-421d-8502-7f99864ff1d0,Ulrich Martin,brewpub,5 Hausener Hauptstraße,,,Schonungen,Bayern,97453,Germany,+49 9727 403011,http://brauerei-martin.de/,10.3108329,50.0703201
-dd2fa5e9-1e73-4936-ad84-40df811d27aa,Unertl,brewpub,6 Lerchenberger Straße,,,Haag in Oberbayern,Bayern,83527,Germany,+49 8072 8297,http://www.brauerei-unertl.de,12.1873161,48.160537
-f6d56aab-551d-4f75-b9e9-137b939fd99d,Unser Dorfbräu,closed,11 Flurweg,,,Seeshaupt,Bayern,82402,Germany,,http://www.unserdorfbraeu.de,11.2862406,47.8224558
+adf47933-f19d-4cc6-a6b4-63f7ea53b069,Sigwart,closed,Roßmühle 10,,,Weißenburg in Bayern,Bayern,91781,Germany,+49 9141 85750,http://www.brauerei-sigwart.de,10.9750088,49.0312566
+9a8d18f8-5d65-47fd-9324-3117d7982d53,Simmerberger,brewpub,Ellhofer Straße 2,,,Weiler-Simmerberg,Bayern,88171,Germany,+49 8387 1016,http://www.braeustatt-simmerberg.de,9.9451787,47.5867932
+aebc095e-4ef1-470e-a19f-7d48e226f2bf,Simmseer Braumanufaktur,brewpub,Krottenhausmühlstraße 42,,,Stephanskirchen,Bayern,83071,Germany,+49 8036 9096606,http://www.simmseer.de,12.1901766,47.8500375
+d271ef30-0334-4a69-a8d3-434615b8cc33,Simon,brewpub,Heroldstraße 12,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 9123 2323,http://www.brauerei-simon.de,11.2798793,49.5153352
+399093ac-9c09-4e7c-922a-cbe76b97b40b,Sitter-Bräu,micro,Riedelsbach 12,,,Neureichenau,Bayern,94089,Germany,+49 8583 96040,http://www.gut-riedelsbach.de,13.78764,48.7502
+ee99faf4-6b45-4891-a76d-3d1cae24c0e5,Sonnen-Bräu,brewpub,Zaugendorfer Straße 4,,,Rattelsdorf,Bayern,96179,Germany,+49 9533 981017,http://www.gasthaus-schmitt.de,10.8639895,50.0612606
+e5a80737-9526-42e3-a0a2-10c3b5c3ca6c,Sonnenbräu,brewpub,Nailaer Straße 20,,,Lichtenberg,Bayern,95192,Germany,+49 9288 304,http://www.facebook.com/SB.LBG/,11.67558,50.38074599999999
+9efc5558-16e8-499c-a71f-d8814095f541,Späth-Bräu,brewpub,Pfarrweg 3,,,Lohberg,Bayern,93470,Germany,+49 9943 7799880,http://www.osser-bier.de,13.1055045,49.1746408
+1db8bb97-e0ed-4150-8c7e-1f58930526ed,Sperber-Bräu,brewpub,Rosenberger Straße 14,,,Sulzbach-Rosenberg,Bayern,92237,Germany,+49 9661 87090,http://www.sperberbraeu.de,11.7409574,49.5042589
+61a05c41-1b3f-48d6-a165-4cc99755fd92,Spessart,brewpub,Junkergasse 2,,,Kreuzwertheim,Bayern,97892,Germany,+49 9342 85700,http://www.spessart-specht.de,9.5166732,49.7633681
+28a2aec4-2003-445e-ab8c-0283be4b3840,Spezial,brewpub,Obere Königstraße 10,,,Bamberg,Bayern,96052,Germany,+49 951 24304,http://www.brauerei-spezial.de,10.8928067,49.8968596
+3b19f01c-cb46-41fd-aa66-3c634f12e6c9,Spezial-Brauerei,brewpub,Hauptstraße 15-17,,,Schierling,Bayern,84069,Germany,+49 9451 3012,http://www.schierlinger-pils.de,12.1374225,48.837841
+ed417aab-8197-42e9-8435-757dddfddbb6,Spitalbrauerei,brewpub,Am Brückenfuß 1-3,,,Regensburg,Bayern,93059,Germany,+49 941 83006155,http://www.spitalbrauerei.de,12.0959952,49.0241423
+6606c44b-dbfb-4fff-9350-f5e1cec8fed5,St. Georgen,brewpub,Marktstraße 12,,,Buttenheim,Bayern,96155,Germany,+49 9545 4460,http://www.kellerbier.de,11.032226,49.8017243
+451761d2-0b1c-46a3-9245-4ae94323d0e0,Stadelbräu,brewpub,Marktplatz 6,,,Zusmarshausen,Bayern,86441,Germany,+49 8291 880,http://www.stadel-braeu.de,10.597849,48.39946
+fcd5c594-aa40-4e24-8c84-7f290515c5fa,Stadlbräu,brewpub,Kybergstraße 19,,,Oberhaching,Bayern,82041,Germany,+49 89 95447565,http://www.bayerische-brauhaus-consulting.de,11.5913115,48.0258995
+de500343-4276-4d65-8173-04361c1b0b42,Stadtbrauerei,brewpub,Brauereigasse 3,,,Spalt,Bayern,91174,Germany,+49 9175 79610,http://www.spalter-bier.de,10.92523,49.17434
+076bf1f8-a5f2-483c-961a-9972379b6b1d,Stadter,brewpub,Hauptstraße 26,,,Aufseß,Bayern,91347,Germany,+49 9274 8193,http://www.brauerei-stadter.de,11.2354334,49.9140886
+621b3b13-1ff7-4bdb-b0fa-49e68fdf6638,Staffelberg-Bräu,brewpub,Mühlteich 7,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 5925,http://www.staffelberg-braeu.de,11.0241054,50.07883289999999
+274d2e24-a423-4f8a-a0cb-9a6f792b552e,Stallbauer,brewpub,Wiesmühl 12,,,Engelsberg,Bayern,84549,Germany,,http://www.brauerei-stallbauer.de,12.566108,48.105877
+788e1155-5d7d-41b1-88ef-0ff719ae4a1f,Stanglbräu,brewpub,Dorfstraße 11,,,Hausen,Bayern,93345,Germany,+49 9448 91830,http://www.stanglbraeu.de,11.9861373,48.8449076
+0c7cacb7-0660-48db-ae72-a03db3f5a871,Stark,brewpub,Alte Straße 4,,,Wertingen,Bayern,86637,Germany,+49 8272 2214,http://www.landgasthof-stark.de,10.6955137,48.5561409
+c2c30af5-936f-4bf3-853d-9917f215ea41,Stärker,brewpub,Brückenauer Straße 6,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.staerkerbraeu.de,9.771565299999999,50.3953363
+d50e9a12-6091-4163-a75a-fc795c64a4e8,Starnberger Brauhaus,brewpub,Alte Weilheimer Straße 3,,,Feldafing,Bayern,82340,Germany,+49 8151 446100,http://www.brauerei.bayern,11.2674236,47.9531593
+c7af7f47-0d77-44ec-884d-3ea3993cbe37,Stefansbräu,brewpub,Wilhelmshöhe 1,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 582393,http://www.dinkelbrauer.de,10.3351237,49.0763876
+935d7138-fde6-4503-8793-52528192b1ca,Steinbach Bräu,brewpub,Vierzigmannstraße 4,,,Erlangen,Bayern,91054,Germany,+49 9131 895912,http://www.steinbach-braeu.de,11.0050399,49.6029026
+937df3a6-f86d-4304-9398-5b5fc79124e1,Sterk,brewpub,Hofmark 2,,,Amberg,Bayern,92224,Germany,+49 9621 914323,http://www.brauerei-sterk.de,11.8962189,49.45828059999999
+adc55e01-81d5-40fa-838d-dc199a38d45c,Stern-Bräu,brewpub,Weinberg 1,,,Schlüsselfeld,Bayern,96132,Germany,+49 9552 320,http://www.brauerei-scheubel.de,10.6194738,49.7615938
+2f33bde0-06ba-44c6-a093-404c9a86ddee,Stiagnbräu,brewpub,Ottersried 22A,,,Rohrbach,Bayern,85296,Germany,+49 8442 7596,http://m.facebook.com/pages/Stiangbr%C3%A4u-Undaschria/180559465331490,11.5395656,48.6172608
+0ab02914-918f-4a48-a4d9-8aa85b1f24a4,Stierberg,brewpub,Stierberg 12,,,Obertaufkirchen,Bayern,84419,Germany,+49 8082 1851,http://www.brauerei-stierberg.de,12.2831909,48.2433528
+62077fcf-2f26-4f80-8654-c03f10c4d0a5,Stöckel,brewpub,Hintergereuth 4,,,Ahorntal,Bayern,95491,Germany,+49 9246 275,http://www.stoeckel-braeu.de,11.45417,49.85093999999999
+b4e37ba7-8c36-4073-90c6-cbcd93a24368,Storchenbräu,brewpub,Kirchplatz 5,,,Pfaffenhausen,Bayern,87772,Germany,+49 8265 7022,http://www.storchenbraeu.de,10.4552377,48.12041079999999
+62234bf8-c7c1-4d1b-929c-77fded8da80e,Stöttner,brewpub,Marktplatz 9,,,Mallersdorf-Pfaffenberg,Bayern,84066,Germany,+49 8772 96080,http://www.stoettner.de,12.2279254,48.76931039999999
+16e94bf2-0004-4691-9833-33d5262ecb26,Strauß,brewpub,An der Rohrach 19,,,Treuchtlingen,Bayern,91757,Germany,+49 9142 8389,http://www.wettelsheimer-bier.de,10.88626,48.98164
+4b3379b0-25b1-480b-959e-f560e8fb6325,Streck,brewpub,Ludwig-Jahn-Straße 11,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.streck-bier.de,10.2276809,50.4542921
+22d708e4-1241-4a0a-b19c-d69c6f5efec5,StreuBräu,brewpub,Sprottauer Straße 18,,,Nürnberg,Bayern,90475,Germany,+49 911 69947798,http://www.streubraeu.de,11.165589,49.414772
+b948513b-995c-4c55-902c-7db9fa8242f9,Streutaler Brauhaus,brewpub,Ludwig-Jahn-Straße 11,,,Ostheim vor der Rhön,Bayern,97645,Germany,+49 9777 9265,http://www.facebook.com/StreutalerBrauhaus/,10.2276809,50.4542921
+1ae5fdb2-3a90-4207-9afc-2dbe72fc92c3,Sudhang,brewpub,Am Südhang 7,,,Amberg,Bayern,92224,Germany,+49 9621 9707956,http://sudhang.de,11.8817761,49.449165
+0c46badb-a58f-4a0a-927e-3f11ac7f935d,Sudhaus Schwarzach,brewpub,Marktplatz 12,,,Schwarzach,Bayern,94374,Germany,+49 9962 90000,http://www.sudhaus-schwarzach.de,12.8105926,48.9145066
+cbc20fd1-0251-4020-924e-1450b389d4a2,Thomann,brewpub,Altmainstraße 5,,,Bad Staffelstein,Bayern,96231,Germany,+49 9573 9688300,http://www.gasthaus-thomann.de,10.9517464,50.0962857
+580a1fa3-5346-4aff-842b-73e693e9b877,Thomasbräu,brewpub,Hofmarkstraße 7,,,Tiefenbach,Bayern,94113,Germany,,http://www.facebook.com/ThomasBräu-667120813429108/,13.38913,48.64628
+90b33a29-0477-49ac-83e9-7a3bee28113f,Thorbräu,brewpub,Wertachbrucker-Tor-Straße 9,,,Augsburg,Bayern,86152,Germany,+49 821 36561,http://www.thorbraeu.de,10.8889472,48.3761372
+f448225e-1a51-405e-b08c-d7cb2994ed29,Tobiasbräu,closed,Ried 11,,,Markt Indersdorf,Bayern,85229,Germany,+49 8136 806719,http://www.tobiasbraeu.de,11.3795185,48.3411421
+bff63db9-37e1-452b-a2c2-c795d7a5b1f4,Tölzer Binderbräu,brewpub,Ludwigstraße 12,,,Bad Tölz,Bayern,83646,Germany,+49 8041 2609,http://www.toelzer-binderbraeu.de,11.5491049,47.7594822
+85272a41-90b3-4ef0-840e-dec939e747f3,Tölzer Mühlfeldbräu,brewpub,Bahnhofstraße 4,,,Bad Tölz,Bayern,83646,Germany,+49 8041 7960571,http://www.gasthaus-toelz.de,11.5667685,47.7616369
+992b7bff-6459-4ced-a004-0ddc0b9c9a0a,Trunk,brewpub,Vierzehnheiligen 3,,,Bad Staffelstein,Bayern,96231,Germany,+49 9571 3488,http://www.brauerei-trunk.de/,11.055603,50.114827
+e3319e1c-135b-4ee3-a32f-db1784b3e09c,Tucher,brewpub,Tucherstraße 10,,,Fürth,Bayern,90763,Germany,+49 911 97760,http://www.tucher.de,10.9962088,49.4417522
+aed2849c-12ba-43f8-bf74-2bd200e2c6c9,Tucher Altes Sudhaus,brewpub,Am Alten Sudhaus 4,,,Nürnberg,Bayern,90409,Germany,+49 911 37677893,http://www.tucher.de,11.0838161,49.46471649999999
+8650ec41-ff53-4921-82ee-5ac66e79c2ae,Turmbräu,brewpub,Spitalgasse 1,,,Rothenburg ob der Tauber,Bayern,91541,Germany,+49 9861 9369380,http://www.turmbraeu.com,10.180387,49.3738505
+bf109dc1-5b3b-421d-8502-7f99864ff1d0,Ulrich Martin,brewpub,Hausener Hauptstraße 5,,,Schonungen,Bayern,97453,Germany,+49 9727 403011,http://brauerei-martin.de/,10.3108329,50.0703201
+dd2fa5e9-1e73-4936-ad84-40df811d27aa,Unertl,brewpub,Lerchenberger Straße 6,,,Haag in Oberbayern,Bayern,83527,Germany,+49 8072 8297,http://www.brauerei-unertl.de,12.1873161,48.160537
+f6d56aab-551d-4f75-b9e9-137b939fd99d,Unser Dorfbräu,closed,Flurweg 11,,,Seeshaupt,Bayern,82402,Germany,,http://www.unserdorfbraeu.de,11.2862406,47.8224558
 d154e939-3768-4b15-92f4-8200dd5710f6,Urban Chestnut,micro,Am-Brunnen 2,,,Wolnzach,Bayern,85283,Germany,,http://www.urbanchestnut.de,,
-77dfbb87-1c56-41a5-af5e-e3121d86ce2a,Urbanus,brewpub,4 Hauptplatz,,,Pfaffenhofen an der Ilm,Bayern,85276,Germany,+49 8441 5043080,http://www.brauhaus-pfaffenhofen.de,11.5085205,48.5299551
-ce5be9d0-82c8-4703-afcc-07fba127f906,Ustersbacher,brewpub,40 Hauptstraße,,,Ustersbach,Bayern,86514,Germany,+49 8236 5890,http://www.ustersbacher.com,10.6410466,48.3157091
-1d152f70-2cf4-4810-88d5-2d5e313e8ecf,Valleyer Schloss Bräu,brewpub,19 Graf-Arco-Straße,,,Valley,Bayern,83626,Germany,+49 8024 4772410,http://www.valleyer.de,11.778997,47.89305650000001
-df9cd7d4-481f-4944-a186-36e3bbccb3be,Vasold & Schmitt,brewpub,3 Schellenberger Weg,,,Neunkirchen am Brand,Bayern,91077,Germany,+49 9134 99410,,11.1359711,49.6115161
-7afafa55-b7fc-463e-95be-84e799b07d36,Wagner,brewpub,1 Pointstraße,,,Memmelsdorf,Bayern,96117,Germany,+49 9542 620,http://www.wagner-merkendorf.de,10.9565339,49.95844169999999
-49b8af9f-90c4-4545-add6-7f5b2091562b,Wagner-Bräu,brewpub,15 Hauptstraße,,,Kemmern,Bayern,96164,Germany,+49 9544 812300,http://www.brauerei-wagner.de,10.8748544,49.9534724
-5553b9b5-e765-4933-a1fa-e9f2d211c4eb,Wald Bräu,brewpub,3 Bräustraße,,,Garching an der Alz,Bayern,84518,Germany,+49 8634 66529,http://www.berghof-babel.de,12.5952974,48.1270861
-4c5efff6-0604-4edd-8139-2a7da8e54dea,Waldschatz Bräu,closed,29 Am Wiesenweg,,,Hausen bei Würzburg,Bayern,97262,Germany,,http://www.ines-beerstore.de,10.0026226,49.913917
-720e3359-ef7c-452d-b91b-6cbde60e1489,Waldschloss-Bräu,brewpub,103 Orber Straße,,,Frammersbach,Bayern,97833,Germany,+49 9355 97340,http://www.waldschloss-brauerei.de,9.4623087,50.0759811
-80a6c1a9-f183-46a8-be05-1844846ab6db,Wasserburger,brewpub,8 Kreuzstraße,,,Dingolfing,Bayern,84130,Germany,+49 8731 3943155,http://www.brauerei-wasserburger.de,12.49159,48.64281
-36dda269-7fcd-4e59-bccc-a939d202939d,Weib's Brauhaus,brewpub,13 Untere Schmiedgasse,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 579490,http://www.weibsbrauhaus.de,10.3169982,49.0702813
-c7c37a1c-8326-4295-b95d-bbb92bb29288,Weihenstephan,brewpub,2 Alte Akademie,,,Freising,Bayern,85354,Germany,+49 8161 5360,http://www.weihenstephaner.de,11.7289326,48.3952883
-742c4372-e22d-483b-ac64-ecf95e53d29d,Weißbräu,brewpub,5 Bräuhausstraße,,,Freilassing,Bayern,83395,Germany,+49 8654 9725,http://www.weissbraeu-freilassing.de,12.981048,47.84215
-068476ab-1e7b-4337-a860-fccc7105618d,Weissbräu Schwendl,brewpub,115 Schalchener Straße,,,Tacherting,Bayern,83342,Germany,+49 8621 2300,http://www.weissbraeu-schwendl.de,12.5689621,48.0576504
-837842e7-3181-499f-86cb-de11345bacfb,Wernecker,brewpub,2 Schönbornstraße,,,Werneck,Bayern,97440,Germany,+49 9722 91080,http://www.wernecker-bier.de,10.1001906,49.982206
-c356b4fa-0497-4796-9850-79b982a5bb2d,Weyermann,brewpub,17-19 Brennerstraße,,,Bamberg,Bayern,96052,Germany,+49 951 932200,http://www.weyermannmalt.com,10.897485,49.9050231
-70a30b83-9e4d-4d52-aa71-3cb65ca43491,Wichert,brewpub,50 Alte Reichsstraße,,,Lichtenfels,Bayern,96215,Germany,+49 9571 3317,http://www.brauerei-wichert.de,11.0866032,50.1527875
-f00b047d-a5bd-40ef-829a-dad3ef368090,Wieninger,brewpub,1 Poststraße,,,Teisendorf,Bayern,83317,Germany,+49 8666 8020,http://www.wieninger.de,12.8235541,47.8489054
-a78a0fca-981d-400e-a19d-11c5a903a36c,Wiethaler,brewpub,7 Welserplatz,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 9126 7651,http://brauerei-wiethaler.de,11.2299216,49.5544817
-d9482d0c-0a42-43d6-8a62-6499b3d89e9c,Wildbräu-Grandauer,brewpub,15 Rotter Straße,,,Grafing bei München,Bayern,85567,Germany,+49 8092 700912,http://www.wildbraeu.de,11.9722078,48.04691709999999
-ba11a59a-edfd-43ae-8b6b-af42ba120452,Will,brewpub,19 Schederndorf,,,Stadelhofen,Bayern,96187,Germany,+49 9504 262,http://www.schederndorf.de,11.15415,50.00572
-3fdf3ed5-013d-4437-ab8d-0e0b4adf9cff,Will Bräu,brewpub,6 Brückenauer Straße,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.will-braeu.de,9.771565299999999,50.3953363
-958c8564-7028-4c8c-aac4-f9d4175f1942,Wimmer,brewpub,1 Bräuberg,,,Bruckberg,Bayern,84079,Germany,+49 8765 206,http://www.brauerei-wimmer.de,11.9931769,48.522782
-05fa1713-381e-4e45-b3d5-a423bbbe7086,Windsheimer,brewpub,12 Metzgergasse,,,Bad Windsheim,Bayern,91438,Germany,+49 9841 66620,http://www.brauerei-windsheimer.de,10.4205815,49.50208079999999
-4f0e79e7-3e99-4633-a858-1b08d1b3df0b,Winkler,brewpub,6 Schanzgäßchen,,,Amberg,Bayern,92224,Germany,+49 9621 784880,http://www.brauerei-winkler.de,11.8624258,49.4459554
-827e32a8-4626-4a75-96c9-e3212b6a1f36,Wittelsbacher Turm-Bräu,brewpub,1 Wittelsbacher Turm,,,Bad Kissingen,Bayern,97688,Germany,+49 971 7858820,http://www.wittelsbacher-turm.de,10.075536,50.162727
-4e22c173-d9a9-4692-a739-ffc15118dfed,Wittmann,brewpub,12 Bachstraße,,,Landshut,Bayern,84036,Germany,+49 871 943060,http://www.brauerei-wittmann.de,12.140248,48.5258079
-14e38d0f-9344-4264-9cfc-bbe6b598f353,Witzgall,brewpub,17 Schlammersdorfer Straße,,,Hallerndorf,Bayern,91352,Germany,+49 9545 7452,,11.0054479,49.7691524
-a4684f47-c636-4cbd-b35d-cc4580bec5a9,Wochinger-Bräu,brewpub,4 St.-Oswald-Straße,,,Traunstein,Bayern,83278,Germany,+49 861 3045,http://www.wochingerbraeu.de,12.6428822,47.8656088
-2a08c71b-780c-4918-b038-9948292ea7b3,Wolf,brewpub,7 Paul-Gerhardt-Platz,,,Rüdenhausen,Bayern,97355,Germany,+49 9383 440,https://wolfruedenhausen.wixsite.com/gasthofbrauereiwolf,10.34325,49.76430999999999
-9e2e3054-8d35-47f4-a7b3-3a5f88796a88,Wolferstetter,brewpub,26 Bürg,,,Vilshofen an der Donau,Bayern,94474,Germany,+49 8541 5880,http://www.wolferstetter-brauerei.de,13.1861543,48.633648
-a3174317-9a31-4518-81f1-5497402edca2,Wolframstub'n,brewpub,10 Hauptstraße,,,Windischeschenbach,Bayern,92670,Germany,+49 9681 1241,http://www.zoiglbrauerei.de,12.1552348,49.80205110000001
-1ad150bb-839e-4d8d-93e9-62cd42c73d4d,Wolfshöher,brewpub,3 Wolfshöhe,,,Neunkirchen am Sand,Bayern,91233,Germany,+49 9153 4040,http://www.wolfshoeher.de,11.3267471,49.5447072
-44fe880a-f60d-41c7-b2c9-68886d1a9317,Wurm,brewpub,2 Hutgasse,,,Pappenheim,Bayern,91788,Germany,+49 9143 837950,,11.03585,48.92842
-f660ccc0-46ec-4cc2-8237-cea30c771c86,Würth,closed,7 Bahnhofstraße,,,Windischeschenbach,Bayern,92670,Germany,+49 9681 1220,http://www.brauerei-wuerth.de,12.1594352,49.7980848
-f099ad53-4684-42f2-afdd-ca5433531916,Würzburger Hofbräu,brewpub,28 Höchberger Straße,,,Würzburg,Bayern,97082,Germany,+49 931 41090,http://www.wuerzburger-hofbraeu.de,9.9144208,49.79181029999999
-6195336c-869a-43c9-acf1-5695a01d55a5,Zehendner,brewpub,18 Mönchsambach,,,Burgebrach,Bayern,96138,Germany,+49 9546 380,http://www.moenchsambacher.de,10.6777805,49.8190061
-db9bf38b-dab2-4bd5-a486-b2f09cacebfe,Ziegler Bräu,brewpub,22 Scharfstraße,,,Mainburg,Bayern,84048,Germany,+49 8751 1470,http://www.ziegler-braeu-mainburg.de,11.7890128,48.6418755
-1eeee782-b08a-49f8-8cb1-6c68e89cf690,Zirndorfer,brewpub,8-10 Rote Straße,,,Zirndorf,Bayern,90513,Germany,+49 911 48068357,http://www.zirndorfer.de,10.9552309,49.44285259999999
-84898092-d89f-4fda-8a0c-2838581b60c9,Zombräu,brewpub,19 Obere Sendlbachstraße,,,Essenbach,Bayern,84051,Germany,+49 8703 4658592,http://www.zombraeu.com,12.1874434,48.6155285
-a0ef1dec-6aed-416c-b46a-41d2166159db,Zötler,brewpub,2 Grüntenstraße,,,Rettenberg,Bayern,87549,Germany,+49 8327 9210,http://www.zoetler.de,10.2999638,47.5756712
-1ac7bc36-378a-451f-87bd-971c96cc26fd,Zum Goldenen Adler,brewpub,10/12 Am Marktplatz,,,Rattelsdorf,Bayern,96179,Germany,+49 9533 982200,http://www.goldener-adler.info/,10.8631718,50.0621264
-b22e0efc-4baf-414d-abef-32e5729d9b47,Zum Goldenen Löwen,brewpub,18 Alte Regensburger Straße,,,Kallmünz,Bayern,93183,Germany,+49 1512 3357186,http://www.luber-kallmuenz.de,11.9575031,49.159893
-00ce4330-269e-4f55-8b21-c749da07ba93,Zum Gründla,brewpub,5 Am Gründlein,,,Kulmbach,Bayern,95326,Germany,+49 9221 823884,http://www.wirtshauszumgründla.de,11.4377778,50.1194444
-2c114f50-c545-46ae-8f26-003cb6a032eb,Zur Sonne,brewpub,2 Regnitzstraße,,,Bischberg,Bayern,96120,Germany,+49 951 62571,http://www.sonnenbier.de,10.8322288,49.9108712
-734d8f3c-0d1c-45d1-842e-b75182551a1c,Zwanzger,brewpub,10 Burghaslacher Straße,,,Uehlfeld,Bayern,91486,Germany,+49 9163 959756,http://www.brauerei-gasthof-zwanzger.de,10.72178,49.67171
+77dfbb87-1c56-41a5-af5e-e3121d86ce2a,Urbanus,brewpub,Hauptplatz 4,,,Pfaffenhofen an der Ilm,Bayern,85276,Germany,+49 8441 5043080,http://www.brauhaus-pfaffenhofen.de,11.5085205,48.5299551
+ce5be9d0-82c8-4703-afcc-07fba127f906,Ustersbacher,brewpub,Hauptstraße 40,,,Ustersbach,Bayern,86514,Germany,+49 8236 5890,http://www.ustersbacher.com,10.6410466,48.3157091
+1d152f70-2cf4-4810-88d5-2d5e313e8ecf,Valleyer Schloss Bräu,brewpub,Graf-Arco-Straße 19,,,Valley,Bayern,83626,Germany,+49 8024 4772410,http://www.valleyer.de,11.778997,47.89305650000001
+df9cd7d4-481f-4944-a186-36e3bbccb3be,Vasold & Schmitt,brewpub,Schellenberger Weg 3,,,Neunkirchen am Brand,Bayern,91077,Germany,+49 9134 99410,,11.1359711,49.6115161
+7afafa55-b7fc-463e-95be-84e799b07d36,Wagner,brewpub,Pointstraße 1,,,Memmelsdorf,Bayern,96117,Germany,+49 9542 620,http://www.wagner-merkendorf.de,10.9565339,49.95844169999999
+49b8af9f-90c4-4545-add6-7f5b2091562b,Wagner-Bräu,brewpub,Hauptstraße 15,,,Kemmern,Bayern,96164,Germany,+49 9544 812300,http://www.brauerei-wagner.de,10.8748544,49.9534724
+5553b9b5-e765-4933-a1fa-e9f2d211c4eb,Wald Bräu,brewpub,Bräustraße 3,,,Garching an der Alz,Bayern,84518,Germany,+49 8634 66529,http://www.berghof-babel.de,12.5952974,48.1270861
+4c5efff6-0604-4edd-8139-2a7da8e54dea,Waldschatz Bräu,closed,Am Wiesenweg 29,,,Hausen bei Würzburg,Bayern,97262,Germany,,http://www.ines-beerstore.de,10.0026226,49.913917
+720e3359-ef7c-452d-b91b-6cbde60e1489,Waldschloss-Bräu,brewpub,Orber Straße 103,,,Frammersbach,Bayern,97833,Germany,+49 9355 97340,http://www.waldschloss-brauerei.de,9.4623087,50.0759811
+80a6c1a9-f183-46a8-be05-1844846ab6db,Wasserburger,brewpub,Kreuzstraße 8,,,Dingolfing,Bayern,84130,Germany,+49 8731 3943155,http://www.brauerei-wasserburger.de,12.49159,48.64281
+36dda269-7fcd-4e59-bccc-a939d202939d,Weib's Brauhaus,brewpub,Untere Schmiedgasse 13,,,Dinkelsbühl,Bayern,91550,Germany,+49 9851 579490,http://www.weibsbrauhaus.de,10.3169982,49.0702813
+c7c37a1c-8326-4295-b95d-bbb92bb29288,Weihenstephan,brewpub,Alte Akademie 2,,,Freising,Bayern,85354,Germany,+49 8161 5360,http://www.weihenstephaner.de,11.7289326,48.3952883
+742c4372-e22d-483b-ac64-ecf95e53d29d,Weißbräu,brewpub,Bräuhausstraße 5,,,Freilassing,Bayern,83395,Germany,+49 8654 9725,http://www.weissbraeu-freilassing.de,12.981048,47.84215
+068476ab-1e7b-4337-a860-fccc7105618d,Weissbräu Schwendl,brewpub,Schalchener Straße 115,,,Tacherting,Bayern,83342,Germany,+49 8621 2300,http://www.weissbraeu-schwendl.de,12.5689621,48.0576504
+837842e7-3181-499f-86cb-de11345bacfb,Wernecker,brewpub,Schönbornstraße 2,,,Werneck,Bayern,97440,Germany,+49 9722 91080,http://www.wernecker-bier.de,10.1001906,49.982206
+c356b4fa-0497-4796-9850-79b982a5bb2d,Weyermann,brewpub,Brennerstraße 17-19,,,Bamberg,Bayern,96052,Germany,+49 951 932200,http://www.weyermannmalt.com,10.897485,49.9050231
+70a30b83-9e4d-4d52-aa71-3cb65ca43491,Wichert,brewpub,Alte Reichsstraße 50,,,Lichtenfels,Bayern,96215,Germany,+49 9571 3317,http://www.brauerei-wichert.de,11.0866032,50.1527875
+f00b047d-a5bd-40ef-829a-dad3ef368090,Wieninger,brewpub,Poststraße 1,,,Teisendorf,Bayern,83317,Germany,+49 8666 8020,http://www.wieninger.de,12.8235541,47.8489054
+a78a0fca-981d-400e-a19d-11c5a903a36c,Wiethaler,brewpub,Welserplatz 7,,,Lauf an der Pegnitz,Bayern,91207,Germany,+49 9126 7651,http://brauerei-wiethaler.de,11.2299216,49.5544817
+d9482d0c-0a42-43d6-8a62-6499b3d89e9c,Wildbräu-Grandauer,brewpub,Rotter Straße 15,,,Grafing bei München,Bayern,85567,Germany,+49 8092 700912,http://www.wildbraeu.de,11.9722078,48.04691709999999
+ba11a59a-edfd-43ae-8b6b-af42ba120452,Will,brewpub,Schederndorf 19,,,Stadelhofen,Bayern,96187,Germany,+49 9504 262,http://www.schederndorf.de,11.15415,50.00572
+3fdf3ed5-013d-4437-ab8d-0e0b4adf9cff,Will Bräu,brewpub,Brückenauer Straße 6,,,Motten,Bayern,97786,Germany,+49 9748 710,http://www.will-braeu.de,9.771565299999999,50.3953363
+958c8564-7028-4c8c-aac4-f9d4175f1942,Wimmer,brewpub,Bräuberg 1,,,Bruckberg,Bayern,84079,Germany,+49 8765 206,http://www.brauerei-wimmer.de,11.9931769,48.522782
+05fa1713-381e-4e45-b3d5-a423bbbe7086,Windsheimer,brewpub,Metzgergasse 12,,,Bad Windsheim,Bayern,91438,Germany,+49 9841 66620,http://www.brauerei-windsheimer.de,10.4205815,49.50208079999999
+4f0e79e7-3e99-4633-a858-1b08d1b3df0b,Winkler,brewpub,Schanzgäßchen 6,,,Amberg,Bayern,92224,Germany,+49 9621 784880,http://www.brauerei-winkler.de,11.8624258,49.4459554
+827e32a8-4626-4a75-96c9-e3212b6a1f36,Wittelsbacher Turm-Bräu,brewpub,Wittelsbacher Turm 1,,,Bad Kissingen,Bayern,97688,Germany,+49 971 7858820,http://www.wittelsbacher-turm.de,10.075536,50.162727
+4e22c173-d9a9-4692-a739-ffc15118dfed,Wittmann,brewpub,Bachstraße 12,,,Landshut,Bayern,84036,Germany,+49 871 943060,http://www.brauerei-wittmann.de,12.140248,48.5258079
+14e38d0f-9344-4264-9cfc-bbe6b598f353,Witzgall,brewpub,Schlammersdorfer Straße 17,,,Hallerndorf,Bayern,91352,Germany,+49 9545 7452,,11.0054479,49.7691524
+a4684f47-c636-4cbd-b35d-cc4580bec5a9,Wochinger-Bräu,brewpub,St.-Oswald-Straße 4,,,Traunstein,Bayern,83278,Germany,+49 861 3045,http://www.wochingerbraeu.de,12.6428822,47.8656088
+2a08c71b-780c-4918-b038-9948292ea7b3,Wolf,brewpub,Paul-Gerhardt-Platz 7,,,Rüdenhausen,Bayern,97355,Germany,+49 9383 440,https://wolfruedenhausen.wixsite.com/gasthofbrauereiwolf,10.34325,49.76430999999999
+9e2e3054-8d35-47f4-a7b3-3a5f88796a88,Wolferstetter,brewpub,Bürg 26,,,Vilshofen an der Donau,Bayern,94474,Germany,+49 8541 5880,http://www.wolferstetter-brauerei.de,13.1861543,48.633648
+a3174317-9a31-4518-81f1-5497402edca2,Wolframstub'n,brewpub,Hauptstraße 10,,,Windischeschenbach,Bayern,92670,Germany,+49 9681 1241,http://www.zoiglbrauerei.de,12.1552348,49.80205110000001
+1ad150bb-839e-4d8d-93e9-62cd42c73d4d,Wolfshöher,brewpub,Wolfshöhe 3,,,Neunkirchen am Sand,Bayern,91233,Germany,+49 9153 4040,http://www.wolfshoeher.de,11.3267471,49.5447072
+44fe880a-f60d-41c7-b2c9-68886d1a9317,Wurm,brewpub,Hutgasse 2,,,Pappenheim,Bayern,91788,Germany,+49 9143 837950,,11.03585,48.92842
+f660ccc0-46ec-4cc2-8237-cea30c771c86,Würth,closed,Bahnhofstraße 7,,,Windischeschenbach,Bayern,92670,Germany,+49 9681 1220,http://www.brauerei-wuerth.de,12.1594352,49.7980848
+f099ad53-4684-42f2-afdd-ca5433531916,Würzburger Hofbräu,brewpub,Höchberger Straße 28,,,Würzburg,Bayern,97082,Germany,+49 931 41090,http://www.wuerzburger-hofbraeu.de,9.9144208,49.79181029999999
+6195336c-869a-43c9-acf1-5695a01d55a5,Zehendner,brewpub,Mönchsambach 18,,,Burgebrach,Bayern,96138,Germany,+49 9546 380,http://www.moenchsambacher.de,10.6777805,49.8190061
+db9bf38b-dab2-4bd5-a486-b2f09cacebfe,Ziegler Bräu,brewpub,Scharfstraße 22,,,Mainburg,Bayern,84048,Germany,+49 8751 1470,http://www.ziegler-braeu-mainburg.de,11.7890128,48.6418755
+1eeee782-b08a-49f8-8cb1-6c68e89cf690,Zirndorfer,brewpub,Rote Straße 8-10,,,Zirndorf,Bayern,90513,Germany,+49 911 48068357,http://www.zirndorfer.de,10.9552309,49.44285259999999
+84898092-d89f-4fda-8a0c-2838581b60c9,Zombräu,brewpub,Obere Sendlbachstraße 19,,,Essenbach,Bayern,84051,Germany,+49 8703 4658592,http://www.zombraeu.com,12.1874434,48.6155285
+a0ef1dec-6aed-416c-b46a-41d2166159db,Zötler,brewpub,Grüntenstraße 2,,,Rettenberg,Bayern,87549,Germany,+49 8327 9210,http://www.zoetler.de,10.2999638,47.5756712
+1ac7bc36-378a-451f-87bd-971c96cc26fd,Zum Goldenen Adler,brewpub,Am Marktplatz 10/12,,,Rattelsdorf,Bayern,96179,Germany,+49 9533 982200,http://www.goldener-adler.info/,10.8631718,50.0621264
+b22e0efc-4baf-414d-abef-32e5729d9b47,Zum Goldenen Löwen,brewpub,Alte Regensburger Straße 18,,,Kallmünz,Bayern,93183,Germany,+49 1512 3357186,http://www.luber-kallmuenz.de,11.9575031,49.159893
+00ce4330-269e-4f55-8b21-c749da07ba93,Zum Gründla,brewpub,Am Gründlein 5,,,Kulmbach,Bayern,95326,Germany,+49 9221 823884,http://www.wirtshauszumgründla.de,11.4377778,50.1194444
+2c114f50-c545-46ae-8f26-003cb6a032eb,Zur Sonne,brewpub,Regnitzstraße 2,,,Bischberg,Bayern,96120,Germany,+49 951 62571,http://www.sonnenbier.de,10.8322288,49.9108712
+734d8f3c-0d1c-45d1-842e-b75182551a1c,Zwanzger,brewpub,Burghaslacher Straße 10,,,Uehlfeld,Bayern,91486,Germany,+49 9163 959756,http://www.brauerei-gasthof-zwanzger.de,10.72178,49.67171

--- a/data/germany/bayern.csv
+++ b/data/germany/bayern.csv
@@ -327,7 +327,7 @@ e0a2a6c4-3c7f-436e-a532-642674fcfb41,Knoblach,brewpub,1 Kremmeldorfer Straße,,,
 c5195e07-5f1b-4b08-b676-af33c4f80e88,König von Flandern,brewpub,25 Maximilianstraße,,,Augsburg,Bayern,86150,Germany,+49 821 20709818,http://www.koenigvonflandern.de,10.8985536,48.36745730000001
 00157704-9821-43e7-9ed9-7fbe58f040f6,Kössel-Bräu,brewpub,17 Mariahilfer Straße,,,Eisenberg,Bayern,87637,Germany,+49 8364 8556,http://www.koessel-braeu.de,10.6128103,47.6103922
 dd2b8448-8b93-4ca3-bb10-ee3fd9c48ec2,Kraus,brewpub,11 Luitpoldstraße,,,Hirschaid,Bayern,96114,Germany,+49 9543 84440,http://www.brauerei-kraus.de,10.987145,49.8158179
-13a9865e-335a-4a3d-a23d-acc4547e44fb,Kreisheimatstube,micro,Schwaninger-Strasse 18,,,Ellzee,Bayern,89352,Germany,,,10.2945984,48.3164598
+13a9865e-335a-4a3d-a23d-acc4547e44fb,Kreisheimatstube,micro,Schwaninger-Straße 18,,,Ellzee,Bayern,89352,Germany,,,10.2945984,48.3164598
 0da08afd-c3f2-4812-a421-7694b66ef1b1,Krieger,brewpub,6 Oberer Stadtplatz,,,Landau an der Isar,Bayern,94405,Germany,+49 9951 6049144,http://www.brauerei-krieger.de,12.6908333,48.6697222
 bf09f033-65db-4428-a3ce-fd84bf7aad38,Kronburger,brewpub,21 Hauptstraße,,,Kronburg,Bayern,87758,Germany,+49 8394 237,http://www.brauerei-kronburg.de,10.15767,47.90434
 b8c30da4-fe68-4063-9a9a-8ae9f9274032,Kronprinz,brewpub,109 Gaustadter Hauptstraße,,,Bamberg,Bayern,96049,Germany,+49 951 96430514,http://www.kronprinz.beer,10.8649128,49.9026341
@@ -415,7 +415,7 @@ f37cc38c-7b26-4fc3-9fb3-0487fcdbf75d,Pfarrbräu,brewpub,8 Am Dorfplatz,,,Karlsta
 c0e4b43e-88ad-4790-ba4e-c4ca09cf4cd9,Pflüglerbräu,brewpub,24 Grünecker Straße,,,Neufahrn bei Freising,Bayern,85375,Germany,+49 176 21521678,http://www.pflueglerbraeu.de,11.6794669,48.3146644
 c26f1bd2-102e-4f41-9243-ba720a282837,Pillmeier Bräu,brewpub,28 Rottenburger Straße,,,Langquaid,Bayern,84085,Germany,+49 179 9079111,http://www.pillmeier-braeu.jimdo.com,12.0487966,48.819107
 3bcf6ddd-a2fe-4c24-bcc3-773ad398cf55,Plank,brewpub,1 Marktplatz,,,Laaber,Bayern,93164,Germany,+49 9498 8707,http://www.brauerei-plank.de,11.8860761,49.06519309999999
-e0346ca0-ae8b-466c-bb2f-49c6a4d43d58,Plötz Bräu 2,brewpub,Bachstr. 10,,,Peißenberg,Bayern,82380,Germany,,http://www.imbierium.de,11.0756776,47.80558550000001
+e0346ca0-ae8b-466c-bb2f-49c6a4d43d58,Plötz Bräu 2,brewpub,Bachstraße 10,,,Peißenberg,Bayern,82380,Germany,,http://www.imbierium.de,11.0756776,47.80558550000001
 5c8c925d-0d35-4782-a820-0c133da7407b,Pöllinger,brewpub,65 Moosburger Straße,,,Pfeffenhausen,Bayern,84076,Germany,+49 8782 96060,http://www.brauerei-poellinger.de,11.9654149,48.6577919
 1eb5a213-7eeb-4ebb-bec0-ef26d1c39bf7,Post,brewpub,10 Herrenstraße,,,Bad Kötzting,Bayern,93444,Germany,+49 9941 6628,http://www.posthotel-bad-koetzting.de,12.8562707,49.1748354
 8df40fcc-acd8-4a93-8db2-ee9e5d8d1431,Postbräu,brewpub,4 Schreieggstraße,,,Thannhausen,Bayern,86470,Germany,+49 8281 9050,,10.4730013,48.2830028

--- a/data/germany/berlin.csv
+++ b/data/germany/berlin.csv
@@ -1,5 +1,5 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-5e69d342-1efc-469e-bf8b-22d276c6d863,Berlin Craft Beer Experience,bar,Reichenberger Str. 176,,,Berlin,Berlin,10999,Germany,4915779216971,http://www.berlincraftbeerexperience.com/,13.4168836,52.4995161
+5e69d342-1efc-469e-bf8b-22d276c6d863,Berlin Craft Beer Experience,bar,Reichenberger Straße 176,,,Berlin,Berlin,10999,Germany,4915779216971,http://www.berlincraftbeerexperience.com/,13.4168836,52.4995161
 75a67b02-da04-4f9e-8cee-9381d152d17a,Berliner Berg Brauerei,brewpub,39 Treptower Straße,,,Berlin,Berlin,12059,Germany,+49 30 64435906,http://www.berlinerberg.com,13.4580395,52.4847416
 3b109373-3e38-4737-82d9-9ae954127df4,Berliner-Kindl-Schultheiss,brewpub,66-69 Indira-Gandhi-Straße,,,Berlin,Berlin,13053,Germany,+49 30 96090,http://www.schultheiss.de,13.469868,52.5425763
 74390e45-23b3-4989-baa9-21de59ebeeb8,Bierfabrik,brewpub,13 Karl-Liebknecht-Straße,,,Berlin,Berlin,10178,Germany,+49 30 30878989,http://www.berlinerbierfabrik.com,13.4079375,52.5225596

--- a/data/germany/berlin.csv
+++ b/data/germany/berlin.csv
@@ -1,42 +1,42 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
 5e69d342-1efc-469e-bf8b-22d276c6d863,Berlin Craft Beer Experience,bar,Reichenberger Straße 176,,,Berlin,Berlin,10999,Germany,4915779216971,http://www.berlincraftbeerexperience.com/,13.4168836,52.4995161
-75a67b02-da04-4f9e-8cee-9381d152d17a,Berliner Berg Brauerei,brewpub,39 Treptower Straße,,,Berlin,Berlin,12059,Germany,+49 30 64435906,http://www.berlinerberg.com,13.4580395,52.4847416
-3b109373-3e38-4737-82d9-9ae954127df4,Berliner-Kindl-Schultheiss,brewpub,66-69 Indira-Gandhi-Straße,,,Berlin,Berlin,13053,Germany,+49 30 96090,http://www.schultheiss.de,13.469868,52.5425763
-74390e45-23b3-4989-baa9-21de59ebeeb8,Bierfabrik,brewpub,13 Karl-Liebknecht-Straße,,,Berlin,Berlin,10178,Germany,+49 30 30878989,http://www.berlinerbierfabrik.com,13.4079375,52.5225596
+75a67b02-da04-4f9e-8cee-9381d152d17a,Berliner Berg Brauerei,brewpub,Treptower Straße 39,,,Berlin,Berlin,12059,Germany,+49 30 64435906,http://www.berlinerberg.com,13.4580395,52.4847416
+3b109373-3e38-4737-82d9-9ae954127df4,Berliner-Kindl-Schultheiss,brewpub,Indira-Gandhi-Straße 66-69,,,Berlin,Berlin,13053,Germany,+49 30 96090,http://www.schultheiss.de,13.469868,52.5425763
+74390e45-23b3-4989-baa9-21de59ebeeb8,Bierfabrik,brewpub,Karl-Liebknecht-Straße 13,,,Berlin,Berlin,10178,Germany,+49 30 30878989,http://www.berlinerbierfabrik.com,13.4079375,52.5225596
 69bdb3dd-708a-430b-ac8c-5346f382f0d3,Birgit,beergarden,Schleusenufer 3,,,Berlin,Berlin,10997,Germany,491725746904,https://www.birgit.club/,13.4123414,52.5093176
-bc75414d-6c99-46a3-a41f-9ec0fcf5672d,Brauerei Heldenblut,brewpub,22/23 Wühlischstraße,,,Berlin,Berlin,10245,Germany,+49 30 29367534,http://www.brauerei-heldenblut.de,13.4606998,52.5089972
-37f2882b-7fe8-4589-9455-d8888faef9c9,Brauhaus in Spandau,brewpub,1 Neuendorfer Straße,,,Berlin,Berlin,13585,Germany,+49 30 3539070,http://www.brauhaus-spandau.de,13.2066083,52.54071829999999
-d505fb49-e3ea-4368-8aa9-82a616140550,Brauhaus Neulich,bar,20 Selchower Straße,,,Berlin,Berlin,12049,Germany,+49 30 60945646,http://www.brauhaus-neulich.de,13.4199255,52.4784257
+bc75414d-6c99-46a3-a41f-9ec0fcf5672d,Brauerei Heldenblut,brewpub,Wühlischstraße 22/23,,,Berlin,Berlin,10245,Germany,+49 30 29367534,http://www.brauerei-heldenblut.de,13.4606998,52.5089972
+37f2882b-7fe8-4589-9455-d8888faef9c9,Brauhaus in Spandau,brewpub,Neuendorfer Straße 1,,,Berlin,Berlin,13585,Germany,+49 30 3539070,http://www.brauhaus-spandau.de,13.2066083,52.54071829999999
+d505fb49-e3ea-4368-8aa9-82a616140550,Brauhaus Neulich,bar,Selchower Straße 20,,,Berlin,Berlin,12049,Germany,+49 30 60945646,http://www.brauhaus-neulich.de,13.4199255,52.4784257
 342d3dbb-40c9-41f1-b841-2e965065b009,Brewbaker,brewpub,Sickingenstraße 9,,,Berlin,Berlin,10553,Germany,,https://brewbaker.de/,13.325188,52.532636
 e58d60d7-92f7-4f8d-8a1a-6d02c25a32ee,BrewDog Berlin Mitte,bar,Ackerstraße 29,,,Berlin,Berlin,10115,Germany,493048477770,https://www.brewdog.com/eu_de/brewdog-berlin-mitte,13.395714,52.532839
-8cb10ea6-68dd-4e09-8c1f-c8eb8293975c,Brewer's Tribute,brewpub,41 Zur Alten Börse,,,Berlin,Berlin,12681,Germany,+49 30 55571267,http://www.brewerstribute.de,13.5249891,52.5159568
+8cb10ea6-68dd-4e09-8c1f-c8eb8293975c,Brewer's Tribute,brewpub,Zur Alten Börse 41,,,Berlin,Berlin,12681,Germany,+49 30 55571267,http://www.brewerstribute.de,13.5249891,52.5159568
 6bc5487a-9d12-402d-a7d1-cccb156d38ce,BRLO,brewpub,Schöneberger Straße 16,,,Berlin,Berlin,10963,Germany,+49 30 55577606,http://www.brlo.de,13.3737,52.5001966
 1fe01316-a2ee-428b-8200-ba3f054eda6d,BRLO Brwhouse,large,Schöneberger Straße 16,,,Berlin,Berlin,10963,Germany,493055577606,https://www.brlo.de/gastronomien/brlo-brwhouse,13.373742,52.500288
-a2041112-721f-47b1-8460-6a7d0c05c8b4,Circus Hostel Brewing,micro,1a Weinbergsweg,,,Berlin,Berlin,10119,Germany,+49 30 20003939,http://www.circus-berlin.de,13.4019406,52.5301079
-563eb674-ab1b-419b-8bd0-6f5446c12837,CraftZentrum,brewpub,21 Telegrafenweg,,,Berlin,Berlin,13599,Germany,+49 171 5611352,http://www.craftzentrum.berlin,13.2230956,52.5421731
-185bd0e2-2db0-4fe1-beb3-4166261a0787,Einbar,bar,185 Oranienstraße,,,Berlin,Berlin,10999,Germany,,http://www.einbarbrauerei.com,13.421101,52.500657
-47309c4b-e319-41d2-9935-a5e495fac093,Eschenbräu,brewpub,67 Triftstraße,,,Berlin,Berlin,13353,Germany,+49 162 4931915,http://www.eschenbraeu.de,13.3594853,52.5434732
-e4578ec9-9023-4527-bec0-c05252f4c5bb,Flessa Br,brewpub,39 Petersburger Straße,,,Berlin,Berlin,10249,Germany,+49 30 23409269,http://www.brauerei-flessa.de,13.4505708,52.52288129999999
-99f3cd80-7132-465c-905e-d5c8a6763f6d,Georgbræu,brewpub,4 Spreeufer,,,Berlin,Berlin,10178,Germany,+49 30 2424244,http://www.georgbraeu.de,13.4055038,52.5165548
+a2041112-721f-47b1-8460-6a7d0c05c8b4,Circus Hostel Brewing,micro,Weinbergsweg 1a,,,Berlin,Berlin,10119,Germany,+49 30 20003939,http://www.circus-berlin.de,13.4019406,52.5301079
+563eb674-ab1b-419b-8bd0-6f5446c12837,CraftZentrum,brewpub,Telegrafenweg 21,,,Berlin,Berlin,13599,Germany,+49 171 5611352,http://www.craftzentrum.berlin,13.2230956,52.5421731
+185bd0e2-2db0-4fe1-beb3-4166261a0787,Einbar,bar,Oranienstraße 185,,,Berlin,Berlin,10999,Germany,,http://www.einbarbrauerei.com,13.421101,52.500657
+47309c4b-e319-41d2-9935-a5e495fac093,Eschenbräu,brewpub,Triftstraße 67,,,Berlin,Berlin,13353,Germany,+49 162 4931915,http://www.eschenbraeu.de,13.3594853,52.5434732
+e4578ec9-9023-4527-bec0-c05252f4c5bb,Flessa Br,brewpub,Petersburger Straße 39,,,Berlin,Berlin,10249,Germany,+49 30 23409269,http://www.brauerei-flessa.de,13.4505708,52.52288129999999
+99f3cd80-7132-465c-905e-d5c8a6763f6d,Georgbræu,brewpub,Spreeufer 4,,,Berlin,Berlin,10178,Germany,+49 30 2424244,http://www.georgbraeu.de,13.4055038,52.5165548
 b3128b43-31c0-420c-b2c0-5638c97aea95,Golgatha Biergarten,beergarden,Katzbachstraße &  Monumentenstraße,,,Berlin,Berlin,10965,Germany,,http://www.golgatha-berlin.de/,13.3791632,52.4868139
-bc46d506-5022-4d24-9b97-22749987ac7d,Heidenpeters,brewpub,42-43 Eisenbahnstraße,,,Berlin,Berlin,10997,Germany,+49 176 22291688,http://www.heidenpeters.de,13.4317195,52.5019629
-d4d1aa26-1bf6-43d9-b380-cbd47109d225,Holzmarkt Brauerei,brewpub,25 Holzmarktstraße,,,Berlin,Berlin,10243,Germany,+49 30 47361686,http://www.holzmarkt-brauerei.de,13.4268548,52.51154349999999
-0e006c1d-2c67-4a9a-92c5-2777ca2cfed1,Hops & Barley,brewpub,22/23 Wühlischstraße,,,Berlin,Berlin,10245,Germany,+49 30 29367534,http://www.hopsandbarley-berlin.de,13.4606998,52.5089972
+bc46d506-5022-4d24-9b97-22749987ac7d,Heidenpeters,brewpub,Eisenbahnstraße 42-43,,,Berlin,Berlin,10997,Germany,+49 176 22291688,http://www.heidenpeters.de,13.4317195,52.5019629
+d4d1aa26-1bf6-43d9-b380-cbd47109d225,Holzmarkt Brauerei,brewpub,Holzmarktstraße 25,,,Berlin,Berlin,10243,Germany,+49 30 47361686,http://www.holzmarkt-brauerei.de,13.4268548,52.51154349999999
+0e006c1d-2c67-4a9a-92c5-2777ca2cfed1,Hops & Barley,brewpub,Wühlischstraße 22/23,,,Berlin,Berlin,10245,Germany,+49 30 29367534,http://www.hopsandbarley-berlin.de,13.4606998,52.5089972
 3798245b-7f5e-4c83-b59e-888e080a8c23,Lemke am Alex,brewpub,Dircksenstraße,,,Berlin,Berlin,10178,Germany,+49 30 24728727,http://www.lemke.berlin,13.404724,52.5232756
 221d8550-3574-4a08-810b-a5552ef4e3da,Lemke am Hackeschen Markt,brewpub,Dircksenstraße,,,Berlin,Berlin,10178,Germany,+49 30 24728727,http://www.brauhaus-lemke.com/index.php?area=1,13.404724,52.5232756
-f348510f-bc17-4e80-afe0-46a7bed357f8,Lemke am Schloß Charlottenburg,brewpub,1 Luisenplatz,,,Berlin,Berlin,10585,Germany,+49 30 30878979,http://www.brauhaus-lemke.com/index.php?area=2,13.2998062,52.5199784
-23701817-d820-414c-8bf1-3f85ea3618f8,Malz & Moritz,brewpub,162 Oranienstraße,,,Berlin,Berlin,10969,Germany,+49 30 69515911,http://www.malzundmoritz.de,13.4139938,52.5025993
-90c7f42e-76a1-4652-86e9-2f8ec0bbd063,Marcus-Bräu,brewpub,1-3 Münzstraße,,,Berlin,Berlin,10178,Germany,+49 30 2476985,http://www.brau-dein-bier.de,13.409178,52.523963
+f348510f-bc17-4e80-afe0-46a7bed357f8,Lemke am Schloß Charlottenburg,brewpub,Luisenplatz 1,,,Berlin,Berlin,10585,Germany,+49 30 30878979,http://www.brauhaus-lemke.com/index.php?area=2,13.2998062,52.5199784
+23701817-d820-414c-8bf1-3f85ea3618f8,Malz & Moritz,brewpub,Oranienstraße 162,,,Berlin,Berlin,10969,Germany,+49 30 69515911,http://www.malzundmoritz.de,13.4139938,52.5025993
+90c7f42e-76a1-4652-86e9-2f8ec0bbd063,Marcus-Bräu,brewpub,Münzstraße 1-3,,,Berlin,Berlin,10178,Germany,+49 30 2476985,http://www.brau-dein-bier.de,13.409178,52.523963
 e5d8969a-c6b8-4931-901b-0ba2222bcd63,Mikkeller Berlin,bar,Torstraße 102,,,Berlin,Berlin,10119,Germany,,https://mikkeller.com/locations/mikkeller-berlin,13.3942421,52.5285769
-53abde46-31bf-49fe-a584-d084359fcc76,Pfefferbräu,brewpub,176 Schönhauser Allee,,,Berlin,Berlin,10119,Germany,+49 30 233289800,http://www.pfefferbraeu.de,13.4118118,52.5314979
+53abde46-31bf-49fe-a584-d084359fcc76,Pfefferbräu,brewpub,Schönhauser Allee 176,,,Berlin,Berlin,10119,Germany,+49 30 233289800,http://www.pfefferbraeu.de,13.4118118,52.5314979
 53c24b39-49a6-495d-8048-4412389cb450,Prater Beer Garden,beergarden,Kastanienallee 7-9,,,Berlin,Berlin,10435,Germany,,https://www.prater-biergarten.de/,13.3942421,52.5285752
-3e86ce79-7c30-42f1-864b-630b7273943f,Privatbrauerei am Rollberg,brewpub,3 Am Sudhaus,,,Berlin,Berlin,12053,Germany,+49 30 68084577,http://rollberger.de,13.4306631,52.4794237
-fb68efad-7775-4255-8d24-efb0282ce30f,Quartier-Bier,brewpub,29 Ackerstraße,,,Berlin,Berlin,10115,Germany,+49 30 48477770,http://www.quartier-bier.com,13.395794,52.5328642
-17b44828-848a-4ec4-9815-4e0ab1e1339c,Schalander,brewpub,99 Revaler Straße,haus 9,,Berlin,Berlin,10245,Germany,,http://hausbrauerei-berlin.de/,13.456801,52.507079
-cc5b9820-d251-4c1b-a3c9-451985c08157,Schloßplatzbrauerei,brewpub,24 Grünstraße,,,Berlin,Berlin,12555,Germany,+49 176 63226876,http://www.schlossplatzbrauerei.de,13.5744228,52.44462
-d0a0ab97-6b28-4400-a02e-9681ae4dbe06,Stone,brewpub,29 Ackerstraße,,,Berlin,Berlin,10115,Germany,+49 30 48477770,http://www.berlin.stonebrewing.com,13.395794,52.5328642
-fdc00ab8-3274-4414-ac3d-f92a617a14e8,Straßenbräu,brewpub,30 Neue Bahnhofstraße,,,Berlin,Berlin,10245,Germany,+49 30 55527550,http://www.strassenbraeu.de,13.4693127,52.5055415
-17fd5d83-ff81-46ef-86b2-1282e3188c6b,Südstern,brewpub,69 Hasenheide,,,Berlin,Berlin,10967,Germany,+49 30 50945420,http://www.brauhaus-suedstern.de,13.4104848,52.4883456
-9aa71fe9-ee16-4cf0-91dd-ac6ad13d9efa,Two Fellas,brewpub,30 Mühlenstraße,,,Berlin,Berlin,13187,Germany,+49 1573 7293523,http://www.twofellas.beer,13.4091429,52.5630081
-b9ea7611-806b-46ee-a5f1-279f86bf025e,Vagabund,brewpub,16-20 Oudenarder Straße,,,Berlin,Berlin,13347,Germany,+49 30 45977635,http://www.vagabundbrauerei.de,13.359492,52.5530096
-227e68dc-0663-4943-9eed-deae60de6183,Zukunft Ostkreuz,brewpub,68 Alt-Stralau,,,Berlin,Berlin,10245,Germany,+49 176 57861079,http://www.zukunft-ostkreuz.de,13.4659139,52.4975412
+3e86ce79-7c30-42f1-864b-630b7273943f,Privatbrauerei am Rollberg,brewpub,Am Sudhaus 3,,,Berlin,Berlin,12053,Germany,+49 30 68084577,http://rollberger.de,13.4306631,52.4794237
+fb68efad-7775-4255-8d24-efb0282ce30f,Quartier-Bier,brewpub,Ackerstraße 29,,,Berlin,Berlin,10115,Germany,+49 30 48477770,http://www.quartier-bier.com,13.395794,52.5328642
+17b44828-848a-4ec4-9815-4e0ab1e1339c,Schalander,brewpub,Revaler Straße 99,haus 9,,Berlin,Berlin,10245,Germany,,http://hausbrauerei-berlin.de/,13.456801,52.507079
+cc5b9820-d251-4c1b-a3c9-451985c08157,Schloßplatzbrauerei,brewpub,Grünstraße 24,,,Berlin,Berlin,12555,Germany,+49 176 63226876,http://www.schlossplatzbrauerei.de,13.5744228,52.44462
+d0a0ab97-6b28-4400-a02e-9681ae4dbe06,Stone,brewpub,Ackerstraße 29,,,Berlin,Berlin,10115,Germany,+49 30 48477770,http://www.berlin.stonebrewing.com,13.395794,52.5328642
+fdc00ab8-3274-4414-ac3d-f92a617a14e8,Straßenbräu,brewpub,Neue Bahnhofstraße 30,,,Berlin,Berlin,10245,Germany,+49 30 55527550,http://www.strassenbraeu.de,13.4693127,52.5055415
+17fd5d83-ff81-46ef-86b2-1282e3188c6b,Südstern,brewpub,Hasenheide 69,,,Berlin,Berlin,10967,Germany,+49 30 50945420,http://www.brauhaus-suedstern.de,13.4104848,52.4883456
+9aa71fe9-ee16-4cf0-91dd-ac6ad13d9efa,Two Fellas,brewpub,Mühlenstraße 30,,,Berlin,Berlin,13187,Germany,+49 1573 7293523,http://www.twofellas.beer,13.4091429,52.5630081
+b9ea7611-806b-46ee-a5f1-279f86bf025e,Vagabund,brewpub,Oudenarder Straße 16-20,,,Berlin,Berlin,13347,Germany,+49 30 45977635,http://www.vagabundbrauerei.de,13.359492,52.5530096
+227e68dc-0663-4943-9eed-deae60de6183,Zukunft Ostkreuz,brewpub,Alt-Stralau 68,,,Berlin,Berlin,10245,Germany,+49 176 57861079,http://www.zukunft-ostkreuz.de,13.4659139,52.4975412

--- a/data/germany/brandenburg.csv
+++ b/data/germany/brandenburg.csv
@@ -1,37 +1,37 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-0e8bc17d-a0f8-4cd8-b207-eeb0fe369d01,Alte Ölmühle / Herz-Bräu,brewpub,52 Bad Wilsnacker Straße,,,Wittenberge,Brandenburg,19322,Germany,+49 3877 567994600,http://www.oelmuehle-wittenberge.de,11.7593927,52.9906349
-ee991914-5f3e-4b2e-9241-b0fa4f306fc5,Babben,brewpub,2 Brauhausgasse,,,Lübbenau/Spreewald,Brandenburg,03222,Germany,+49 3542 2126,http://www.babben-bier.de,13.9677778,51.8694444
-15925a01-78bb-45ca-b745-61f73b03778a,Barnimer Brauhaus,brewpub,4 Am Bahnhof,,,Hohenfinow,Brandenburg,16248,Germany,+49 33362 619000,http://www.barnimer-brauhaus.de,13.9280135,52.83050129999999
-ab7cfd95-d5fd-4665-b25d-54cb2a6de10f,Braumanufaktur,brewpub,102 Templiner Straße,,,Potsdam,Brandenburg,14473,Germany,+49 33209 217979,http://www.braumanufaktur.de,13.0235965,52.35940369999999
-4d5e138a-38e9-4f01-928f-69b04d47102b,Braumanufaktur Marstall Boitzenburg,brewpub,5 Templiner Straße,,,Boitzenburger Land,Brandenburg,17268,Germany,+49 39889 550005,http://www.boizenburger-bier.de,13.604319,53.2622546
-e1c28e52-395a-49f7-9535-5e2628789f11,Burgbräuhaus,brewpub,16 Bahnhofstraße,,,Bad Belzig,Brandenburg,14806,Germany,+49 33841 449933,http://www.burgbraeuhaus.de,12.587143,52.136917
-fc07fc0d-1340-40bc-a4bd-4dd40739564f,Burgwall Bräu,brewpub,54 a Lindenallee,,,Oberuckersee,Brandenburg,17291,Germany,+49 39863 7149,,13.8771315,53.18652549999999
-43fa307c-5475-42d2-b919-bb2fd3dfc63b,Erlerbnispark Paaren,brewpub,1-3 Gartenstraße,,,Schönwalde-Glien,Brandenburg,14621,Germany,+49 33230 740,http://www.erlebnispark-paaren.de,12.9816784,52.6497128
-549233f4-f90c-4acf-8fd9-e931e69015f3,Finsterwalder Brauhaus,brewpub,13 Sonnewalder Straße,,,Finsterwalde,Brandenburg,03238,Germany,+49 3531 2286,http://www.finsterwalder-brauhaus.de,13.7057146,51.6365991
-8c7bf5d0-1352-46c7-9620-19e7e1892350,Frankfurter Brauhaus,brewpub,3 Lebuser Chaussee,,,Frankfurt (Oder),Brandenburg,15234,Germany,+49 335 6610,http://www.frankfurter-brauhaus.de,14.530693,52.3647122
-6c08086f-e86d-4030-8050-be3f0c386ff8,Fürstenwalder Rathausbräu,brewpub,1 Am Markt,,,Fürstenwalde/Spree,Brandenburg,15517,Germany,+49 3361 7600841,http://www.rathausbraeu-fuerstenwalde.de,14.0635512,52.3585387
-eb396522-275a-4d1f-bb6b-5f1820d1ed26,G.Bräu,brewpub,2c Ernst-Thälmann-Straße,,,Bernau bei Berlin,Brandenburg,16321,Germany,+49 3338 768528,http://www.gbrau.com,13.6349248,52.6620675
-bfc678ca-08a1-4c4a-b334-4b16f4d877aa,Gottfried Bräu,brewpub,123 Prenzlauer Chaussee,,,Wandlitz,Brandenburg,16348,Germany,+49 172 4554235,http://www.rialto-wandlitz.de,13.4634141,52.7464482
-660dd6e2-767b-4b66-ba88-a794cfadcb3d,Hebenbräu,brewpub,143 Mötzower Landstraße,,,Brandenburg an der Havel,Brandenburg,14776,Germany,,http://www.facebook.com/Brauhausschmerzke/,12.5794799,52.4348
-8bb7a9b2-f8d9-4436-a301-e4988e5de3be,Hofbrauerei Krongut Bornstedt,brewpub,6-7 Ribbeckstraße,,,Potsdam,Brandenburg,14469,Germany,+49 331 550650,http://www.krongut-bornstedt.de,13.0302968,52.408103
-a6fb9c21-6cf6-4a13-b178-7ba7e5422c62,Hotel LéonWood,brewpub,26 Steindamm,,,Senftenberg,Brandenburg,01968,Germany,+49 3573 363000,http://www.hotel-leonwood.de,14.0071912,51.5144518
-ebe50d23-08dc-4863-a342-0bdacd097773,Kalkofenbrauerei,closed,1 Am Hafen,,,Wriezen,Brandenburg,16269,Germany,+49 33456 2733,http://www.kalkofenbier-wriezen.de,14.13914,52.72501
-94dd6311-a6a5-437f-8e8e-dc74243b08d4,Kavalierhäuser,brewpub,1 Schloßplatz,,,Königs Wusterhausen,Brandenburg,15711,Germany,+49 3375 5665038,http://www.schloss-koenigs-wusterhausen.de,13.6246351,52.2992485
-8733012e-81b7-4769-a9ba-30acc393e713,Kirchers Brauhaus,brewpub,42 Brauhausstraße,,,Drebkau,Brandenburg,03116,Germany,+49 35602 701,http://www.brauerei-kircher.de,14.22173,51.65822989999999
-a81434bc-9f6a-426b-bb5b-f51fe5900f39,Kneipe Pur,bar,23A Lewaldstraße,,,Brandenburg an der Havel,Brandenburg,14774,Germany,+49 3381 403466,http://www.kneipepur.de,12.4154472,52.4157562
-473aff8d-9f36-4a78-a73a-3e0a44022e5b,Knobinger,closed,68 Zinnaer Vorstadt,,,Jüterbog,Brandenburg,14913,Germany,+49 174 6548277,https://de-de.facebook.com/KnobingerBier,13.0852188,51.9946734
+0e8bc17d-a0f8-4cd8-b207-eeb0fe369d01,Alte Ölmühle / Herz-Bräu,brewpub,Bad Wilsnacker Straße 52,,,Wittenberge,Brandenburg,19322,Germany,+49 3877 567994600,http://www.oelmuehle-wittenberge.de,11.7593927,52.9906349
+ee991914-5f3e-4b2e-9241-b0fa4f306fc5,Babben,brewpub,Brauhausgasse 2,,,Lübbenau/Spreewald,Brandenburg,03222,Germany,+49 3542 2126,http://www.babben-bier.de,13.9677778,51.8694444
+15925a01-78bb-45ca-b745-61f73b03778a,Barnimer Brauhaus,brewpub,Am Bahnhof 4,,,Hohenfinow,Brandenburg,16248,Germany,+49 33362 619000,http://www.barnimer-brauhaus.de,13.9280135,52.83050129999999
+ab7cfd95-d5fd-4665-b25d-54cb2a6de10f,Braumanufaktur,brewpub,Templiner Straße 102,,,Potsdam,Brandenburg,14473,Germany,+49 33209 217979,http://www.braumanufaktur.de,13.0235965,52.35940369999999
+4d5e138a-38e9-4f01-928f-69b04d47102b,Braumanufaktur Marstall Boitzenburg,brewpub,Templiner Straße 5,,,Boitzenburger Land,Brandenburg,17268,Germany,+49 39889 550005,http://www.boizenburger-bier.de,13.604319,53.2622546
+e1c28e52-395a-49f7-9535-5e2628789f11,Burgbräuhaus,brewpub,Bahnhofstraße 16,,,Bad Belzig,Brandenburg,14806,Germany,+49 33841 449933,http://www.burgbraeuhaus.de,12.587143,52.136917
+fc07fc0d-1340-40bc-a4bd-4dd40739564f,Burgwall Bräu,brewpub,a Lindenallee 54,,,Oberuckersee,Brandenburg,17291,Germany,+49 39863 7149,,13.8771315,53.18652549999999
+43fa307c-5475-42d2-b919-bb2fd3dfc63b,Erlerbnispark Paaren,brewpub,Gartenstraße 1-3,,,Schönwalde-Glien,Brandenburg,14621,Germany,+49 33230 740,http://www.erlebnispark-paaren.de,12.9816784,52.6497128
+549233f4-f90c-4acf-8fd9-e931e69015f3,Finsterwalder Brauhaus,brewpub,Sonnewalder Straße 13,,,Finsterwalde,Brandenburg,03238,Germany,+49 3531 2286,http://www.finsterwalder-brauhaus.de,13.7057146,51.6365991
+8c7bf5d0-1352-46c7-9620-19e7e1892350,Frankfurter Brauhaus,brewpub,Lebuser Chaussee 3,,,Frankfurt (Oder),Brandenburg,15234,Germany,+49 335 6610,http://www.frankfurter-brauhaus.de,14.530693,52.3647122
+6c08086f-e86d-4030-8050-be3f0c386ff8,Fürstenwalder Rathausbräu,brewpub,Am Markt 1,,,Fürstenwalde/Spree,Brandenburg,15517,Germany,+49 3361 7600841,http://www.rathausbraeu-fuerstenwalde.de,14.0635512,52.3585387
+eb396522-275a-4d1f-bb6b-5f1820d1ed26,G.Bräu,brewpub,Ernst-Thälmann-Straße 2c,,,Bernau bei Berlin,Brandenburg,16321,Germany,+49 3338 768528,http://www.gbrau.com,13.6349248,52.6620675
+bfc678ca-08a1-4c4a-b334-4b16f4d877aa,Gottfried Bräu,brewpub,Prenzlauer Chaussee 123,,,Wandlitz,Brandenburg,16348,Germany,+49 172 4554235,http://www.rialto-wandlitz.de,13.4634141,52.7464482
+660dd6e2-767b-4b66-ba88-a794cfadcb3d,Hebenbräu,brewpub,Mötzower Landstraße 143,,,Brandenburg an der Havel,Brandenburg,14776,Germany,,http://www.facebook.com/Brauhausschmerzke/,12.5794799,52.4348
+8bb7a9b2-f8d9-4436-a301-e4988e5de3be,Hofbrauerei Krongut Bornstedt,brewpub,Ribbeckstraße 6-7,,,Potsdam,Brandenburg,14469,Germany,+49 331 550650,http://www.krongut-bornstedt.de,13.0302968,52.408103
+a6fb9c21-6cf6-4a13-b178-7ba7e5422c62,Hotel LéonWood,brewpub,Steindamm 26,,,Senftenberg,Brandenburg,01968,Germany,+49 3573 363000,http://www.hotel-leonwood.de,14.0071912,51.5144518
+ebe50d23-08dc-4863-a342-0bdacd097773,Kalkofenbrauerei,closed,Am Hafen 1,,,Wriezen,Brandenburg,16269,Germany,+49 33456 2733,http://www.kalkofenbier-wriezen.de,14.13914,52.72501
+94dd6311-a6a5-437f-8e8e-dc74243b08d4,Kavalierhäuser,brewpub,Schloßplatz 1,,,Königs Wusterhausen,Brandenburg,15711,Germany,+49 3375 5665038,http://www.schloss-koenigs-wusterhausen.de,13.6246351,52.2992485
+8733012e-81b7-4769-a9ba-30acc393e713,Kirchers Brauhaus,brewpub,Brauhausstraße 42,,,Drebkau,Brandenburg,03116,Germany,+49 35602 701,http://www.brauerei-kircher.de,14.22173,51.65822989999999
+a81434bc-9f6a-426b-bb5b-f51fe5900f39,Kneipe Pur,bar,Lewaldstraße 23A,,,Brandenburg an der Havel,Brandenburg,14774,Germany,+49 3381 403466,http://www.kneipepur.de,12.4154472,52.4157562
+473aff8d-9f36-4a78-a73a-3e0a44022e5b,Knobinger,closed,Zinnaer Vorstadt 68,,,Jüterbog,Brandenburg,14913,Germany,+49 174 6548277,https://de-de.facebook.com/KnobingerBier,13.0852188,51.9946734
 7732bb1a-9484-437f-b7f8-64cd33c0593b,Krabat,micro,Leineweberweg,,,Burg (Spreewald),Brandenburg,03096,Germany,,http://www.spreewaldhotel-krabat.de,14.1348814,51.8302931
-70a66d60-948d-4dd7-baa3-e8afbc7ace3c,Labieratorium,closed,41a Finsterwalder Straße,,,Cottbus,Brandenburg,03048,Germany,,http://www.labieratorium.de,14.3179376,51.746305
-aeceaa85-4d6a-48d5-b428-f74120f295d9,Märkische Bierstuben,brewpub,49 Große Milower Straße,,,Rathenow,Brandenburg,14712,Germany,+49 3385 512886,http://www.maerkische-bierstuben.de,12.3380884,52.5975502
-9e4748d8-61e3-439a-96ba-577e71fa7db0,Meierei,brewpub,10 Im Neuen Garten,,,Potsdam,Brandenburg,14469,Germany,+49 331 7043211,http://www.meierei-potsdam.de,13.0696853,52.4221304
-b62f8f0b-3e43-4307-98c4-a5e14f8961c4,Prignitzer Hofbräu,brewpub,4 Hauptstraße Buchholz,,,Pritzwalk,Brandenburg,16928,Germany,+49 3395 304090,http://www.prignitzer-hof.de,12.1820826,53.1202128
-2755cd93-a50e-4c78-8a6e-e6f6eec1da35,Privatbrauerei Heymann - Heymische Braukunst,brewpub,4 Am Bahnhof,,,Hohenfinow,Brandenburg,16248,Germany,+49 33362 619000,http://www.brauerei-heymann.de,13.9280135,52.83050129999999
-6c0caa7d-8acc-4cdc-9743-c4c2be2f9c81,SchleusenBrauerei,brewpub,2b An der Schleuse,,,Woltersdorf,Brandenburg,15569,Germany,+49 3362 8862296,http://www.schleusenwirtschaft.de,13.7653654,52.4419459
-ea3df147-c8c2-4666-8908-e8c17d164190,Sozietätsbrauerei,micro,22 Bernauer Straße,,,Altlandsberg,Brandenburg,15345,Germany,+49 33438 649011,http://www.schlossgut-altlandsberg.eu,13.7284489,52.56673439999999
-fbe22ae8-3b08-4806-9106-4357061217fd,Spreewälder,brewpub,53 Dorfstraße,,,Schlepzig,Brandenburg,15910,Germany,+49 35472 6620,http://www.spreewaldbrauerei.de,13.8885913,52.0289319
-16ab7fd0-f231-493d-8606-5f52d1b76ed9,Storch Bier,closed,1 Rutenberger Straße,,,Lychen,Brandenburg,17279,Germany,+49 173 4631245,http://www.storch-bier.de,13.3098564,53.21883520000001
-b86cdc4a-11f2-4f78-ab54-589d5a31fb80,Taverna Obscura,closed,1 Auf der Burg,,,Plattenburg,Brandenburg,19339,Germany,+49 38791 568225,http://www.burgkeller-plattenburg.de,12.0303663,52.9581562
-3290c3c4-aad7-4c40-bc7b-7a5a982ce44c,Uckermärker,brewpub,49 Alte Handelsstraße,,,Chorin,Brandenburg,16230,Germany,+49 3334 420557,http://www.choriner.de,13.8150373,52.9106027
-d8d6fde9-f0ca-44a4-8ac1-e737e1530861,Zum Grünen Baum,micro,4 Templiner Straße,,,Boitzenburger Land,Brandenburg,17268,Germany,+49 39889 569995,http://www.boizenburg.de,13.6045343,53.26313219999999
-136195f1-7f1f-47c9-8d8b-fc4a3423480a,Zum Rittmeister,brewpub,9 Seestraße,,,Werder (Havel),Brandenburg,14542,Germany,+49 3327 4646,http://www.zum-rittmeister.de,12.8674,52.4087226
-263d81ed-5109-4fbe-9891-04173a5b0a07,Zur Alten Brauerei,brewpub,30 Mühlenstraße,,,Beelitz,Brandenburg,14547,Germany,+49 33204 35777,http://www.zuraltenbrauerei.de/,12.974678,52.2320059
+70a66d60-948d-4dd7-baa3-e8afbc7ace3c,Labieratorium,closed,Finsterwalder Straße 41a,,,Cottbus,Brandenburg,03048,Germany,,http://www.labieratorium.de,14.3179376,51.746305
+aeceaa85-4d6a-48d5-b428-f74120f295d9,Märkische Bierstuben,brewpub,Große Milower Straße 49,,,Rathenow,Brandenburg,14712,Germany,+49 3385 512886,http://www.maerkische-bierstuben.de,12.3380884,52.5975502
+9e4748d8-61e3-439a-96ba-577e71fa7db0,Meierei,brewpub,Im Neuen Garten 10,,,Potsdam,Brandenburg,14469,Germany,+49 331 7043211,http://www.meierei-potsdam.de,13.0696853,52.4221304
+b62f8f0b-3e43-4307-98c4-a5e14f8961c4,Prignitzer Hofbräu,brewpub,Hauptstraße Buchholz 4,,,Pritzwalk,Brandenburg,16928,Germany,+49 3395 304090,http://www.prignitzer-hof.de,12.1820826,53.1202128
+2755cd93-a50e-4c78-8a6e-e6f6eec1da35,Privatbrauerei Heymann - Heymische Braukunst,brewpub,Am Bahnhof 4,,,Hohenfinow,Brandenburg,16248,Germany,+49 33362 619000,http://www.brauerei-heymann.de,13.9280135,52.83050129999999
+6c0caa7d-8acc-4cdc-9743-c4c2be2f9c81,SchleusenBrauerei,brewpub,An der Schleuse 2b,,,Woltersdorf,Brandenburg,15569,Germany,+49 3362 8862296,http://www.schleusenwirtschaft.de,13.7653654,52.4419459
+ea3df147-c8c2-4666-8908-e8c17d164190,Sozietätsbrauerei,micro,Bernauer Straße 22,,,Altlandsberg,Brandenburg,15345,Germany,+49 33438 649011,http://www.schlossgut-altlandsberg.eu,13.7284489,52.56673439999999
+fbe22ae8-3b08-4806-9106-4357061217fd,Spreewälder,brewpub,Dorfstraße 53,,,Schlepzig,Brandenburg,15910,Germany,+49 35472 6620,http://www.spreewaldbrauerei.de,13.8885913,52.0289319
+16ab7fd0-f231-493d-8606-5f52d1b76ed9,Storch Bier,closed,Rutenberger Straße 1,,,Lychen,Brandenburg,17279,Germany,+49 173 4631245,http://www.storch-bier.de,13.3098564,53.21883520000001
+b86cdc4a-11f2-4f78-ab54-589d5a31fb80,Taverna Obscura,closed,Auf der Burg 1,,,Plattenburg,Brandenburg,19339,Germany,+49 38791 568225,http://www.burgkeller-plattenburg.de,12.0303663,52.9581562
+3290c3c4-aad7-4c40-bc7b-7a5a982ce44c,Uckermärker,brewpub,Alte Handelsstraße 49,,,Chorin,Brandenburg,16230,Germany,+49 3334 420557,http://www.choriner.de,13.8150373,52.9106027
+d8d6fde9-f0ca-44a4-8ac1-e737e1530861,Zum Grünen Baum,micro,Templiner Straße 4,,,Boitzenburger Land,Brandenburg,17268,Germany,+49 39889 569995,http://www.boizenburg.de,13.6045343,53.26313219999999
+136195f1-7f1f-47c9-8d8b-fc4a3423480a,Zum Rittmeister,brewpub,Seestraße 9,,,Werder (Havel),Brandenburg,14542,Germany,+49 3327 4646,http://www.zum-rittmeister.de,12.8674,52.4087226
+263d81ed-5109-4fbe-9891-04173a5b0a07,Zur Alten Brauerei,brewpub,Mühlenstraße 30,,,Beelitz,Brandenburg,14547,Germany,+49 33204 35777,http://www.zuraltenbrauerei.de/,12.974678,52.2320059

--- a/data/germany/bremen.csv
+++ b/data/germany/bremen.csv
@@ -1,5 +1,5 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-46bca971-41fc-43d3-afda-8d3d27e433ef,Beck's,brewpub,20 Am Deich,,,Bremen,Bremen,28199,Germany,+49 421 50940,https://www.becks.de/,8.792207,53.0768437
-b8f65a9f-7183-4e44-8070-05b70b039608,Grebhan's Bier,closed,29A Haferwende,,,Bremen,Bremen,28357,Germany,+49 421 3976697,http://www.grebhansbier.com,8.882765899999999,53.1077556
-388e2251-37a8-4836-bd87-75de111a1041,Schüttinger,brewpub,12-13 Hinter dem Schütting,,,Bremen,Bremen,28195,Germany,+49 421 3376633,http://www.schuettinger.de,8.8066459,53.0749157
-dc9f4b21-4e7a-405c-8cf2-5e0f6f62f158,Union,brewpub,12-13 Theodorstraße,,,Bremen,Bremen,28219,Germany,+49 421 8982160,http://www.brauerei-bremen.de,8.7931341,53.10045909999999
+46bca971-41fc-43d3-afda-8d3d27e433ef,Beck's,brewpub,Am Deich 20,,,Bremen,Bremen,28199,Germany,+49 421 50940,https://www.becks.de/,8.792207,53.0768437
+b8f65a9f-7183-4e44-8070-05b70b039608,Grebhan's Bier,closed,Haferwende 29A,,,Bremen,Bremen,28357,Germany,+49 421 3976697,http://www.grebhansbier.com,8.882765899999999,53.1077556
+388e2251-37a8-4836-bd87-75de111a1041,Schüttinger,brewpub,Hinter dem Schütting 12-13,,,Bremen,Bremen,28195,Germany,+49 421 3376633,http://www.schuettinger.de,8.8066459,53.0749157
+dc9f4b21-4e7a-405c-8cf2-5e0f6f62f158,Union,brewpub,Theodorstraße 12-13,,,Bremen,Bremen,28219,Germany,+49 421 8982160,http://www.brauerei-bremen.de,8.7931341,53.10045909999999

--- a/data/germany/hamburg.csv
+++ b/data/germany/hamburg.csv
@@ -1,6 +1,6 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
 95a483ca-d13c-4e78-bfd6-658149d2e874,Alles Elbe,closed,63 Hein-Hoyer-Straße,,,Hamburg,Hamburg,20359,Germany,+49 40 28474009,http://www.alleselbe.de,9.962679300000001,53.5531382
-fe78c40e-fdfa-42b0-9189-262612d5f241,Birrificio Shanghait,brewpub,Schaeferstrasse 26,,,Hamburg,Hamburg,20357,Germany,,http://www.shanghait.beer,,
+fe78c40e-fdfa-42b0-9189-262612d5f241,Birrificio Shanghait,brewpub,Schaeferstraße 26,,,Hamburg,Hamburg,20357,Germany,,http://www.shanghait.beer,,
 2cdf2044-dca0-40bb-bbb7-1a8b4ff512ae,Blockbräu,brewpub,3 Bei den Sankt Pauli-Landungsbrücken,,,Hamburg,Hamburg,20359,Germany,+49 40 44405000,http://www.block-braeu.de,9.9692527,53.5456339
 284d3345-9d22-4927-97fe-2fecf96c88fc,Buddelship Brauerei,brewpub,29 Kohlhöfen,,,Hamburg,Hamburg,20355,Germany,+49 173 5849981,http://www.buddelship.com,9.9798165,53.553332
 2ee06562-95c7-4b24-b09d-aecaee5d82f1,Bunthaus,brewpub,33 Moorwerder Hauptdeich,,,Hamburg,Hamburg,21109,Germany,+49 40 18047215,http://www.bunthaus.beer,10.0630783,53.4611879

--- a/data/germany/hamburg.csv
+++ b/data/germany/hamburg.csv
@@ -1,15 +1,15 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-95a483ca-d13c-4e78-bfd6-658149d2e874,Alles Elbe,closed,63 Hein-Hoyer-Straße,,,Hamburg,Hamburg,20359,Germany,+49 40 28474009,http://www.alleselbe.de,9.962679300000001,53.5531382
+95a483ca-d13c-4e78-bfd6-658149d2e874,Alles Elbe,closed,Hein-Hoyer-Straße 63,,,Hamburg,Hamburg,20359,Germany,+49 40 28474009,http://www.alleselbe.de,9.962679300000001,53.5531382
 fe78c40e-fdfa-42b0-9189-262612d5f241,Birrificio Shanghait,brewpub,Schaeferstraße 26,,,Hamburg,Hamburg,20357,Germany,,http://www.shanghait.beer,,
-2cdf2044-dca0-40bb-bbb7-1a8b4ff512ae,Blockbräu,brewpub,3 Bei den Sankt Pauli-Landungsbrücken,,,Hamburg,Hamburg,20359,Germany,+49 40 44405000,http://www.block-braeu.de,9.9692527,53.5456339
-284d3345-9d22-4927-97fe-2fecf96c88fc,Buddelship Brauerei,brewpub,29 Kohlhöfen,,,Hamburg,Hamburg,20355,Germany,+49 173 5849981,http://www.buddelship.com,9.9798165,53.553332
-2ee06562-95c7-4b24-b09d-aecaee5d82f1,Bunthaus,brewpub,33 Moorwerder Hauptdeich,,,Hamburg,Hamburg,21109,Germany,+49 40 18047215,http://www.bunthaus.beer,10.0630783,53.4611879
-3251f7e1-3130-4b8c-80bb-02b364616c7d,Burzel Bräu,brewpub,12 Beerenweg,,,Hamburg,Hamburg,22761,Germany,+49 40 85158229,http://www.landgang-brauerei.de/,9.9226025,53.56550859999999
-8bad5262-5b50-4006-a70c-2403b3bc191d,Circle 8,closed,267 Alsterdorfer Straße,,,Hamburg,Hamburg,22297,Germany,,http://www.circle8brewery.de,10.006676,53.6080037
-76bedbe9-923e-4674-baad-71736c030578,Corbeker,brewpub,13 Heykenaukamp,,,Hamburg,Hamburg,21147,Germany,+49 40 381010,http://www.corbek-brauerei.de,9.9112095,53.479127
-48fd7cfd-30f4-49d1-8f62-10e2c22e2e21,Gröninger,brewpub,47 Willy-Brandt-Straße,,,Hamburg,Hamburg,20457,Germany,+49 40 570105100,http://www.groeninger-hamburg.de,9.9962792,53.54714800000001
-df35acd1-bb4a-45ff-9e9e-ae36a5bec80f,Holsten,brewpub,13 Heykenaukamp,,,Hamburg,Hamburg,21147,Germany,+49 40 381010,http://www.holsten.de,9.9112095,53.479127
-7a73f97e-ada7-4311-8f0c-5004ca328ffc,Kreativbrauerei,brewpub,74-92 Sinstorfer Kirchweg,,,Hamburg,Hamburg,21077,Germany,+49 40 47190747,http://www.kreativbrauerei.de,9.9596087,53.4279623
-ef252151-f9c6-491d-aaa9-c0e0bd1a62d6,Landgang,brewpub,12 Beerenweg,,,Hamburg,Hamburg,22761,Germany,+49 40 85158229,http://www.landgang-brauerei.de,9.9226025,53.56550859999999
-4d6ccbf7-a89b-4ea4-b166-c7da8196faef,Ratsherrn,brewpub,30a Lagerstraße,,,Hamburg,Hamburg,20357,Germany,+49 40 380728920,http://www.ratsherrn.de,9.9682417,53.563016
-0d1d0c85-e66d-4e23-8bd5-73cfca50e6a9,ÜberQuell,brewpub,28-32 Sankt Pauli Fischmarkt,,,Hamburg,Hamburg,20359,Germany,+49 40 334421260,http://www.ueberquell.com,9.958575,53.5462563
+2cdf2044-dca0-40bb-bbb7-1a8b4ff512ae,Blockbräu,brewpub,Bei den Sankt Pauli-Landungsbrücken 3,,,Hamburg,Hamburg,20359,Germany,+49 40 44405000,http://www.block-braeu.de,9.9692527,53.5456339
+284d3345-9d22-4927-97fe-2fecf96c88fc,Buddelship Brauerei,brewpub,Kohlhöfen 29,,,Hamburg,Hamburg,20355,Germany,+49 173 5849981,http://www.buddelship.com,9.9798165,53.553332
+2ee06562-95c7-4b24-b09d-aecaee5d82f1,Bunthaus,brewpub,Moorwerder Hauptdeich 33,,,Hamburg,Hamburg,21109,Germany,+49 40 18047215,http://www.bunthaus.beer,10.0630783,53.4611879
+3251f7e1-3130-4b8c-80bb-02b364616c7d,Burzel Bräu,brewpub,Beerenweg 12,,,Hamburg,Hamburg,22761,Germany,+49 40 85158229,http://www.landgang-brauerei.de/,9.9226025,53.56550859999999
+8bad5262-5b50-4006-a70c-2403b3bc191d,Circle 8,closed,Alsterdorfer Straße 267,,,Hamburg,Hamburg,22297,Germany,,http://www.circle8brewery.de,10.006676,53.6080037
+76bedbe9-923e-4674-baad-71736c030578,Corbeker,brewpub,Heykenaukamp 13,,,Hamburg,Hamburg,21147,Germany,+49 40 381010,http://www.corbek-brauerei.de,9.9112095,53.479127
+48fd7cfd-30f4-49d1-8f62-10e2c22e2e21,Gröninger,brewpub,Willy-Brandt-Straße 47,,,Hamburg,Hamburg,20457,Germany,+49 40 570105100,http://www.groeninger-hamburg.de,9.9962792,53.54714800000001
+df35acd1-bb4a-45ff-9e9e-ae36a5bec80f,Holsten,brewpub,Heykenaukamp 13,,,Hamburg,Hamburg,21147,Germany,+49 40 381010,http://www.holsten.de,9.9112095,53.479127
+7a73f97e-ada7-4311-8f0c-5004ca328ffc,Kreativbrauerei,brewpub,Sinstorfer Kirchweg 74-92,,,Hamburg,Hamburg,21077,Germany,+49 40 47190747,http://www.kreativbrauerei.de,9.9596087,53.4279623
+ef252151-f9c6-491d-aaa9-c0e0bd1a62d6,Landgang,brewpub,Beerenweg 12,,,Hamburg,Hamburg,22761,Germany,+49 40 85158229,http://www.landgang-brauerei.de,9.9226025,53.56550859999999
+4d6ccbf7-a89b-4ea4-b166-c7da8196faef,Ratsherrn,brewpub,Lagerstraße 30a,,,Hamburg,Hamburg,20357,Germany,+49 40 380728920,http://www.ratsherrn.de,9.9682417,53.563016
+0d1d0c85-e66d-4e23-8bd5-73cfca50e6a9,ÜberQuell,brewpub,Sankt Pauli Fischmarkt 28-32,,,Hamburg,Hamburg,20359,Germany,+49 40 334421260,http://www.ueberquell.com,9.958575,53.5462563

--- a/data/germany/hessen.csv
+++ b/data/germany/hessen.csv
@@ -1,79 +1,79 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-ddae7cb2-84c9-44f0-bbab-93781b5cf837,Alsfelder,brewpub,8 Cent,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.alsfelder.de,9.392651299999999,50.6390531
-0474f95d-9e16-4b45-b789-93827fcc13c2,Alt Oberurseler Brauhaus,brewpub,13 Ackergasse,,,Oberursel (Taunus),Hessen,61440,Germany,+49 6171 54370,http://www.meinbier.de,8.578921,50.202898
+ddae7cb2-84c9-44f0-bbab-93781b5cf837,Alsfelder,brewpub,Cent 8,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.alsfelder.de,9.392651299999999,50.6390531
+0474f95d-9e16-4b45-b789-93827fcc13c2,Alt Oberurseler Brauhaus,brewpub,Ackergasse 13,,,Oberursel (Taunus),Hessen,61440,Germany,+49 6171 54370,http://www.meinbier.de,8.578921,50.202898
 36ee96e3-cb87-460b-bbb8-2c2a3c33b28a,Alt-Giessen,micro,Westanlage 30,,,Giessen,Hessen,35390,Germany,,http://www.altgiessen.de,,
-ad3a2f17-d7a8-432a-91c0-1ff29b4398fd,Alte Feuerwache,brewpub,6 Schulgasse,,,Idstein,Hessen,65510,Germany,+49 6126 958112,http://www.brauhaus-alte-feuerwache.de,8.2680809,50.22186019999999
-8a884a90-88e6-44b7-98d3-fbfe01e9cf82,Bad Wildunger Brauhaus,brewpub,2 Frankenberger Straße,,,Bad Wildungen,Hessen,34537,Germany,+49 5621 74150,http://www.brauhaus-bad-wildungen.de,9.10132,51.10931
-80e9b35a-d269-4b0b-b103-68849afb477e,Bier Hannes,brewpub,568 Hanauer Landstraße,,,Frankfurt am Main,Hessen,60386,Germany,+49 69 412890,http://www.bier-hannes.de,8.7680832,50.13322849999999
-a98205b4-e51c-41df-b567-eb37a7cbff4a,Biermanufaktur Rotenburg,brewpub,7 Obertor,,,Rotenburg an der Fulda,Hessen,36199,Germany,+49 6623 9141220,http://www.bier-rotenburg.de,9.7317962,50.9949722
-2a07391b-a93e-4cf1-9d4e-853d752fdcb0,Binding,bar,13 Wallstraße,,,Frankfurt am Main,Hessen,60594,Germany,+49 1515 7801106,http://www.binding.de,8.6884342,50.1049117
-9903d1d3-b439-4784-bbec-451c78afabaa,Bramanufaktur Steckenpferd,brewpub,19a Schwanenweg,,,Kassel,Hessen,34123,Germany,+49 1525 5429152,http://www.braumanufaktur-steckenpferd.de,9.5129863,51.3088337
-207c3c9d-ea5d-4fd4-af4f-d77cab830591,Brauhaus 18·80,brewpub,4 Auf der Lache,,,Fritzlar,Hessen,34560,Germany,+49 5622 918809,http://www.brauhaus1880.de,9.2769718,51.1222076
-75e57315-27f9-4a3c-bc83-f187edf69e91,Brauhaus Castel,brewpub,27 Otto-Suhr-Ring,,,Wiesbaden,Hessen,55252,Germany,+49 6134 24999,http://www.brauhaus-castel.de,8.29242,50.01686
-4a47766e-d24f-4892-b3e9-d80bd4bc4ef0,Brauhaus Michelsrombacher Wald,brewpub,51 Michelsrombacher Straße,,,Fulda,Hessen,36039,Germany,+49 172 4706525,http://www.brauhaus-mrw.de,9.686620699999999,50.5906329
-71fc9541-2f0f-497f-874c-f3b2ad312de3,Braustil,closed,57 Oeder Weg,,,Frankfurt am Main,Hessen,60318,Germany,,http://www.braustil.de,8.6803232,50.1219242
-30c10773-f482-4760-8993-41dc65f6343f,BrauWerkstatt Malsfeld,brewpub,9 Brauereistraße,,,Malsfeld,Hessen,34323,Germany,+49 1522 8873118,http://www.brauwerkstatt-malsfeld.de,9.545593499999999,51.0905518
-31cf78f2-54a7-4472-b4bb-323a613a8275,Brewers Fantasy,brewpub,14 Paul-Joseph-Straße,,,Fürth,Hessen,64658,Germany,+49 6207 4619386,http://www.brewers-fantasy.de,8.7457354,49.6632373
-5b2bc4a9-8ec2-44bf-ac4f-db71f493ffcc,Burgbrauerei,brewpub,8 Cent,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,https://www.lauterbacher-auerhahn.de/,9.3921847,50.6398732
-856cc26e-a905-4e19-a2d5-7548d8f79655,Bürgerbräu Wächtersbach,closed,8 Schloßstraße,,,Wächtersbach,Hessen,63607,Germany,+49 6053 8070,http://www.bbwbach.de,9.2858044,50.2584777
-10433415-27dd-4c42-85f9-fa8aef1941d8,Burggraf Bräu,closed,231 Darmstädter Straße,,,Bensheim,Hessen,64625,Germany,+49 6251 72525,http://www.burggraf-braeu.de,8.6185745,49.7055401
-7e3a2800-2510-459c-aecf-92a3b3450b1c,CraftBrauSchmiede,brewpub,124 Friedberger Straße,,,Bad Vilbel,Hessen,61118,Germany,+49 6101 523690,http://www.craftbrauschmiede.de,8.7437358,50.1927438
-ca4d8c57-a58c-487e-a346-b29426fb5c4a,Darmstädter,brewpub,8 Marktplatz,,,Darmstadt,Hessen,64283,Germany,+49 6151 26444,http://www.darmstaedter.de,8.6558455,49.8720899
-49c93a9a-2614-4c6e-8023-689c558cb6ce,Das Brauhaus,brewpub,1 An der Wied,,,Rüsselsheim am Main,Hessen,65428,Germany,+49 6142 562430,http://www.ruesselsheimerbrauhaus.de,8.4566384,49.9848106
-2700c023-d25a-4257-9f4b-2d618154969c,Daum Bräu,brewpub,14A Erbacher Straße,,,Michelstadt,Hessen,64720,Germany,+49 170 5833883,http://www.daumbraeu.tk,9.006020099999999,49.6765
-4c28cf94-42b9-4677-9827-38e7dfa1d1e9,Dorfbrä,brewpub,7 Mittelstraße,,,Wartenberg,Hessen,36367,Germany,+49 6648 9110073,http://www.dorfbraeuhaus.de,9.474583599999999,50.6077865
-23c46fad-5ef6-44bf-8757-8348da5140f6,Drayß Back & Brauhaus,brewpub,1 Bahnhofstraße,,,Lorsch,Hessen,64653,Germany,+49 6251 9892234,http://www.back-und-brauhaus.de,8.5675885,49.6542632
-99772622-2010-4933-a3c2-f8355f09924b,Edermünder Brauscheune,closed,3A Grifter Straße,,,Edermünde,Hessen,34295,Germany,+49 5665 969896,http://www.brauscheune.de,9.4297066,51.202439
-cb9fbb8d-caf4-4a29-b8c1-d23e2deb2642,Engelhardt Bier,brewpub,9 Kirchplatz,,,Bad Hersfeld,Hessen,36251,Germany,+49 6621 8011513,http://www.engelhardt-bier.de,9.7076197,50.8689714
-c61bf022-689b-4600-afd0-4d2c2ec6a794,Eschweger Klosterbrauerei,brewpub,19 Thüringer Straße,,,Eschwege,Hessen,37269,Germany,+49 5651 30730,http://www.eschweger-klosterbrauerei.de,10.0250048,51.2004812
-2fc87af7-1254-4b91-81d4-fa3bd05f0cec,Faselbräu,brewpub,4 Hintergasse,,,Mörfelden-Walldorf,Hessen,64546,Germany,+49 179 9333705,http://www.faselbraeu.de,8.568683199999999,49.97268340000001
-9bfd94d2-bc3a-4495-bd82-6eecf26a77f6,Fleisbacher,micro,45 Zur Dornheck,,,Sinn,Hessen,35764,Germany,+49 2772 5089035,http://www.fleischbacher-brauerei.de,8.3227476,50.64331379999999
-386feff3-9539-44e5-b87c-8732d37c4757,Flügge,micro,11 Ostparkstraße,,,Frankfurt am Main,Hessen,60314,Germany,+49 69 87000181,http://www.brauerei-fluegge.de,8.7100329,50.1143428
-38bfb001-66c7-4970-a6ba-f2338b9739f6,Fuldabrücker Landbrauerei,brewpub,1A Rundstraße,,,Fuldabrück,Hessen,34277,Germany,+49 5665 30088,http://www.kassel-essentrinken.de/kunden/gastro/LKS/landbrauerei/vk.html,9.501488199999999,51.2280175
-6f35c700-e495-4b75-9dc4-2cfded4a9a7b,Glaabsbräu,brewpub,1 Wallstraße,,,Seligenstadt,Hessen,63500,Germany,+49 6182 9260,http://www.glaabsbraeu.de,8.9734986,50.0447693
-bc2caf09-abfc-43a1-bc35-d9f3b946937b,Graf Zeppelin,brewpub,10 Zeppelinstraße,,,Bad Homburg vor der Höhe,Hessen,61352,Germany,+49 6172 288662,http://www.hofgut-kronenhof.de/brauhaus/,8.6116654,50.2142958
-8804214c-7d23-4960-a8aa-4161978f81bf,Grohe,brewpub,3 Nieder-Ramstädter Straße,,,Darmstadt,Hessen,64283,Germany,+49 6151 4291111,http://www.grohe-gastro.de,8.656749999999999,49.8691833
-f1e9579e-8c01-4dff-b7a4-9a2c0da42c98,Gutshof,brewpub,2 Zum Gutshof,,,Herborn,Hessen,35745,Germany,+49 2772 5755740,http://www.gutshof-herborn.de,8.3064469,50.6689786
-8cb9705e-01f5-40c5-ba48-7268931b8855,Halber Mond,brewpub,5 Ludwigstraße,,,Heppenheim (Bergstraße),Hessen,64646,Germany,+49 6252 126848,http://www.halber-mond.com,8.6386001,49.6416174
-9375b01a-a2bc-485c-adc7-8dc72e1db63b,Hausbrauerei Armin Latzko,brewpub,5 Harkauer Weg,,,Wetter (Hessen),Hessen,35083,Germany,+49 6423 2557,,8.6885843,50.9075497
-0a4b9f32-745a-4847-85d2-f79032778466,Heidenroder Craft Brauerei,closed,8 Parkstraße,,,Heidenrod,Hessen,65321,Germany,,http://www.heidenroder-craft-brauerei.de,7.9456066,50.1492289
-4dcc422f-ab94-4097-8069-9e7884053e8b,Hochstädter Landbier,brewpub,13 Bischofsheimer Straße,,,Maintal,Hessen,63477,Germany,+49 6181 432326,http://www.hochstaedter-landbier.de,8.8303237,50.1528488
-b9f0b5b3-beac-4ea7-a83e-bff3ba1cf7ad,Hochstift,brewpub,12 Leipziger Straße,,,Fulda,Hessen,36037,Germany,+49 661 83500,http://www.hochstift.de,9.6770041,50.55787549999999
-5e12c783-55cf-44be-9c90-28d203a4b656,Hopfenherz,closed,3 Feldbergstraße,,,Weiterstadt,Hessen,64331,Germany,+49 6150 14337,http://www.hopfenherz.de,8.5624509,49.9136865
+ad3a2f17-d7a8-432a-91c0-1ff29b4398fd,Alte Feuerwache,brewpub,Schulgasse 6,,,Idstein,Hessen,65510,Germany,+49 6126 958112,http://www.brauhaus-alte-feuerwache.de,8.2680809,50.22186019999999
+8a884a90-88e6-44b7-98d3-fbfe01e9cf82,Bad Wildunger Brauhaus,brewpub,Frankenberger Straße 2,,,Bad Wildungen,Hessen,34537,Germany,+49 5621 74150,http://www.brauhaus-bad-wildungen.de,9.10132,51.10931
+80e9b35a-d269-4b0b-b103-68849afb477e,Bier Hannes,brewpub,Hanauer Landstraße 568,,,Frankfurt am Main,Hessen,60386,Germany,+49 69 412890,http://www.bier-hannes.de,8.7680832,50.13322849999999
+a98205b4-e51c-41df-b567-eb37a7cbff4a,Biermanufaktur Rotenburg,brewpub,Obertor 7,,,Rotenburg an der Fulda,Hessen,36199,Germany,+49 6623 9141220,http://www.bier-rotenburg.de,9.7317962,50.9949722
+2a07391b-a93e-4cf1-9d4e-853d752fdcb0,Binding,bar,Wallstraße 13,,,Frankfurt am Main,Hessen,60594,Germany,+49 1515 7801106,http://www.binding.de,8.6884342,50.1049117
+9903d1d3-b439-4784-bbec-451c78afabaa,Bramanufaktur Steckenpferd,brewpub,Schwanenweg 19a,,,Kassel,Hessen,34123,Germany,+49 1525 5429152,http://www.braumanufaktur-steckenpferd.de,9.5129863,51.3088337
+207c3c9d-ea5d-4fd4-af4f-d77cab830591,Brauhaus 18·80,brewpub,Auf der Lache 4,,,Fritzlar,Hessen,34560,Germany,+49 5622 918809,http://www.brauhaus1880.de,9.2769718,51.1222076
+75e57315-27f9-4a3c-bc83-f187edf69e91,Brauhaus Castel,brewpub,Otto-Suhr-Ring 27,,,Wiesbaden,Hessen,55252,Germany,+49 6134 24999,http://www.brauhaus-castel.de,8.29242,50.01686
+4a47766e-d24f-4892-b3e9-d80bd4bc4ef0,Brauhaus Michelsrombacher Wald,brewpub,Michelsrombacher Straße 51,,,Fulda,Hessen,36039,Germany,+49 172 4706525,http://www.brauhaus-mrw.de,9.686620699999999,50.5906329
+71fc9541-2f0f-497f-874c-f3b2ad312de3,Braustil,closed,Oeder Weg 57,,,Frankfurt am Main,Hessen,60318,Germany,,http://www.braustil.de,8.6803232,50.1219242
+30c10773-f482-4760-8993-41dc65f6343f,BrauWerkstatt Malsfeld,brewpub,Brauereistraße 9,,,Malsfeld,Hessen,34323,Germany,+49 1522 8873118,http://www.brauwerkstatt-malsfeld.de,9.545593499999999,51.0905518
+31cf78f2-54a7-4472-b4bb-323a613a8275,Brewers Fantasy,brewpub,Paul-Joseph-Straße 14,,,Fürth,Hessen,64658,Germany,+49 6207 4619386,http://www.brewers-fantasy.de,8.7457354,49.6632373
+5b2bc4a9-8ec2-44bf-ac4f-db71f493ffcc,Burgbrauerei,brewpub,Cent 8,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,https://www.lauterbacher-auerhahn.de/,9.3921847,50.6398732
+856cc26e-a905-4e19-a2d5-7548d8f79655,Bürgerbräu Wächtersbach,closed,Schloßstraße 8,,,Wächtersbach,Hessen,63607,Germany,+49 6053 8070,http://www.bbwbach.de,9.2858044,50.2584777
+10433415-27dd-4c42-85f9-fa8aef1941d8,Burggraf Bräu,closed,Darmstädter Straße 231,,,Bensheim,Hessen,64625,Germany,+49 6251 72525,http://www.burggraf-braeu.de,8.6185745,49.7055401
+7e3a2800-2510-459c-aecf-92a3b3450b1c,CraftBrauSchmiede,brewpub,Friedberger Straße 124,,,Bad Vilbel,Hessen,61118,Germany,+49 6101 523690,http://www.craftbrauschmiede.de,8.7437358,50.1927438
+ca4d8c57-a58c-487e-a346-b29426fb5c4a,Darmstädter,brewpub,Marktplatz 8,,,Darmstadt,Hessen,64283,Germany,+49 6151 26444,http://www.darmstaedter.de,8.6558455,49.8720899
+49c93a9a-2614-4c6e-8023-689c558cb6ce,Das Brauhaus,brewpub,An der Wied 1,,,Rüsselsheim am Main,Hessen,65428,Germany,+49 6142 562430,http://www.ruesselsheimerbrauhaus.de,8.4566384,49.9848106
+2700c023-d25a-4257-9f4b-2d618154969c,Daum Bräu,brewpub,Erbacher Straße 14A,,,Michelstadt,Hessen,64720,Germany,+49 170 5833883,http://www.daumbraeu.tk,9.006020099999999,49.6765
+4c28cf94-42b9-4677-9827-38e7dfa1d1e9,Dorfbrä,brewpub,Mittelstraße 7,,,Wartenberg,Hessen,36367,Germany,+49 6648 9110073,http://www.dorfbraeuhaus.de,9.474583599999999,50.6077865
+23c46fad-5ef6-44bf-8757-8348da5140f6,Drayß Back & Brauhaus,brewpub,Bahnhofstraße 1,,,Lorsch,Hessen,64653,Germany,+49 6251 9892234,http://www.back-und-brauhaus.de,8.5675885,49.6542632
+99772622-2010-4933-a3c2-f8355f09924b,Edermünder Brauscheune,closed,Grifter Straße 3A,,,Edermünde,Hessen,34295,Germany,+49 5665 969896,http://www.brauscheune.de,9.4297066,51.202439
+cb9fbb8d-caf4-4a29-b8c1-d23e2deb2642,Engelhardt Bier,brewpub,Kirchplatz 9,,,Bad Hersfeld,Hessen,36251,Germany,+49 6621 8011513,http://www.engelhardt-bier.de,9.7076197,50.8689714
+c61bf022-689b-4600-afd0-4d2c2ec6a794,Eschweger Klosterbrauerei,brewpub,Thüringer Straße 19,,,Eschwege,Hessen,37269,Germany,+49 5651 30730,http://www.eschweger-klosterbrauerei.de,10.0250048,51.2004812
+2fc87af7-1254-4b91-81d4-fa3bd05f0cec,Faselbräu,brewpub,Hintergasse 4,,,Mörfelden-Walldorf,Hessen,64546,Germany,+49 179 9333705,http://www.faselbraeu.de,8.568683199999999,49.97268340000001
+9bfd94d2-bc3a-4495-bd82-6eecf26a77f6,Fleisbacher,micro,Zur Dornheck 45,,,Sinn,Hessen,35764,Germany,+49 2772 5089035,http://www.fleischbacher-brauerei.de,8.3227476,50.64331379999999
+386feff3-9539-44e5-b87c-8732d37c4757,Flügge,micro,Ostparkstraße 11,,,Frankfurt am Main,Hessen,60314,Germany,+49 69 87000181,http://www.brauerei-fluegge.de,8.7100329,50.1143428
+38bfb001-66c7-4970-a6ba-f2338b9739f6,Fuldabrücker Landbrauerei,brewpub,Rundstraße 1A,,,Fuldabrück,Hessen,34277,Germany,+49 5665 30088,http://www.kassel-essentrinken.de/kunden/gastro/LKS/landbrauerei/vk.html,9.501488199999999,51.2280175
+6f35c700-e495-4b75-9dc4-2cfded4a9a7b,Glaabsbräu,brewpub,Wallstraße 1,,,Seligenstadt,Hessen,63500,Germany,+49 6182 9260,http://www.glaabsbraeu.de,8.9734986,50.0447693
+bc2caf09-abfc-43a1-bc35-d9f3b946937b,Graf Zeppelin,brewpub,Zeppelinstraße 10,,,Bad Homburg vor der Höhe,Hessen,61352,Germany,+49 6172 288662,http://www.hofgut-kronenhof.de/brauhaus/,8.6116654,50.2142958
+8804214c-7d23-4960-a8aa-4161978f81bf,Grohe,brewpub,Nieder-Ramstädter Straße 3,,,Darmstadt,Hessen,64283,Germany,+49 6151 4291111,http://www.grohe-gastro.de,8.656749999999999,49.8691833
+f1e9579e-8c01-4dff-b7a4-9a2c0da42c98,Gutshof,brewpub,Zum Gutshof 2,,,Herborn,Hessen,35745,Germany,+49 2772 5755740,http://www.gutshof-herborn.de,8.3064469,50.6689786
+8cb9705e-01f5-40c5-ba48-7268931b8855,Halber Mond,brewpub,Ludwigstraße 5,,,Heppenheim (Bergstraße),Hessen,64646,Germany,+49 6252 126848,http://www.halber-mond.com,8.6386001,49.6416174
+9375b01a-a2bc-485c-adc7-8dc72e1db63b,Hausbrauerei Armin Latzko,brewpub,Harkauer Weg 5,,,Wetter (Hessen),Hessen,35083,Germany,+49 6423 2557,,8.6885843,50.9075497
+0a4b9f32-745a-4847-85d2-f79032778466,Heidenroder Craft Brauerei,closed,Parkstraße 8,,,Heidenrod,Hessen,65321,Germany,,http://www.heidenroder-craft-brauerei.de,7.9456066,50.1492289
+4dcc422f-ab94-4097-8069-9e7884053e8b,Hochstädter Landbier,brewpub,Bischofsheimer Straße 13,,,Maintal,Hessen,63477,Germany,+49 6181 432326,http://www.hochstaedter-landbier.de,8.8303237,50.1528488
+b9f0b5b3-beac-4ea7-a83e-bff3ba1cf7ad,Hochstift,brewpub,Leipziger Straße 12,,,Fulda,Hessen,36037,Germany,+49 661 83500,http://www.hochstift.de,9.6770041,50.55787549999999
+5e12c783-55cf-44be-9c90-28d203a4b656,Hopfenherz,closed,Feldbergstraße 3,,,Weiterstadt,Hessen,64331,Germany,+49 6150 14337,http://www.hopfenherz.de,8.5624509,49.9136865
 493474e7-4d57-4472-8b95-693a9ea75543,Hütt,closed,Knallhuette 1,,,Baunatal,Hessen,34225,Germany,+49 561 499070,http://www.huett.de,9.4485783,51.2607152
-5ce68c09-7627-46a2-abf5-1899a94f8187,Kärrners,brewpub,7 Kurparkstraße,,,Bad Orb,Hessen,63619,Germany,+49 6052 2515,http://www.kaerrners.de,9.351436099999999,50.2234687
-6a106b60-b328-4d66-b8c3-8d6e2287ad87,Kellerwälder Brauhaus,closed,19 Kasseler Straße,,,Gilserberg,Hessen,34630,Germany,+49 6696 911811,http://www.kellerwaelder.de,9.0660204,50.9520639
-2c5dc79e-c4b9-4732-ad09-2ad80d709798,Kultland Brauerei,brewpub,8 Pappelweg,,,Friedberg (Hessen),Hessen,61169,Germany,+49 6031 7793990,http://www.kultland-brauerei.de,8.7911825,50.3258997
-11029e2d-3a21-4f9e-872c-fb242638c1ff,Landbrauerei Bierbacher,brewpub,8 Cent,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.bierbacher.de,9.3921847,50.6398732
-dac65787-0d73-45fe-80d2-9790fb3af01d,Landmuseum Ransel,closed,34 Kirchstraße,,,Lorch,Hessen,65391,Germany,+49 6726 2088,http://www.flk-ransel.de,7.8489247,50.1015761
-71beaa85-c67e-4b89-a6c9-993fdc969ea0,Lauterbacher-Auerhahn,brewpub,8 Cent,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.lauterbacher-auerhahn.de,9.3921847,50.6398732
+5ce68c09-7627-46a2-abf5-1899a94f8187,Kärrners,brewpub,Kurparkstraße 7,,,Bad Orb,Hessen,63619,Germany,+49 6052 2515,http://www.kaerrners.de,9.351436099999999,50.2234687
+6a106b60-b328-4d66-b8c3-8d6e2287ad87,Kellerwälder Brauhaus,closed,Kasseler Straße 19,,,Gilserberg,Hessen,34630,Germany,+49 6696 911811,http://www.kellerwaelder.de,9.0660204,50.9520639
+2c5dc79e-c4b9-4732-ad09-2ad80d709798,Kultland Brauerei,brewpub,Pappelweg 8,,,Friedberg (Hessen),Hessen,61169,Germany,+49 6031 7793990,http://www.kultland-brauerei.de,8.7911825,50.3258997
+11029e2d-3a21-4f9e-872c-fb242638c1ff,Landbrauerei Bierbacher,brewpub,Cent 8,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.bierbacher.de,9.3921847,50.6398732
+dac65787-0d73-45fe-80d2-9790fb3af01d,Landmuseum Ransel,closed,Kirchstraße 34,,,Lorch,Hessen,65391,Germany,+49 6726 2088,http://www.flk-ransel.de,7.8489247,50.1015761
+71beaa85-c67e-4b89-a6c9-993fdc969ea0,Lauterbacher-Auerhahn,brewpub,Cent 8,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.lauterbacher-auerhahn.de,9.3921847,50.6398732
 28dec8c3-c7d6-4a57-b1d6-2eb6dd0440f1,Licher,brewpub,Am-Hardtberg 1,,,Lich,Hessen,35423,Germany,+49 6404 820,http://www.licher.de,8.817150999999999,50.515228
-c6c293d9-8fd6-425e-a98e-d033ac9f8a20,Maus Bräu,brewpub,2 Am Backhaus,,,Hünfeld,Hessen,36088,Germany,+49 6652 9829900,http://www.mausbräu.de,9.77711,50.62818009999999
+c6c293d9-8fd6-425e-a98e-d033ac9f8a20,Maus Bräu,brewpub,Am Backhaus 2,,,Hünfeld,Hessen,36088,Germany,+49 6652 9829900,http://www.mausbräu.de,9.77711,50.62818009999999
 4d2986b7-3df5-4cbf-89fa-b0c0c3670520,Michelsbräu,brewpub,Fahrstraße 83,,,Babenhausen in Hessen,Hessen,64832,Germany,,http://www.michelsbraeu.de,,
-3303fa3c-6c42-4a2e-ae9f-794c5f177d01,Michelstädter Bier,brewpub,1 Mauerstraße,,,Michelstadt,Hessen,64720,Germany,+49 6061 5666,http://www.michelstaedterbier.de,9.0055034,49.6785118
-c284aa9c-f61f-4ec2-b380-d716c2d189fa,Niddaer Marktbräu,brewpub,21 Markt,,,Nidda,Hessen,63667,Germany,+49 6043 984328,http://www.hotel-zur-traube.de,9.0085745,50.4132436
-e5c25cc6-7b7c-4508-a1ed-d8f7fdc52966,Obermühle,brewpub,17 Gebrüder Wahl Straße,,,Braunfels,Hessen,35619,Germany,+49 6442 4382,http://www.obermuehle-braunfels.de,8.3820239,50.5163149
-1fb887b8-6ea6-4b0a-a6f9-c4825a1b7fe0,Osterbach Brauerei,brewpub,1a Untertor,,,Gemünden (Wohra),Hessen,35285,Germany,+49 1525 3305923,http://www.osterbachbrauerei.de,8.9701425,50.9728167
-bdbf2f67-fe45-467d-80f0-03dfe0f761e7,Petrimühle,micro,1 Bezirksstraße,,,Selters (Taunus),Hessen,65618,Germany,+49 174 4474443,http://www.petrimuehle.de,8.2570392,50.3693347
-e1c5aa63-5a7b-4fae-8ff0-2d1be43ea486,Pfungstädter,brewpub,1 Mühlstraße,,,Pfungstadt,Hessen,64319,Germany,+49 6157 955591,http://www.pfungstaedter.de,8.6046006,49.804539
-164e9b77-4e8b-4a8a-9e14-a41cb1b22a45,Ranseler Hofbräu,brewpub,5 Unterstraße,,,Lorch,Hessen,65391,Germany,+49 6726 839359,http://www.ranseler.de,7.84325,50.10101
-2fd148cb-77d1-4932-834a-6ddd3ac47e00,Rathausbräu,brewpub,1 Mauerstraße,,,Michelstadt,Hessen,64720,Germany,+49 6061 5666,http://www.rathausbraeu.de,9.0055034,49.6785118
-d52bbbd8-a576-478d-aa76-3815123ff3dc,Ratskeller,brewpub,8 Marktplatz,,,Darmstadt,Hessen,64283,Germany,+49 6151 26444,http://www.ratskeller-darmstadt.de,8.6558455,49.8720899
-f585eba2-0f06-4cf9-a583-fa5273218d5f,Rüsselsheimer Bräu,brewpub,4-6 Mainstraße,,,Rüsselsheim am Main,Hessen,65428,Germany,+49 6142 961240,http://www.ruesselsheimer-braeu.de,8.4112505,49.996112
-3367c1a1-8690-41a3-b7a8-8d766381096a,Schinkel's Brauhaus,brewpub,10 Oberburgstraße,,,Witzenhausen,Hessen,37213,Germany,+49 5542 911210,http://www.schinkels-brauhaus.de,9.854563700000002,51.3412361
-22968983-c168-4da2-91ee-a2188532cae3,Schmidt,brewpub,4 Kastanienstraße,,,Kronberg im Taunus,Hessen,61476,Germany,+49 6173 950095,http://www.getraenkeschmiede.de,8.5362457,50.1853463
-44aa86fc-0c73-4405-be5e-bf46f05a3f3a,Schmucker,brewpub,89 Hauptstraße,,,Mossautal,Hessen,64756,Germany,+49 6061 7020,http://www.schmucker-bier.de,8.9245452,49.6735565
-23bc8a59-0e9c-4b40-9b99-769aab5f5d6d,Schönecker Brauhaus,closed,28 Büdesheimer Straße,,,Schöneck,Hessen,61137,Germany,+49 6187 9020341,,8.8405917,50.2013919
-9f9e2f16-7609-42bb-81c3-374e59b80eea,Schwalm Bräu,brewpub,3 Ascheröder Straße,,,Schwalmstadt,Hessen,34613,Germany,+49 6691 23051,http://www.schwalmbraeu.de,9.1938712,50.91212480000001
-186dcb8a-d9e7-4b65-a42a-6389adfd1120,Selbolder Brauhaus,brewpub,10 Ringstraße,,,Langenselbold,Hessen,63505,Germany,+49 163 6344106,,9.038163899999999,50.1836823
-fe865192-788a-48a0-a7d3-9da08289e8a5,Umstädter Brauhaus,brewpub,28 Zimmerstraße,,,Groß-Umstadt,Hessen,64823,Germany,+49 6078 3345,http://www.umstaedter-brauhaus.de,8.9331142,49.8658724
-bb7df836-b0ca-4704-bc5f-fcc53fd7f388,WasserCraftWerk,brewpub,2 Isarstraße,,,Kelsterbach,Hessen,65451,Germany,+49 6142 5909590,http://www.wassercraftwerk.de,8.4770375,50.0370954
-98bc69b9-9b31-4d00-aa7d-3c6a17da29cd,Weingut Werk2,brewpub,2 Behlstraße,,,Geisenheim,Hessen,65366,Germany,+49 6722 4979712,http://www.werk2weine.de,7.967339999999999,49.98437999999999
-d9eb2106-81f1-4733-b21d-1f1661dd9331,Werk II,micro,35 Walburger Straße,,,Großalmerode,Hessen,37247,Germany,+49 5604 9369915,http://www.werk-2.eu,9.7704551,51.2292193
-1c7215d5-a73f-4ff6-878c-22d2d4769769,Weschnitztaler Braumanufaktur,closed,23 Siemensring,,,Fürth,Hessen,64658,Germany,,http://www.weschnitztaler.com,8.7908312,49.6570556
-688e59b1-f142-4697-92e9-83b90580bc7c,Wiesbadener Braumanufaktur,closed,55 Hagenauer Straße,,,Wiesbaden,Hessen,65203,Germany,+49 611 333355,http://www.wiesbadener.beer,8.214846699999999,50.0500578
-86116d5c-f2d0-4dfe-91bc-42ae29a9be7f,Wiesenmühle,brewpub,13 Wiesenmühlenstraße,,,Fulda,Hessen,36037,Germany,+49 661 928680,http://www.wiesenmuehle.de,9.668020000000002,50.55114
-86258dd3-bac4-41c4-96cb-0ddee3049fa2,Wilhelmsbader Hof Bräu,brewpub,80 Kesselstädter Straße,,,Hanau,Hessen,63454,Germany,+49 6181 5779090,http://www.wilhelmsbader-hof.de,8.877749099999999,50.14797919999999
-ceec01be-29e5-46fb-8fff-a678c7456958,Willinger Brauhaus,brewpub,2 In den Kämpen,,,Willingen (Upland),Hessen,34508,Germany,+49 5632 9690500,http://www.willinger-brauhaus.de,8.60508,51.2946
-523f41a9-ac2b-4015-bf02-9d3c413b9eef,Zum Braumeister,closed,5 Frankfurter Straße,,,Bad Soden-Salmünster,Hessen,63628,Germany,+49 6056 912911,http://www.zum-braumeister.de,9.368439,50.277567
-f0014403-0155-4532-9d9b-42d2ce16e65d,Zwölf Apostel,brewpub,1 Rosenbergerstraße,,,Frankfurt am Main,Hessen,60313,Germany,+49 69 288668,http://www.12aposteln-frankfurt.de,8.6863403,50.1173831
+3303fa3c-6c42-4a2e-ae9f-794c5f177d01,Michelstädter Bier,brewpub,Mauerstraße 1,,,Michelstadt,Hessen,64720,Germany,+49 6061 5666,http://www.michelstaedterbier.de,9.0055034,49.6785118
+c284aa9c-f61f-4ec2-b380-d716c2d189fa,Niddaer Marktbräu,brewpub,Markt 21,,,Nidda,Hessen,63667,Germany,+49 6043 984328,http://www.hotel-zur-traube.de,9.0085745,50.4132436
+e5c25cc6-7b7c-4508-a1ed-d8f7fdc52966,Obermühle,brewpub,Gebrüder Wahl Straße 17,,,Braunfels,Hessen,35619,Germany,+49 6442 4382,http://www.obermuehle-braunfels.de,8.3820239,50.5163149
+1fb887b8-6ea6-4b0a-a6f9-c4825a1b7fe0,Osterbach Brauerei,brewpub,Untertor 1a,,,Gemünden (Wohra),Hessen,35285,Germany,+49 1525 3305923,http://www.osterbachbrauerei.de,8.9701425,50.9728167
+bdbf2f67-fe45-467d-80f0-03dfe0f761e7,Petrimühle,micro,Bezirksstraße 1,,,Selters (Taunus),Hessen,65618,Germany,+49 174 4474443,http://www.petrimuehle.de,8.2570392,50.3693347
+e1c5aa63-5a7b-4fae-8ff0-2d1be43ea486,Pfungstädter,brewpub,Mühlstraße 1,,,Pfungstadt,Hessen,64319,Germany,+49 6157 955591,http://www.pfungstaedter.de,8.6046006,49.804539
+164e9b77-4e8b-4a8a-9e14-a41cb1b22a45,Ranseler Hofbräu,brewpub,Unterstraße 5,,,Lorch,Hessen,65391,Germany,+49 6726 839359,http://www.ranseler.de,7.84325,50.10101
+2fd148cb-77d1-4932-834a-6ddd3ac47e00,Rathausbräu,brewpub,Mauerstraße 1,,,Michelstadt,Hessen,64720,Germany,+49 6061 5666,http://www.rathausbraeu.de,9.0055034,49.6785118
+d52bbbd8-a576-478d-aa76-3815123ff3dc,Ratskeller,brewpub,Marktplatz 8,,,Darmstadt,Hessen,64283,Germany,+49 6151 26444,http://www.ratskeller-darmstadt.de,8.6558455,49.8720899
+f585eba2-0f06-4cf9-a583-fa5273218d5f,Rüsselsheimer Bräu,brewpub,Mainstraße 4-6,,,Rüsselsheim am Main,Hessen,65428,Germany,+49 6142 961240,http://www.ruesselsheimer-braeu.de,8.4112505,49.996112
+3367c1a1-8690-41a3-b7a8-8d766381096a,Schinkel's Brauhaus,brewpub,Oberburgstraße 10,,,Witzenhausen,Hessen,37213,Germany,+49 5542 911210,http://www.schinkels-brauhaus.de,9.854563700000002,51.3412361
+22968983-c168-4da2-91ee-a2188532cae3,Schmidt,brewpub,Kastanienstraße 4,,,Kronberg im Taunus,Hessen,61476,Germany,+49 6173 950095,http://www.getraenkeschmiede.de,8.5362457,50.1853463
+44aa86fc-0c73-4405-be5e-bf46f05a3f3a,Schmucker,brewpub,Hauptstraße 89,,,Mossautal,Hessen,64756,Germany,+49 6061 7020,http://www.schmucker-bier.de,8.9245452,49.6735565
+23bc8a59-0e9c-4b40-9b99-769aab5f5d6d,Schönecker Brauhaus,closed,Büdesheimer Straße 28,,,Schöneck,Hessen,61137,Germany,+49 6187 9020341,,8.8405917,50.2013919
+9f9e2f16-7609-42bb-81c3-374e59b80eea,Schwalm Bräu,brewpub,Ascheröder Straße 3,,,Schwalmstadt,Hessen,34613,Germany,+49 6691 23051,http://www.schwalmbraeu.de,9.1938712,50.91212480000001
+186dcb8a-d9e7-4b65-a42a-6389adfd1120,Selbolder Brauhaus,brewpub,Ringstraße 10,,,Langenselbold,Hessen,63505,Germany,+49 163 6344106,,9.038163899999999,50.1836823
+fe865192-788a-48a0-a7d3-9da08289e8a5,Umstädter Brauhaus,brewpub,Zimmerstraße 28,,,Groß-Umstadt,Hessen,64823,Germany,+49 6078 3345,http://www.umstaedter-brauhaus.de,8.9331142,49.8658724
+bb7df836-b0ca-4704-bc5f-fcc53fd7f388,WasserCraftWerk,brewpub,Isarstraße 2,,,Kelsterbach,Hessen,65451,Germany,+49 6142 5909590,http://www.wassercraftwerk.de,8.4770375,50.0370954
+98bc69b9-9b31-4d00-aa7d-3c6a17da29cd,Weingut Werk2,brewpub,Behlstraße 2,,,Geisenheim,Hessen,65366,Germany,+49 6722 4979712,http://www.werk2weine.de,7.967339999999999,49.98437999999999
+d9eb2106-81f1-4733-b21d-1f1661dd9331,Werk II,micro,Walburger Straße 35,,,Großalmerode,Hessen,37247,Germany,+49 5604 9369915,http://www.werk-2.eu,9.7704551,51.2292193
+1c7215d5-a73f-4ff6-878c-22d2d4769769,Weschnitztaler Braumanufaktur,closed,Siemensring 23,,,Fürth,Hessen,64658,Germany,,http://www.weschnitztaler.com,8.7908312,49.6570556
+688e59b1-f142-4697-92e9-83b90580bc7c,Wiesbadener Braumanufaktur,closed,Hagenauer Straße 55,,,Wiesbaden,Hessen,65203,Germany,+49 611 333355,http://www.wiesbadener.beer,8.214846699999999,50.0500578
+86116d5c-f2d0-4dfe-91bc-42ae29a9be7f,Wiesenmühle,brewpub,Wiesenmühlenstraße 13,,,Fulda,Hessen,36037,Germany,+49 661 928680,http://www.wiesenmuehle.de,9.668020000000002,50.55114
+86258dd3-bac4-41c4-96cb-0ddee3049fa2,Wilhelmsbader Hof Bräu,brewpub,Kesselstädter Straße 80,,,Hanau,Hessen,63454,Germany,+49 6181 5779090,http://www.wilhelmsbader-hof.de,8.877749099999999,50.14797919999999
+ceec01be-29e5-46fb-8fff-a678c7456958,Willinger Brauhaus,brewpub,In den Kämpen 2,,,Willingen (Upland),Hessen,34508,Germany,+49 5632 9690500,http://www.willinger-brauhaus.de,8.60508,51.2946
+523f41a9-ac2b-4015-bf02-9d3c413b9eef,Zum Braumeister,closed,Frankfurter Straße 5,,,Bad Soden-Salmünster,Hessen,63628,Germany,+49 6056 912911,http://www.zum-braumeister.de,9.368439,50.277567
+f0014403-0155-4532-9d9b-42d2ce16e65d,Zwölf Apostel,brewpub,Rosenbergerstraße 1,,,Frankfurt am Main,Hessen,60313,Germany,+49 69 288668,http://www.12aposteln-frankfurt.de,8.6863403,50.1173831

--- a/data/germany/hessen.csv
+++ b/data/germany/hessen.csv
@@ -49,7 +49,7 @@ dac65787-0d73-45fe-80d2-9790fb3af01d,Landmuseum Ransel,closed,34 Kirchstraße,,,
 71beaa85-c67e-4b89-a6c9-993fdc969ea0,Lauterbacher-Auerhahn,brewpub,8 Cent,,,Lauterbach (Hessen),Hessen,36341,Germany,+49 6641 1800,http://www.lauterbacher-auerhahn.de,9.3921847,50.6398732
 28dec8c3-c7d6-4a57-b1d6-2eb6dd0440f1,Licher,brewpub,Am-Hardtberg 1,,,Lich,Hessen,35423,Germany,+49 6404 820,http://www.licher.de,8.817150999999999,50.515228
 c6c293d9-8fd6-425e-a98e-d033ac9f8a20,Maus Bräu,brewpub,2 Am Backhaus,,,Hünfeld,Hessen,36088,Germany,+49 6652 9829900,http://www.mausbräu.de,9.77711,50.62818009999999
-4d2986b7-3df5-4cbf-89fa-b0c0c3670520,Michelsbräu,brewpub,Fahrstr. 83,,,Babenhausen in Hessen,Hessen,64832,Germany,,http://www.michelsbraeu.de,,
+4d2986b7-3df5-4cbf-89fa-b0c0c3670520,Michelsbräu,brewpub,Fahrstraße 83,,,Babenhausen in Hessen,Hessen,64832,Germany,,http://www.michelsbraeu.de,,
 3303fa3c-6c42-4a2e-ae9f-794c5f177d01,Michelstädter Bier,brewpub,1 Mauerstraße,,,Michelstadt,Hessen,64720,Germany,+49 6061 5666,http://www.michelstaedterbier.de,9.0055034,49.6785118
 c284aa9c-f61f-4ec2-b380-d716c2d189fa,Niddaer Marktbräu,brewpub,21 Markt,,,Nidda,Hessen,63667,Germany,+49 6043 984328,http://www.hotel-zur-traube.de,9.0085745,50.4132436
 e5c25cc6-7b7c-4508-a1ed-d8f7fdc52966,Obermühle,brewpub,17 Gebrüder Wahl Straße,,,Braunfels,Hessen,35619,Germany,+49 6442 4382,http://www.obermuehle-braunfels.de,8.3820239,50.5163149
@@ -67,7 +67,7 @@ f585eba2-0f06-4cf9-a583-fa5273218d5f,Rüsselsheimer Bräu,brewpub,4-6 Mainstraß
 9f9e2f16-7609-42bb-81c3-374e59b80eea,Schwalm Bräu,brewpub,3 Ascheröder Straße,,,Schwalmstadt,Hessen,34613,Germany,+49 6691 23051,http://www.schwalmbraeu.de,9.1938712,50.91212480000001
 186dcb8a-d9e7-4b65-a42a-6389adfd1120,Selbolder Brauhaus,brewpub,10 Ringstraße,,,Langenselbold,Hessen,63505,Germany,+49 163 6344106,,9.038163899999999,50.1836823
 fe865192-788a-48a0-a7d3-9da08289e8a5,Umstädter Brauhaus,brewpub,28 Zimmerstraße,,,Groß-Umstadt,Hessen,64823,Germany,+49 6078 3345,http://www.umstaedter-brauhaus.de,8.9331142,49.8658724
-bb7df836-b0ca-4704-bc5f-fcc53fd7f388,WasserCraftWerk,brewpub,2 Isarstrasse,,,Kelsterbach,Hessen,65451,Germany,+49 6142 5909590,http://www.wassercraftwerk.de,8.4770375,50.0370954
+bb7df836-b0ca-4704-bc5f-fcc53fd7f388,WasserCraftWerk,brewpub,2 Isarstraße,,,Kelsterbach,Hessen,65451,Germany,+49 6142 5909590,http://www.wassercraftwerk.de,8.4770375,50.0370954
 98bc69b9-9b31-4d00-aa7d-3c6a17da29cd,Weingut Werk2,brewpub,2 Behlstraße,,,Geisenheim,Hessen,65366,Germany,+49 6722 4979712,http://www.werk2weine.de,7.967339999999999,49.98437999999999
 d9eb2106-81f1-4733-b21d-1f1661dd9331,Werk II,micro,35 Walburger Straße,,,Großalmerode,Hessen,37247,Germany,+49 5604 9369915,http://www.werk-2.eu,9.7704551,51.2292193
 1c7215d5-a73f-4ff6-878c-22d2d4769769,Weschnitztaler Braumanufaktur,closed,23 Siemensring,,,Fürth,Hessen,64658,Germany,,http://www.weschnitztaler.com,8.7908312,49.6570556

--- a/data/germany/mecklenburg-vorpommern.csv
+++ b/data/germany/mecklenburg-vorpommern.csv
@@ -1,28 +1,28 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-c582e59d-8a6f-4adb-8777-40a49b33ad39,Barther Brauerei,closed,6 Gewerbegebiet am Betonwerk,,,Barth,Mecklenburg-Vorpommern,18356,Germany,+49 38231 450052,http://www.brauerei-barth.de,12.69887,54.371801
-a5148921-f252-4abc-9163-cb4c9f1f6bea,Brauhaus am Lohberg,brewpub,15 Kleine Hohe Straße,,,Wismar,Mecklenburg-Vorpommern,23966,Germany,+49 3841 618860,http://www.brauhaus-wismar.de,11.461062,53.89536289999999
-f9c2351f-cf80-4937-803f-667b205a2012,Brauhaus Müritz,brewpub,1 Am Tiefwarensee,,,Waren (Müritz),Mecklenburg-Vorpommern,17192,Germany,+49 3991 125933,http://www.brauhaus-mueritz.de,12.6869525,53.5166893
+c582e59d-8a6f-4adb-8777-40a49b33ad39,Barther Brauerei,closed,Gewerbegebiet am Betonwerk 6,,,Barth,Mecklenburg-Vorpommern,18356,Germany,+49 38231 450052,http://www.brauerei-barth.de,12.69887,54.371801
+a5148921-f252-4abc-9163-cb4c9f1f6bea,Brauhaus am Lohberg,brewpub,Kleine Hohe Straße 15,,,Wismar,Mecklenburg-Vorpommern,23966,Germany,+49 3841 618860,http://www.brauhaus-wismar.de,11.461062,53.89536289999999
+f9c2351f-cf80-4937-803f-667b205a2012,Brauhaus Müritz,brewpub,Am Tiefwarensee 1,,,Waren (Müritz),Mecklenburg-Vorpommern,17192,Germany,+49 3991 125933,http://www.brauhaus-mueritz.de,12.6869525,53.5166893
 7a6a00f5-9c24-439b-8781-49f9bdb7b9a3,Brauhaus Stadtkrug,brewpub,Markt 3/4,,,Ueckermünde,Mecklenburg-Vorpommern,17373,Germany,+49 39771 800,https://www.hotel-ueckermuende.de/de/brauhaus/brauhaus-stadtkrug,14.046447,53.7371126
-587e90e6-8c09-4efb-83f9-3b414b4d97aa,Braumanufaktur Ludwigslust,brewpub,26 Friedrich-Naumann-Allee,,,Ludwigslust,Mecklenburg-Vorpommern,19288,Germany,+49 171 5425535,http://www.braumanufaktur-lwl.de,11.4889895,53.3274291
+587e90e6-8c09-4efb-83f9-3b414b4d97aa,Braumanufaktur Ludwigslust,brewpub,Friedrich-Naumann-Allee 26,,,Ludwigslust,Mecklenburg-Vorpommern,19288,Germany,+49 171 5425535,http://www.braumanufaktur-lwl.de,11.4889895,53.3274291
 9cd604c2-b04f-4b40-bd49-8bf2f42ec8e4,Darguner Brauerei,large,Brauereistraße 3,,,Dargun,Mecklenburg-Vorpommern,17159,Germany,+49 39959 3010,https://www.darguner.com,12.869844,53.9036051
-0d71b301-e202-439e-94b4-ec172e1b5acb,Darßer Brauhaus,brewpub,1 Bergstraße,,,Prerow,Mecklenburg-Vorpommern,18375,Germany,+49 38233 717757,http://www.darsser-brauhaus.de,12.567468,54.446834
+0d71b301-e202-439e-94b4-ec172e1b5acb,Darßer Brauhaus,brewpub,Bergstraße 1,,,Prerow,Mecklenburg-Vorpommern,18375,Germany,+49 38233 717757,http://www.darsser-brauhaus.de,12.567468,54.446834
 e448f7fa-b5b4-465d-98a6-6ea0d4757f67,Fischland Brauerei,brewpub,Hafenweg 6,,,Ribnitz-Damgarten,Mecklenburg-Vorpommern,18347,Germany,,http://www.raeuscherhaus.com,12.4188497,54.3720244
-fa4ce5bf-a706-4a98-b655-8a79cd1f4a2c,Handwerksbrauerei Hennings,brewpub,1 Schloßstraße,,,Leezen,Mecklenburg-Vorpommern,19067,Germany,+49 174 2357281,http://www.brauerei-hennings.de,11.4983581,53.6621831
+fa4ce5bf-a706-4a98-b655-8a79cd1f4a2c,Handwerksbrauerei Hennings,brewpub,Schloßstraße 1,,,Leezen,Mecklenburg-Vorpommern,19067,Germany,+49 174 2357281,http://www.brauerei-hennings.de,11.4983581,53.6621831
 130b9a08-137e-4156-9da2-d4b4417d6278,Hanseatische Brauerei Rostock,large,Doberaner Straße 27,,,Rostock,Mecklenburg-Vorpommern,18057,Germany,+49 381 456450,https://www.rostocker.de/,12.1192313,54.0896156
 64c02706-f897-42b9-ada0-96f8e4fc11dc,Hofbrauerei Deibow,brewpub,Dorfstraße 23,,,Milow,Mecklenburg-Vorpommern,19300,Germany,,http://www.hof-lebenskraft.de,11.527733,53.176047
-89bdd113-feca-4cce-80db-8b9377bb2b51,Hoppen un Molt,brewpub,49 Alexandrinenstraße,,,Rostock,Mecklenburg-Vorpommern,18119,Germany,,http://www.hoppen-molt.de,12.086497,54.177895
-8b9baae5-efbd-42da-badc-80da5da3f0fa,Kaiserliches Postamt,brewpub,5 Schuhmarkt,,,Parchim,Mecklenburg-Vorpommern,19370,Germany,+49 1520 3167056,http://www.kaiserliches-postamt-parchim.de,11.8470391,53.4268357
-21155544-a1b0-4e46-9c02-1ac66821cd05,Marlower Brauerei,brewpub,33 Carl-Kossow-Straße,,,Marlow,Mecklenburg-Vorpommern,18337,Germany,,http://www.marlower-brauerei.de,12.569932,54.1507379
+89bdd113-feca-4cce-80db-8b9377bb2b51,Hoppen un Molt,brewpub,Alexandrinenstraße 49,,,Rostock,Mecklenburg-Vorpommern,18119,Germany,,http://www.hoppen-molt.de,12.086497,54.177895
+8b9baae5-efbd-42da-badc-80da5da3f0fa,Kaiserliches Postamt,brewpub,Schuhmarkt 5,,,Parchim,Mecklenburg-Vorpommern,19370,Germany,+49 1520 3167056,http://www.kaiserliches-postamt-parchim.de,11.8470391,53.4268357
+21155544-a1b0-4e46-9c02-1ac66821cd05,Marlower Brauerei,brewpub,Carl-Kossow-Straße 33,,,Marlow,Mecklenburg-Vorpommern,18337,Germany,,http://www.marlower-brauerei.de,12.569932,54.1507379
 34686681-560a-4f54-807b-537c2400117c,Mecklenburgische Brauerei Lübz,large,Eisenbeissstraße 1,,,Lübz,Mecklenburg-Vorpommern,19386,Germany,+49 38731 360,http://www.luebzer.de,12.0194563,53.46166239999999
-8a3aa3f4-6a75-434b-bc0f-3ea00ed70f2b,Ostsee Brauhaus,brewpub,41 Strandstraße,,,Kühlungsborn,Mecklenburg-Vorpommern,18225,Germany,+49 38293 4060,http://www.ostsee-brauhaus.de,11.7592242,54.1507843
+8a3aa3f4-6a75-434b-bc0f-3ea00ed70f2b,Ostsee Brauhaus,brewpub,Strandstraße 41,,,Kühlungsborn,Mecklenburg-Vorpommern,18225,Germany,+49 38293 4060,http://www.ostsee-brauhaus.de,11.7592242,54.1507843
 a0e41520-d127-4f8b-ad22-47147199432d,Recknitz Bräu,closed,Wohrenstorf 8,,,Cammin,Mecklenburg-Vorpommern,18195,Germany,,http://kuhstall-wohrenstorf.de,12.429163,54.010193
-3dbfe0be-63e4-47bf-92c7-5a9f9d7e5db3,Rügener Insel-Brauerei,brewpub,2C Hauptstraße,,,Rambin,Mecklenburg-Vorpommern,18573,Germany,+49 38306 238700,http://www.insel-brauerei.de,13.2007082,54.3532252
-658abf9d-036b-47fa-91f4-ef300f9a036a,Rumpelstilz Brauscheune,brewpub,19 Krummenhagener Straße,,,Steinhagen,Mecklenburg-Vorpommern,18442,Germany,+49 38327 61334,http://www.rumpelstilz-brauscheune.de,13.0202778,54.2333333
-b2259028-2f2a-4b78-8139-81eb94f119b5,Stolperhof,brewpub,33 Peenstraße,,,Stolpe an der Peene,Mecklenburg-Vorpommern,17391,Germany,+49 39721 5500,http://www.stolperhof.wordpress.com,13.5631602,53.8721921
-28a802af-d426-42cb-b32d-9ca55e200751,Störtebeker Braumanufaktur,brewpub,84-85 Greifswalder Chaussee,,,Stralsund,Mecklenburg-Vorpommern,18439,Germany,+49 3831 2550,http://www.stoertebeker-braumanufaktur.de,13.0949374,54.2906206
-f939cb49-7b21-4218-a680-99ac8db9c73b,Trotzenburg,brewpub,6 Tiergartenallee,,,Rostock,Mecklenburg-Vorpommern,18059,Germany,+49 381 203600,http://www.brauhaus-trotzenburg.de,12.0879972,54.0800457
+3dbfe0be-63e4-47bf-92c7-5a9f9d7e5db3,Rügener Insel-Brauerei,brewpub,Hauptstraße 2C,,,Rambin,Mecklenburg-Vorpommern,18573,Germany,+49 38306 238700,http://www.insel-brauerei.de,13.2007082,54.3532252
+658abf9d-036b-47fa-91f4-ef300f9a036a,Rumpelstilz Brauscheune,brewpub,Krummenhagener Straße 19,,,Steinhagen,Mecklenburg-Vorpommern,18442,Germany,+49 38327 61334,http://www.rumpelstilz-brauscheune.de,13.0202778,54.2333333
+b2259028-2f2a-4b78-8139-81eb94f119b5,Stolperhof,brewpub,Peenstraße 33,,,Stolpe an der Peene,Mecklenburg-Vorpommern,17391,Germany,+49 39721 5500,http://www.stolperhof.wordpress.com,13.5631602,53.8721921
+28a802af-d426-42cb-b32d-9ca55e200751,Störtebeker Braumanufaktur,brewpub,Greifswalder Chaussee 84-85,,,Stralsund,Mecklenburg-Vorpommern,18439,Germany,+49 3831 2550,http://www.stoertebeker-braumanufaktur.de,13.0949374,54.2906206
+f939cb49-7b21-4218-a680-99ac8db9c73b,Trotzenburg,brewpub,Tiergartenallee 6,,,Rostock,Mecklenburg-Vorpommern,18059,Germany,+49 381 203600,http://www.brauhaus-trotzenburg.de,12.0879972,54.0800457
 3142beb7-891b-43ce-8fe3-291a7bf2993d,Usedomer Brauhaus,brewpub,Friedensplatz,,,Heringsdorf,Mecklenburg-Vorpommern,17424,Germany,+49 38378 61421,http://www.usedomer-brauhaus.de,14.1662737,53.9558192
-fe135fc9-45cb-4b39-a1a5-2ffbb0760969,Vielanker Brauhaus,brewpub,1 Lindenplatz,,,Vielank,Mecklenburg-Vorpommern,19303,Germany,+49 38759 339180,http://www.vielanker-brauhaus.de,11.1396289,53.2356254
-daa8d4f5-9774-4dec-a0fd-840b12912437,Wallensteinkeller,brewpub,33 Rostocker Straße,,,Neubrandenburg,Mecklenburg-Vorpommern,17033,Germany,+49 395 5630789,http://www.wallensteinkeller-neubrandenburg.de,13.2464778,53.5584941
-5535482e-f9ff-45b1-ab71-d8fc0123b980,Wasserschloß Mellenthin,brewpub,5 Schlossallee,,,Mellenthin,Mecklenburg-Vorpommern,17429,Germany,+49 38379 28780,http://www.wasserschloss-mellenthin.de,14.0165056,53.9236835
-45af3a9c-bfac-4943-b350-084379807693,Zur Linde,brewpub,20 Dorfstraße,,,Mönchgut,Mecklenburg-Vorpommern,18586,Germany,+49 38308 5540,http://www.landgasthof-zur-linde-ruegen.de,13.7048231,54.3297447
+fe135fc9-45cb-4b39-a1a5-2ffbb0760969,Vielanker Brauhaus,brewpub,Lindenplatz 1,,,Vielank,Mecklenburg-Vorpommern,19303,Germany,+49 38759 339180,http://www.vielanker-brauhaus.de,11.1396289,53.2356254
+daa8d4f5-9774-4dec-a0fd-840b12912437,Wallensteinkeller,brewpub,Rostocker Straße 33,,,Neubrandenburg,Mecklenburg-Vorpommern,17033,Germany,+49 395 5630789,http://www.wallensteinkeller-neubrandenburg.de,13.2464778,53.5584941
+5535482e-f9ff-45b1-ab71-d8fc0123b980,Wasserschloß Mellenthin,brewpub,Schlossallee 5,,,Mellenthin,Mecklenburg-Vorpommern,17429,Germany,+49 38379 28780,http://www.wasserschloss-mellenthin.de,14.0165056,53.9236835
+45af3a9c-bfac-4943-b350-084379807693,Zur Linde,brewpub,Dorfstraße 20,,,Mönchgut,Mecklenburg-Vorpommern,18586,Germany,+49 38308 5540,http://www.landgasthof-zur-linde-ruegen.de,13.7048231,54.3297447

--- a/data/germany/niedersachsen.csv
+++ b/data/germany/niedersachsen.csv
@@ -68,7 +68,7 @@ a02e0ab0-1616-41be-b373-b0178025040f,Ratskeller Buxtehude,brewpub,2 Breite Stra�
 66d14bc0-6819-48e4-a14f-eed9a3cc4620,Schmieriger Lachs,micro,Gross-Ellenberg 4,,,Suhlendorf,Niedersachsen,29562,Germany,,,,
 2fa8ed82-9393-4897-a3e8-ea1150927f79,Schnuckenbräu,brewpub,3 Hünzingen,,,Walsrode,Niedersachsen,29664,Germany,+49 5161 970144,http://www.schnuckenbraeu.de,9.5880665,52.8979018
 4b716637-5727-436a-b05a-730bf39f3e90,Scholar,closed,8 Theaterstraße,,,Göttingen,Niedersachsen,37073,Germany,+49 551 41616,http://www.scholarbeer.com,9.937865000000002,51.53484
-6e5d4ec4-913f-4d88-a4d0-e3baa521b429,Schwarze Huhn,brewpub,Hildesheimer-Str. 8,,,Holle,Niedersachsen,31188,Germany,,http://www.schwarzeshuhn.de,10.1637872,52.10717709999999
+6e5d4ec4-913f-4d88-a4d0-e3baa521b429,Schwarze Huhn,brewpub,Hildesheimer-Straße 8,,,Holle,Niedersachsen,31188,Germany,,http://www.schwarzeshuhn.de,10.1637872,52.10717709999999
 92a0340b-6389-458c-abaa-924bdf31777d,Selsinger Hof,brewpub,1 Bahnhofstraße,,,Selsingen,Niedersachsen,27446,Germany,+49 4284 93930,http://www.schuetzenhof-selsingen.de,9.21393,53.37189
 4a80fbc7-94be-422e-bb04-8a6186b37d0f,Sommerbecker (Dachs),brewpub,9 Klein Sommerbeck,,,Dahlenburg,Niedersachsen,21368,Germany,+49 5851 9794291,http://www.sommerbecker-dachs.de,10.6792887,53.20199
 893abecf-4535-49e8-b05e-4bdbb50f1312,Stebner,brewpub,31 Rebenring,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.stebner-privatbrauerei.de,10.5302439,52.276725

--- a/data/germany/niedersachsen.csv
+++ b/data/germany/niedersachsen.csv
@@ -1,80 +1,80 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-cfa61f1d-4b3b-4fb1-a35a-f1fe25411e7c,Allersheim,closed,6 Allersheim,,,Holzminden,Niedersachsen,37603,Germany,+49 5531 1250,http://www.brauerei-allersheim.de,9.4794014,51.8424352
-df78986a-9a20-4a4b-a718-26698af122d6,Alt Neuhaus,brewpub,1 Bei der Kirche,,,Neuhaus (Oste),Niedersachsen,21785,Germany,+49 4752 841033,http://www.ulex.de,9.0347318,53.8014793
-1c5e34bb-a0bb-4342-a964-a65f7b19ccca,Altenauer Brauerei,brewpub,29 Breite Straße,,,Altenau im Harz,Niedersachsen,38707,Germany,+49 5328 217,http://www.altenauer-brauerei.de,10.4481894,51.80087839999999
-e25f3ee3-987d-4305-a595-56a957116658,Altes Brauhaus,brewpub,9 Am Alten Brauhaus,,,Wolfsburg,Niedersachsen,38442,Germany,+49 5362 3140,http://www.brauhaus-fallersleben.de,10.7172676,52.4166626
-1dbe2c5d-41f9-4859-9f94-79fc24e9fa51,Artland Bräu,closed,4 Haller Straße,,,Nortrup,Niedersachsen,49638,Germany,+49 5436 969617,http://www.artland-brauerei.de,7.88856,52.60442
-3160f48a-19ee-4517-b3e5-0829c6e6b48c,Auricher Probier,micro,11 Kreihüttenmoorweg,,,Aurich,Niedersachsen,26607,Germany,+49 4941 97040,http://www.auricher-probier.de,7.4895666,53.5035889
-ab5da324-e305-4b72-a672-b43f2563e3f7,Back- und Brauhaus Brinker,closed,3 Breiter Weg,,,Georgsmarienhütte,Niedersachsen,49124,Germany,+49 5401 2289,http://www.back-brauhaus.de,8.04412,52.20282
-7f6df298-f7c9-464b-b02d-aa3a121438c7,Bad Pyrmonter Hofbrauerei,closed,44 Hauptstraße,,,Bad Pyrmont,Niedersachsen,31812,Germany,+49 171 5810658,http://www.badpyrmonterhofbrauerei.de,9.3163424,51.9890526
-84f05688-b04a-41f4-b954-fa7498f7c9ff,Bannas Bier,micro,61A Bargloyer Straße,,,Wildeshausen,Niedersachsen,27793,Germany,+49 4431 72408,http://www.bannas-bier.de,8.4173862,52.8908857
-a6c0ec91-a2a9-4485-92a5-7cd09f3bb92b,Bergbräu,brewpub,10 Rosenstraße,,,Uslar,Niedersachsen,37170,Germany,+49 5571 92220,http://www.bergbraeu.de,9.6421466,51.65913219999999
-2b0480fd-b00c-4c17-8e45-72335027966e,Bleckeder Brauhaus,brewpub,20 Breite Straße,,,Bleckede,Niedersachsen,21354,Germany,+49 5852 500,http://www.bleckeder-brauhaus.de,10.7311599,53.2924935
-20d1adab-670d-4b5d-9a61-24065c88c819,boGler's,brewpub,4 Am Tiefen Moor,,,Uetze,Niedersachsen,31311,Germany,+49 1516 4695659,http://boglers.jimdo.com,10.142892,52.44978700000001
-3f551dd3-080d-49c8-b00a-4ceb58fd2211,Brauakademie Zellerfeld,brewpub,11 Bornhardtstraße,,,Clausthal-Zellerfeld,Niedersachsen,38678,Germany,+49 5328 80221,http://www.brauakademie-zellerfeld.com,10.3327056,51.8179671
-30ef4016-f88f-48d6-83ea-f49aa6eb7f12,Brauerei Beura,brewpub,35 Hasestraße,,,Osnabrück,Niedersachsen,49074,Germany,+49 541 24535,http://www.beura.de,8.0433629,52.2784618
-1c6a953b-ecd8-4e04-b8ab-00392fd91886,Brauerei Braunschweig,brewpub,31 Rebenring,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.oettinger-bier.de,10.5302439,52.276725
-9d3bb386-5264-4c58-b932-983733c17b5e,Brauhaus Goslar,brewpub,2 Marktkirchhof,,,Goslar,Niedersachsen,38640,Germany,+49 5321 685804,http://www.brauhaus-goslar.de,10.4280556,51.9052778
-3c94db44-d746-48a7-b628-46cefc72df42,BrauManufaktur Baltrum,closed,53 Westdorf,,,Baltrum,Niedersachsen,26579,Germany,+49 1525 3776437,http://www.bmb-baltrum.de,7.3711121,53.7267755
-ff11f642-8305-4fce-8150-b396510d8233,Burgwedeler Brauhaus,brewpub,5 Am Markt,,,Burgwedel,Niedersachsen,30938,Germany,+49 160 2502499,http://www.burgwedeler-brauerei.de/,9.8542999,52.49214
-e727713f-2a19-4113-bdb4-3381eb693317,Butjenter Brauhaus,brewpub,65 Butjadinger Straße,,,Nordenham,Niedersachsen,26954,Germany,+49 4731 93880,http://www.butjadinger-tor.de,8.441583699999999,53.48265929999999
-b8c294b5-a0d5-47c2-8656-7ee175fc97e6,CM Keller Bräu,closed,18 Lange Straße,,,Nordstemmen,Niedersachsen,31171,Germany,+49 1512 0132999,http://www.cm-keller-braeu.de,9.81552,52.18472999999999
-dfa7f4db-d811-48aa-a32f-c7a8553b66b9,Denner Bier,micro,7 Lange Reihe,,,Bad Münder am Deister,Niedersachsen,31848,Germany,+49 5151 100825,http://www.denner-bier.de,9.454983,52.142003
-772f5c4c-a853-4265-97b7-bb475458173a,Denver's,brewpub,56A Ringstraße,,,Wolfenbüttel,Niedersachsen,38304,Germany,+49 5331 887145,http://www.denvers.de,10.5124986,52.1644651
-babb10b1-14fc-47d8-92f9-79022707701a,Dorster Kesselbräu,brewpub,1 In den Angerhöfen,,,Osterode am Harz,Niedersachsen,37520,Germany,+49 5552 708604,http://www.dorster-kesselbraeu.de,10.1583552,51.6995976
-d30f73fc-dc08-418b-b0e0-a31253e65c54,Duderstädter Braumanufaktur,micro,13 Kardinal-Kopp-Straße,,,Duderstadt,Niedersachsen,37115,Germany,+49 1512 6598343,http://www.heimatliebe-bier.de,10.2632033,51.5151378
-80e98a1e-b097-471e-bb11-c4e3becedc17,Einbecker,brewpub,4-7 Papenstraße,,,Einbeck,Niedersachsen,37574,Germany,+49 5561 7970,http://www.einbecker.com,9.864616,51.8162371
-8e18c1f1-93b5-4d39-922d-f41f4fa73aaf,Ernst August,brewpub,13 Schmiedestraße,,,Hannover,Niedersachsen,30159,Germany,+49 511 365950,http://www.brauhaus.net,9.7346457,52.3730499
-ce128f72-6bd6-4224-bd21-c8635b3443fc,Gilde,brewpub,132 Hildesheimer Straße,,,Hannover,Niedersachsen,30173,Germany,+49 511 98080,http://www.gildebrau.de,9.753367299999999,52.3540077
-696fb1aa-6c91-4b7e-9dea-276490e9f17b,Grafschafter Brauhaus,brewpub,2 Vechteaue,,,Nordhorn,Niedersachsen,48529,Germany,+49 5921 723988,http://www.alteweberei.de,7.0747705,52.4320879
-3420d18c-f318-4fb4-a492-020b6a007b40,Gutshof Rethmar,brewpub,16 Gutsstraße,,,Sehnde,Niedersachsen,31319,Germany,+49 5138 4813330,http://www.gutshof-rethmar.de,10.0028824,52.3123302
-bfb96bdd-2462-4175-999c-a5a044aaa0eb,Härke,brewpub,5 Am Werderpark,,,Peine,Niedersachsen,31224,Germany,+49 5171 4050,http://www.braumanufaktur-haerke.de,10.2311566,52.3209846
-446a682e-ad4f-440b-9219-0bb172e499a2,Hartinger,brewpub,27 Waldkaterallee,,,Rinteln,Niedersachsen,31737,Germany,+49 5751 17980,http://www.waldkater.com,9.0823,52.20934
-bfb76922-6b7e-49c7-9a76-f6386467cca2,Häsefelder Brauerei,brewpub,4 Häsefeld,,,Langwedel,Niedersachsen,27299,Germany,+49 4232 267216,http://www.haesefelder-brauerei.de,9.166790599999999,52.983233
-1240cb01-94fd-47c2-bba8-ad4c5680442e,Herrenhäuser,brewpub,83-99 Herrenhäuser Straße,,,Hannover,Niedersachsen,30419,Germany,+49 511 79070,http://www.herrenhaeuser.de,9.6813253,52.3941539
-a0b9ab3d-2ffb-45fc-aecc-213a3f412a7f,Hildesheimer Braumanufaktur,brewpub,15 Goslarsche Landstraße,,,Hildesheim,Niedersachsen,31135,Germany,+49 163 9633516,http://www.hildesheimer-braumanufaktur.de,9.970095299999999,52.1509504
-84bd6712-07df-4268-969a-b8d97064907d,Hillthaler,brewpub,47 Wiefelsteder Straße,,,Bad Zwischenahn,Niedersachsen,26160,Germany,+49 4403 9390930,http://www.hillthaler.jimdo.com,8.043346699999999,53.1936291
-fdba5e04-3c3f-4ade-96d0-a1c54527ecd1,Hofschänke / Braumanufaktur Christof Töbelmann,brewpub,41 Hauptstraße,,,Wagenfeld,Niedersachsen,49419,Germany,+49 5444 398,http://www.steakhaus-wagenfeld.de,8.588771300000001,52.5488753
-71c5636d-ffeb-48d0-8797-94838c7bf87e,Hotel Frommann,brewpub,8 Harburger Straße,,,Buchholz in der Nordheide,Niedersachsen,21244,Germany,+49 4181 2870,http://www.hotelfrommann.de,9.8744205,53.3662212
-e54974fc-c342-420b-9233-2351a7b73855,Hüpscher Werkstatt,brewpub,24 An der Halbe,,,Pattensen,Niedersachsen,30982,Germany,+49 5045 4580831,http://www.hüpscher.de,9.7312944,52.2402943
-9577951f-f652-42c0-b79f-d07f9d1b8fbf,Inselbrauerei,closed,21 Hauptstraße,,,Langeoog,Niedersachsen,26465,Germany,+49 173 6253000,http://www.langeooger.com,7.4807009,53.7466853
-93b780d1-a28a-4706-b080-9f8d9f410f91,Jever,brewpub,18 Elisabethufer,,,Jever,Niedersachsen,26441,Germany,+49 4461 130,http://www.jever.de,7.9018218,53.5754685
-eeb3df2a-786f-4615-a184-5ae27847b980,Klindworths,brewpub,1 Hauptstraße,,,Sauensiek,Niedersachsen,21644,Germany,+49 4169 91100,http://www.klindworths.de,9.595877699999999,53.3796015
-feec2fa6-b7c6-4023-ad6a-4db3a6866aec,Küsten-Brauerei,brewpub,1 Buttforder Straße,,,Werdum,Niedersachsen,26427,Germany,+49 4974 546,http://www.watt-n-bier.de,7.715992999999998,53.66013659999999
-ba57d2d7-3e50-4316-8b3f-cb41370f5d15,Landhaus,brewpub,2 Heinrich-Schulte-Straße,,,Lünne,Niedersachsen,48480,Germany,+49 5906 933490,http://www.landhaus-brauerei.de,7.4270722,52.42866950000001
-792fb587-0f0e-4869-a913-06ffc34272d2,Mad Dukes Brewery,brewpub,13 Fliederkehre,,,Kissenbrück,Niedersachsen,38324,Germany,+49 5331 9944776,http://www.maddukes.de,10.5846584,52.112607
-acab4733-3cfa-4920-b6b1-ce06bd7d89a0,Mälzer,brewpub,43 Heiligengeiststraße,,,Lüneburg,Niedersachsen,21335,Germany,+49 4131 47777,http://www.maelzer-brauhaus.de,10.4081269,53.2469535
-5fb731a8-a01a-4095-a13b-2f12a05953bf,Marienbräu,brewpub,1 Apothekerstraße,,,Jever,Niedersachsen,26441,Germany,+49 4461 744990,http://www.marienbraeu.com,7.901264400000001,53.5744936
-38b64d27-25c0-4ea6-99c2-8068b27286cf,Martfelder Hausbrauerei,brewpub,3A Elbinger Straße,,,Martfeld,Niedersachsen,27327,Germany,+49 163 4313717,http://www.mhb-bier.de,9.0652493,52.8856439
-03063929-3d60-4760-be99-a0b1b0dc53a4,Mashsee Brauerei,brewpub,17 Am Eisenwerk,,,Hannover,Niedersachsen,30519,Germany,+49 511 37022974,http://www.mashsee.de,9.7848756,52.3280245
-b78af64b-a803-4f5b-a147-ba3466855b98,Meierhöfer,brewpub,1 Ahnser Straße,,,Obernkirchen,Niedersachsen,31683,Germany,+49 5724 7409,http://www.obernkirchen-info.de/hausbrauerei-meierhoefer/,9.0964835,52.27216989999999
-027443c9-ea8f-42d0-a960-07ca8c7e41b4,Meiers Lebenslust,brewpub,64 Osterstraße,,,Hannover,Niedersachsen,30159,Germany,+49 511 8982250,http://www.meiers-lebenslust.de,9.7404573,52.3684838
-53dce0e4-5f96-4a65-9da8-31a1c1433a62,Mikrobrauerei Ralf Hellmer,closed,9 Königsberger Straße,,,Rastede,Niedersachsen,26180,Germany,+49 1522 2442039,http://www.mikrobrauerei-hellmer.business.site,8.18848,53.2426719
-b4ce04a0-7086-4abc-a6d4-f556aed60a4c,Mühlengrund,brewpub,1 Mühlenstraße,,,Wienhausen,Niedersachsen,29342,Germany,+49 5149 331,http://www.braugasthaus-muehlengrund.de,10.1874149,52.5800645
-119863eb-141e-4d47-b754-f6af2815440e,My Bier,brewpub,34 Oldenburger Straße,,,Wardenburg,Niedersachsen,26203,Germany,+49 1525 2843718,http://www.my-bier.de,8.1919271,53.0914396
-7b1e7ab0-4c2f-4236-aeeb-c18f312fbed8,National Jürgen Brauerei,brewpub,31 Rebenring,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.njb-brauerei.de,10.5302439,52.276725
-f5638c4d-1fcc-4a01-b5f8-9f48f97081af,Nolte,brewpub,102 Dahlenburger Landstraße,,,Lüneburg,Niedersachsen,21337,Germany,+49 4131 52232,http://www.gasthausbrauerei-nolte.de,10.4391404,53.2461851
-63164674-addc-4606-a8ac-ca67d937ba14,Nordeneyer Brauhaus,brewpub,18 Im Gewerbegelände,,,Norderney,Niedersachsen,26548,Germany,,http://www.norderneyer-brauhaus.de/,7.1749389,53.7113849
-dc6974b1-f128-43d3-8035-5e7908d1539a,Ols Oldenburger Brauerei,brewpub,34 Stau,,,Oldenburg (Oldb),Niedersachsen,26122,Germany,+49 441 26189,http://www.ols-brauerei.de,8.2211828,53.14075099999999
-8192f65d-5f9a-4925-961a-db2058d22d00,Ostfriesen-Bräu,brewpub,8 Voerstad,,,Großefehn,Niedersachsen,26629,Germany,+49 4946 203,http://www.ostfriesenbraeu.de,7.6111112,53.3502994
-d1fdcc76-b264-484e-88f4-5af2f00c898c,Pibe's Brauerei,brewpub,19 An den Eichen,,,Reinstorf,Niedersachsen,21400,Germany,,http://www.facebook.com/pibesbrewporn/,10.5609456,53.2652449
-a208c1fc-5748-4dfa-9622-4e1927056305,Privatbrauerei Braugut Stuhr,brewpub,41 Waldstraße,,,Stuhr,Niedersachsen,28816,Germany,+49 1525 3533052,http://www.braugutstuhr.de/,8.7040045,52.9563272
-26720dc2-6d31-4eba-8f96-e4b325755d2d,Rampendahl,brewpub,35 Hasestraße,,,Osnabrück,Niedersachsen,49074,Germany,+49 541 24535,http://www.rampendahl.de,8.0433629,52.2784618
-d8ed4979-36a9-4597-bee3-06c9a8c5a930,Ratsbrauhaus,brewpub,3 Markt,,,Hann. Münden,Niedersachsen,34346,Germany,+49 5541 957107,http://www.ratsbrauhaus.de,9.6511915,51.4174961
-a02e0ab0-1616-41be-b373-b0178025040f,Ratskeller Buxtehude,brewpub,2 Breite Straße,,,Buxtehude,Niedersachsen,21614,Germany,+49 4161 7529967,http://www.ratskeller-buxtehude.de,9.700249,53.4765033
-1574b74f-75a3-4edb-a92d-12f54efa351e,Robens Craft Beer,brewpub,25 Mittelroder Straße,,,Springe,Niedersachsen,31832,Germany,+49 5044 880562,http://www.german-craft-beer-factory.de,9.6532772,52.1760117
-88b566f6-6a09-40c2-b9c1-3f127ed853fb,Rupp-Bräu,brewpub,10 Feggendorfer Straße,,,Lauenau,Niedersachsen,31867,Germany,+49 5043 2275,http://www.ruppbraeu.de,9.369273,52.27908799999999
-8ec1618d-c67f-40f4-a34e-ba014d770c83,Schadt's,brewpub,28 Höhe,,,Braunschweig,Niedersachsen,38100,Germany,+49 531 400349,http://www.schadts-brauerei-gasthaus.de,10.5227371,52.2655362
+cfa61f1d-4b3b-4fb1-a35a-f1fe25411e7c,Allersheim,closed,Allersheim 6,,,Holzminden,Niedersachsen,37603,Germany,+49 5531 1250,http://www.brauerei-allersheim.de,9.4794014,51.8424352
+df78986a-9a20-4a4b-a718-26698af122d6,Alt Neuhaus,brewpub,Bei der Kirche 1,,,Neuhaus (Oste),Niedersachsen,21785,Germany,+49 4752 841033,http://www.ulex.de,9.0347318,53.8014793
+1c5e34bb-a0bb-4342-a964-a65f7b19ccca,Altenauer Brauerei,brewpub,Breite Straße 29,,,Altenau im Harz,Niedersachsen,38707,Germany,+49 5328 217,http://www.altenauer-brauerei.de,10.4481894,51.80087839999999
+e25f3ee3-987d-4305-a595-56a957116658,Altes Brauhaus,brewpub,Am Alten Brauhaus 9,,,Wolfsburg,Niedersachsen,38442,Germany,+49 5362 3140,http://www.brauhaus-fallersleben.de,10.7172676,52.4166626
+1dbe2c5d-41f9-4859-9f94-79fc24e9fa51,Artland Bräu,closed,Haller Straße 4,,,Nortrup,Niedersachsen,49638,Germany,+49 5436 969617,http://www.artland-brauerei.de,7.88856,52.60442
+3160f48a-19ee-4517-b3e5-0829c6e6b48c,Auricher Probier,micro,Kreihüttenmoorweg 11,,,Aurich,Niedersachsen,26607,Germany,+49 4941 97040,http://www.auricher-probier.de,7.4895666,53.5035889
+ab5da324-e305-4b72-a672-b43f2563e3f7,Back- und Brauhaus Brinker,closed,Breiter Weg 3,,,Georgsmarienhütte,Niedersachsen,49124,Germany,+49 5401 2289,http://www.back-brauhaus.de,8.04412,52.20282
+7f6df298-f7c9-464b-b02d-aa3a121438c7,Bad Pyrmonter Hofbrauerei,closed,Hauptstraße 44,,,Bad Pyrmont,Niedersachsen,31812,Germany,+49 171 5810658,http://www.badpyrmonterhofbrauerei.de,9.3163424,51.9890526
+84f05688-b04a-41f4-b954-fa7498f7c9ff,Bannas Bier,micro,Bargloyer Straße 61A,,,Wildeshausen,Niedersachsen,27793,Germany,+49 4431 72408,http://www.bannas-bier.de,8.4173862,52.8908857
+a6c0ec91-a2a9-4485-92a5-7cd09f3bb92b,Bergbräu,brewpub,Rosenstraße 10,,,Uslar,Niedersachsen,37170,Germany,+49 5571 92220,http://www.bergbraeu.de,9.6421466,51.65913219999999
+2b0480fd-b00c-4c17-8e45-72335027966e,Bleckeder Brauhaus,brewpub,Breite Straße 20,,,Bleckede,Niedersachsen,21354,Germany,+49 5852 500,http://www.bleckeder-brauhaus.de,10.7311599,53.2924935
+20d1adab-670d-4b5d-9a61-24065c88c819,boGler's,brewpub,Am Tiefen Moor 4,,,Uetze,Niedersachsen,31311,Germany,+49 1516 4695659,http://boglers.jimdo.com,10.142892,52.44978700000001
+3f551dd3-080d-49c8-b00a-4ceb58fd2211,Brauakademie Zellerfeld,brewpub,Bornhardtstraße 11,,,Clausthal-Zellerfeld,Niedersachsen,38678,Germany,+49 5328 80221,http://www.brauakademie-zellerfeld.com,10.3327056,51.8179671
+30ef4016-f88f-48d6-83ea-f49aa6eb7f12,Brauerei Beura,brewpub,Hasestraße 35,,,Osnabrück,Niedersachsen,49074,Germany,+49 541 24535,http://www.beura.de,8.0433629,52.2784618
+1c6a953b-ecd8-4e04-b8ab-00392fd91886,Brauerei Braunschweig,brewpub,Rebenring 31,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.oettinger-bier.de,10.5302439,52.276725
+9d3bb386-5264-4c58-b932-983733c17b5e,Brauhaus Goslar,brewpub,Marktkirchhof 2,,,Goslar,Niedersachsen,38640,Germany,+49 5321 685804,http://www.brauhaus-goslar.de,10.4280556,51.9052778
+3c94db44-d746-48a7-b628-46cefc72df42,BrauManufaktur Baltrum,closed,Westdorf 53,,,Baltrum,Niedersachsen,26579,Germany,+49 1525 3776437,http://www.bmb-baltrum.de,7.3711121,53.7267755
+ff11f642-8305-4fce-8150-b396510d8233,Burgwedeler Brauhaus,brewpub,Am Markt 5,,,Burgwedel,Niedersachsen,30938,Germany,+49 160 2502499,http://www.burgwedeler-brauerei.de/,9.8542999,52.49214
+e727713f-2a19-4113-bdb4-3381eb693317,Butjenter Brauhaus,brewpub,Butjadinger Straße 65,,,Nordenham,Niedersachsen,26954,Germany,+49 4731 93880,http://www.butjadinger-tor.de,8.441583699999999,53.48265929999999
+b8c294b5-a0d5-47c2-8656-7ee175fc97e6,CM Keller Bräu,closed,Lange Straße 18,,,Nordstemmen,Niedersachsen,31171,Germany,+49 1512 0132999,http://www.cm-keller-braeu.de,9.81552,52.18472999999999
+dfa7f4db-d811-48aa-a32f-c7a8553b66b9,Denner Bier,micro,Lange Reihe 7,,,Bad Münder am Deister,Niedersachsen,31848,Germany,+49 5151 100825,http://www.denner-bier.de,9.454983,52.142003
+772f5c4c-a853-4265-97b7-bb475458173a,Denver's,brewpub,Ringstraße 56A,,,Wolfenbüttel,Niedersachsen,38304,Germany,+49 5331 887145,http://www.denvers.de,10.5124986,52.1644651
+babb10b1-14fc-47d8-92f9-79022707701a,Dorster Kesselbräu,brewpub,In den Angerhöfen 1,,,Osterode am Harz,Niedersachsen,37520,Germany,+49 5552 708604,http://www.dorster-kesselbraeu.de,10.1583552,51.6995976
+d30f73fc-dc08-418b-b0e0-a31253e65c54,Duderstädter Braumanufaktur,micro,Kardinal-Kopp-Straße 13,,,Duderstadt,Niedersachsen,37115,Germany,+49 1512 6598343,http://www.heimatliebe-bier.de,10.2632033,51.5151378
+80e98a1e-b097-471e-bb11-c4e3becedc17,Einbecker,brewpub,Papenstraße 4-7,,,Einbeck,Niedersachsen,37574,Germany,+49 5561 7970,http://www.einbecker.com,9.864616,51.8162371
+8e18c1f1-93b5-4d39-922d-f41f4fa73aaf,Ernst August,brewpub,Schmiedestraße 13,,,Hannover,Niedersachsen,30159,Germany,+49 511 365950,http://www.brauhaus.net,9.7346457,52.3730499
+ce128f72-6bd6-4224-bd21-c8635b3443fc,Gilde,brewpub,Hildesheimer Straße 132,,,Hannover,Niedersachsen,30173,Germany,+49 511 98080,http://www.gildebrau.de,9.753367299999999,52.3540077
+696fb1aa-6c91-4b7e-9dea-276490e9f17b,Grafschafter Brauhaus,brewpub,Vechteaue 2,,,Nordhorn,Niedersachsen,48529,Germany,+49 5921 723988,http://www.alteweberei.de,7.0747705,52.4320879
+3420d18c-f318-4fb4-a492-020b6a007b40,Gutshof Rethmar,brewpub,Gutsstraße 16,,,Sehnde,Niedersachsen,31319,Germany,+49 5138 4813330,http://www.gutshof-rethmar.de,10.0028824,52.3123302
+bfb96bdd-2462-4175-999c-a5a044aaa0eb,Härke,brewpub,Am Werderpark 5,,,Peine,Niedersachsen,31224,Germany,+49 5171 4050,http://www.braumanufaktur-haerke.de,10.2311566,52.3209846
+446a682e-ad4f-440b-9219-0bb172e499a2,Hartinger,brewpub,Waldkaterallee 27,,,Rinteln,Niedersachsen,31737,Germany,+49 5751 17980,http://www.waldkater.com,9.0823,52.20934
+bfb76922-6b7e-49c7-9a76-f6386467cca2,Häsefelder Brauerei,brewpub,Häsefeld 4,,,Langwedel,Niedersachsen,27299,Germany,+49 4232 267216,http://www.haesefelder-brauerei.de,9.166790599999999,52.983233
+1240cb01-94fd-47c2-bba8-ad4c5680442e,Herrenhäuser,brewpub,Herrenhäuser Straße 83-99,,,Hannover,Niedersachsen,30419,Germany,+49 511 79070,http://www.herrenhaeuser.de,9.6813253,52.3941539
+a0b9ab3d-2ffb-45fc-aecc-213a3f412a7f,Hildesheimer Braumanufaktur,brewpub,Goslarsche Landstraße 15,,,Hildesheim,Niedersachsen,31135,Germany,+49 163 9633516,http://www.hildesheimer-braumanufaktur.de,9.970095299999999,52.1509504
+84bd6712-07df-4268-969a-b8d97064907d,Hillthaler,brewpub,Wiefelsteder Straße 47,,,Bad Zwischenahn,Niedersachsen,26160,Germany,+49 4403 9390930,http://www.hillthaler.jimdo.com,8.043346699999999,53.1936291
+fdba5e04-3c3f-4ade-96d0-a1c54527ecd1,Hofschänke / Braumanufaktur Christof Töbelmann,brewpub,Hauptstraße 41,,,Wagenfeld,Niedersachsen,49419,Germany,+49 5444 398,http://www.steakhaus-wagenfeld.de,8.588771300000001,52.5488753
+71c5636d-ffeb-48d0-8797-94838c7bf87e,Hotel Frommann,brewpub,Harburger Straße 8,,,Buchholz in der Nordheide,Niedersachsen,21244,Germany,+49 4181 2870,http://www.hotelfrommann.de,9.8744205,53.3662212
+e54974fc-c342-420b-9233-2351a7b73855,Hüpscher Werkstatt,brewpub,An der Halbe 24,,,Pattensen,Niedersachsen,30982,Germany,+49 5045 4580831,http://www.hüpscher.de,9.7312944,52.2402943
+9577951f-f652-42c0-b79f-d07f9d1b8fbf,Inselbrauerei,closed,Hauptstraße 21,,,Langeoog,Niedersachsen,26465,Germany,+49 173 6253000,http://www.langeooger.com,7.4807009,53.7466853
+93b780d1-a28a-4706-b080-9f8d9f410f91,Jever,brewpub,Elisabethufer 18,,,Jever,Niedersachsen,26441,Germany,+49 4461 130,http://www.jever.de,7.9018218,53.5754685
+eeb3df2a-786f-4615-a184-5ae27847b980,Klindworths,brewpub,Hauptstraße 1,,,Sauensiek,Niedersachsen,21644,Germany,+49 4169 91100,http://www.klindworths.de,9.595877699999999,53.3796015
+feec2fa6-b7c6-4023-ad6a-4db3a6866aec,Küsten-Brauerei,brewpub,Buttforder Straße 1,,,Werdum,Niedersachsen,26427,Germany,+49 4974 546,http://www.watt-n-bier.de,7.715992999999998,53.66013659999999
+ba57d2d7-3e50-4316-8b3f-cb41370f5d15,Landhaus,brewpub,Heinrich-Schulte-Straße 2,,,Lünne,Niedersachsen,48480,Germany,+49 5906 933490,http://www.landhaus-brauerei.de,7.4270722,52.42866950000001
+792fb587-0f0e-4869-a913-06ffc34272d2,Mad Dukes Brewery,brewpub,Fliederkehre 13,,,Kissenbrück,Niedersachsen,38324,Germany,+49 5331 9944776,http://www.maddukes.de,10.5846584,52.112607
+acab4733-3cfa-4920-b6b1-ce06bd7d89a0,Mälzer,brewpub,Heiligengeiststraße 43,,,Lüneburg,Niedersachsen,21335,Germany,+49 4131 47777,http://www.maelzer-brauhaus.de,10.4081269,53.2469535
+5fb731a8-a01a-4095-a13b-2f12a05953bf,Marienbräu,brewpub,Apothekerstraße 1,,,Jever,Niedersachsen,26441,Germany,+49 4461 744990,http://www.marienbraeu.com,7.901264400000001,53.5744936
+38b64d27-25c0-4ea6-99c2-8068b27286cf,Martfelder Hausbrauerei,brewpub,Elbinger Straße 3A,,,Martfeld,Niedersachsen,27327,Germany,+49 163 4313717,http://www.mhb-bier.de,9.0652493,52.8856439
+03063929-3d60-4760-be99-a0b1b0dc53a4,Mashsee Brauerei,brewpub,Am Eisenwerk 17,,,Hannover,Niedersachsen,30519,Germany,+49 511 37022974,http://www.mashsee.de,9.7848756,52.3280245
+b78af64b-a803-4f5b-a147-ba3466855b98,Meierhöfer,brewpub,Ahnser Straße 1,,,Obernkirchen,Niedersachsen,31683,Germany,+49 5724 7409,http://www.obernkirchen-info.de/hausbrauerei-meierhoefer/,9.0964835,52.27216989999999
+027443c9-ea8f-42d0-a960-07ca8c7e41b4,Meiers Lebenslust,brewpub,Osterstraße 64,,,Hannover,Niedersachsen,30159,Germany,+49 511 8982250,http://www.meiers-lebenslust.de,9.7404573,52.3684838
+53dce0e4-5f96-4a65-9da8-31a1c1433a62,Mikrobrauerei Ralf Hellmer,closed,Königsberger Straße 9,,,Rastede,Niedersachsen,26180,Germany,+49 1522 2442039,http://www.mikrobrauerei-hellmer.business.site,8.18848,53.2426719
+b4ce04a0-7086-4abc-a6d4-f556aed60a4c,Mühlengrund,brewpub,Mühlenstraße 1,,,Wienhausen,Niedersachsen,29342,Germany,+49 5149 331,http://www.braugasthaus-muehlengrund.de,10.1874149,52.5800645
+119863eb-141e-4d47-b754-f6af2815440e,My Bier,brewpub,Oldenburger Straße 34,,,Wardenburg,Niedersachsen,26203,Germany,+49 1525 2843718,http://www.my-bier.de,8.1919271,53.0914396
+7b1e7ab0-4c2f-4236-aeeb-c18f312fbed8,National Jürgen Brauerei,brewpub,Rebenring 31,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.njb-brauerei.de,10.5302439,52.276725
+f5638c4d-1fcc-4a01-b5f8-9f48f97081af,Nolte,brewpub,Dahlenburger Landstraße 102,,,Lüneburg,Niedersachsen,21337,Germany,+49 4131 52232,http://www.gasthausbrauerei-nolte.de,10.4391404,53.2461851
+63164674-addc-4606-a8ac-ca67d937ba14,Nordeneyer Brauhaus,brewpub,Im Gewerbegelände 18,,,Norderney,Niedersachsen,26548,Germany,,http://www.norderneyer-brauhaus.de/,7.1749389,53.7113849
+dc6974b1-f128-43d3-8035-5e7908d1539a,Ols Oldenburger Brauerei,brewpub,Stau 34,,,Oldenburg (Oldb),Niedersachsen,26122,Germany,+49 441 26189,http://www.ols-brauerei.de,8.2211828,53.14075099999999
+8192f65d-5f9a-4925-961a-db2058d22d00,Ostfriesen-Bräu,brewpub,Voerstad 8,,,Großefehn,Niedersachsen,26629,Germany,+49 4946 203,http://www.ostfriesenbraeu.de,7.6111112,53.3502994
+d1fdcc76-b264-484e-88f4-5af2f00c898c,Pibe's Brauerei,brewpub,An den Eichen 19,,,Reinstorf,Niedersachsen,21400,Germany,,http://www.facebook.com/pibesbrewporn/,10.5609456,53.2652449
+a208c1fc-5748-4dfa-9622-4e1927056305,Privatbrauerei Braugut Stuhr,brewpub,Waldstraße 41,,,Stuhr,Niedersachsen,28816,Germany,+49 1525 3533052,http://www.braugutstuhr.de/,8.7040045,52.9563272
+26720dc2-6d31-4eba-8f96-e4b325755d2d,Rampendahl,brewpub,Hasestraße 35,,,Osnabrück,Niedersachsen,49074,Germany,+49 541 24535,http://www.rampendahl.de,8.0433629,52.2784618
+d8ed4979-36a9-4597-bee3-06c9a8c5a930,Ratsbrauhaus,brewpub,Markt 3,,,Hann. Münden,Niedersachsen,34346,Germany,+49 5541 957107,http://www.ratsbrauhaus.de,9.6511915,51.4174961
+a02e0ab0-1616-41be-b373-b0178025040f,Ratskeller Buxtehude,brewpub,Breite Straße 2,,,Buxtehude,Niedersachsen,21614,Germany,+49 4161 7529967,http://www.ratskeller-buxtehude.de,9.700249,53.4765033
+1574b74f-75a3-4edb-a92d-12f54efa351e,Robens Craft Beer,brewpub,Mittelroder Straße 25,,,Springe,Niedersachsen,31832,Germany,+49 5044 880562,http://www.german-craft-beer-factory.de,9.6532772,52.1760117
+88b566f6-6a09-40c2-b9c1-3f127ed853fb,Rupp-Bräu,brewpub,Feggendorfer Straße 10,,,Lauenau,Niedersachsen,31867,Germany,+49 5043 2275,http://www.ruppbraeu.de,9.369273,52.27908799999999
+8ec1618d-c67f-40f4-a34e-ba014d770c83,Schadt's,brewpub,Höhe 28,,,Braunschweig,Niedersachsen,38100,Germany,+49 531 400349,http://www.schadts-brauerei-gasthaus.de,10.5227371,52.2655362
 66d14bc0-6819-48e4-a14f-eed9a3cc4620,Schmieriger Lachs,micro,Gross-Ellenberg 4,,,Suhlendorf,Niedersachsen,29562,Germany,,,,
-2fa8ed82-9393-4897-a3e8-ea1150927f79,Schnuckenbräu,brewpub,3 Hünzingen,,,Walsrode,Niedersachsen,29664,Germany,+49 5161 970144,http://www.schnuckenbraeu.de,9.5880665,52.8979018
-4b716637-5727-436a-b05a-730bf39f3e90,Scholar,closed,8 Theaterstraße,,,Göttingen,Niedersachsen,37073,Germany,+49 551 41616,http://www.scholarbeer.com,9.937865000000002,51.53484
+2fa8ed82-9393-4897-a3e8-ea1150927f79,Schnuckenbräu,brewpub,Hünzingen 3,,,Walsrode,Niedersachsen,29664,Germany,+49 5161 970144,http://www.schnuckenbraeu.de,9.5880665,52.8979018
+4b716637-5727-436a-b05a-730bf39f3e90,Scholar,closed,Theaterstraße 8,,,Göttingen,Niedersachsen,37073,Germany,+49 551 41616,http://www.scholarbeer.com,9.937865000000002,51.53484
 6e5d4ec4-913f-4d88-a4d0-e3baa521b429,Schwarze Huhn,brewpub,Hildesheimer-Straße 8,,,Holle,Niedersachsen,31188,Germany,,http://www.schwarzeshuhn.de,10.1637872,52.10717709999999
-92a0340b-6389-458c-abaa-924bdf31777d,Selsinger Hof,brewpub,1 Bahnhofstraße,,,Selsingen,Niedersachsen,27446,Germany,+49 4284 93930,http://www.schuetzenhof-selsingen.de,9.21393,53.37189
-4a80fbc7-94be-422e-bb04-8a6186b37d0f,Sommerbecker (Dachs),brewpub,9 Klein Sommerbeck,,,Dahlenburg,Niedersachsen,21368,Germany,+49 5851 9794291,http://www.sommerbecker-dachs.de,10.6792887,53.20199
-893abecf-4535-49e8-b05e-4bdbb50f1312,Stebner,brewpub,31 Rebenring,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.stebner-privatbrauerei.de,10.5302439,52.276725
-707ab146-1968-4b8b-a0c8-a204da1248b0,Stierbräu,closed,12 Marschstraße,,,Vechta,Niedersachsen,49377,Germany,+49 4441 918883,http://www.stierbraeu.de,8.2825524,52.7240994
-bd187384-edb1-43f7-909a-5c18ea4d0db5,Tennenbräu,brewpub,7 Ernst-Stackmann-Straße,,,Wittingen,Niedersachsen,29378,Germany,+49 5831 2550,http://www.luebener-tenne.de,10.7441748,52.7266326
-4d016fdd-39fa-4f59-806a-86fa5f4c7daf,Vareler Brauhaus,brewpub,166 Zum Jadebusen,,,Varel,Niedersachsen,26316,Germany,+49 4451 9731600,http://www.vareler-brauhaus.de,8.1071564,53.4180033
-9802ec72-45b1-48dc-b02c-b249d3d4a21f,Wendland Bräu,brewpub,10 Kussebode,,,Clenze,Niedersachsen,29459,Germany,+49 5844 9711111,http://www.wendland-braeu.de,10.9983506,52.92178329999999
-614a0e01-9eed-424a-9cb2-7c2643abae19,Wittinger,brewpub,7 Ernst-Stackmann-Straße,,,Wittingen,Niedersachsen,29378,Germany,+49 5831 2550,http://www.wittinger.com,10.7441748,52.7266326
-49c39461-ab51-42df-9f41-a8c02869246c,Wolters,brewpub,39 Wolfenbütteler Straße,,,Braunschweig,Niedersachsen,38102,Germany,+49 531 27180,http://www.hofbrauhaus-wolters.de,10.5315685,52.2476425
+92a0340b-6389-458c-abaa-924bdf31777d,Selsinger Hof,brewpub,Bahnhofstraße 1,,,Selsingen,Niedersachsen,27446,Germany,+49 4284 93930,http://www.schuetzenhof-selsingen.de,9.21393,53.37189
+4a80fbc7-94be-422e-bb04-8a6186b37d0f,Sommerbecker (Dachs),brewpub,Klein Sommerbeck 9,,,Dahlenburg,Niedersachsen,21368,Germany,+49 5851 9794291,http://www.sommerbecker-dachs.de,10.6792887,53.20199
+893abecf-4535-49e8-b05e-4bdbb50f1312,Stebner,brewpub,Rebenring 31,,,Braunschweig,Niedersachsen,38106,Germany,+49 531 28856907,http://www.stebner-privatbrauerei.de,10.5302439,52.276725
+707ab146-1968-4b8b-a0c8-a204da1248b0,Stierbräu,closed,Marschstraße 12,,,Vechta,Niedersachsen,49377,Germany,+49 4441 918883,http://www.stierbraeu.de,8.2825524,52.7240994
+bd187384-edb1-43f7-909a-5c18ea4d0db5,Tennenbräu,brewpub,Ernst-Stackmann-Straße 7,,,Wittingen,Niedersachsen,29378,Germany,+49 5831 2550,http://www.luebener-tenne.de,10.7441748,52.7266326
+4d016fdd-39fa-4f59-806a-86fa5f4c7daf,Vareler Brauhaus,brewpub,Zum Jadebusen 166,,,Varel,Niedersachsen,26316,Germany,+49 4451 9731600,http://www.vareler-brauhaus.de,8.1071564,53.4180033
+9802ec72-45b1-48dc-b02c-b249d3d4a21f,Wendland Bräu,brewpub,Kussebode 10,,,Clenze,Niedersachsen,29459,Germany,+49 5844 9711111,http://www.wendland-braeu.de,10.9983506,52.92178329999999
+614a0e01-9eed-424a-9cb2-7c2643abae19,Wittinger,brewpub,Ernst-Stackmann-Straße 7,,,Wittingen,Niedersachsen,29378,Germany,+49 5831 2550,http://www.wittinger.com,10.7441748,52.7266326
+49c39461-ab51-42df-9f41-a8c02869246c,Wolters,brewpub,Wolfenbütteler Straße 39,,,Braunschweig,Niedersachsen,38102,Germany,+49 531 27180,http://www.hofbrauhaus-wolters.de,10.5315685,52.2476425

--- a/data/germany/nordrhein-westfalen.csv
+++ b/data/germany/nordrhein-westfalen.csv
@@ -114,7 +114,7 @@ ed8db1c9-d81a-449f-9496-2e8c3cece558,Schlüssel,brewpub,41-47 Bolkerstraße,,,D�
 1f9c3f0f-76d6-419f-a46d-8faaf3a7848a,Schmitz-Mönk,brewpub,28 Jakob-Krebs-Straße,,,Willich,Nordrhein-Westfalen,47877,Germany,+49 2156 2531,http://www.schmitzmoenk.de,6.461055,51.279098
 e3660c32-840d-4ae9-9812-6bb4fd3796b5,Schnaff,brewpub,11B Heidenstraße,,,Hückeswagen,Nordrhein-Westfalen,42499,Germany,+49 2192 9355762,http://www.schnaff.beer,7.336294299999999,51.1501291
 30deb39e-c048-4973-b71d-0ffac2434892,Schumacher,brewpub,123 Oststraße,,,Düsseldorf,Nordrhein-Westfalen,40210,Germany,+49 211 8289020,http://www.brauerei-schumacher.de,6.785279999999999,51.2215533
-9a8baa89-1ef5-43f6-949d-afde9643121d,Seven Craft,micro,Kirchstrasse 35,,,Koenigswinter,Nordrhein-Westfalen,53639,Germany,,http://www.sevencraft.de,,
+9a8baa89-1ef5-43f6-949d-afde9643121d,Seven Craft,micro,Kirchstraße 35,,,Koenigswinter,Nordrhein-Westfalen,53639,Germany,,http://www.sevencraft.de,,
 19d0e82e-191e-4856-8534-b8bfb158da7e,Siegburger Brauhaus,brewpub,37-39 Holzgasse,,,Siegburg,Nordrhein-Westfalen,53721,Germany,+49 2241 55999,http://www.siegburger-brauhaus.de,7.210516,50.798213
 34b23f93-0cb0-485e-a26d-0258f4d39015,Simian Ales,brewpub,57 Mühlenweg,,,Krefeld,Nordrhein-Westfalen,47839,Germany,,http://www.simian-ales.com,6.504070899999999,51.3689281
 44fb680d-78a3-451b-a70d-99225d2e288b,Stauder,brewpub,88 Stauderstraße,,,Essen,Nordrhein-Westfalen,45326,Germany,+49 201 36160,http://www.stauder.de,7.020521899999999,51.49664749999999

--- a/data/germany/nordrhein-westfalen.csv
+++ b/data/germany/nordrhein-westfalen.csv
@@ -1,146 +1,146 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-e2923681-b2b4-443b-9f90-6d560992e85f,2T,micro,1 Bismarckstraße,,,Lindlar,Nordrhein-Westfalen,51789,Germany,+49 2266 8058830,http://www.2t-brauerei.de,7.375127000000001,51.0241713
-a4c08e73-ecff-4fe1-9911-edb865e75229,Aktionsbrauerei Dähne,brewpub,48 Eschstraße,,,Herne,Nordrhein-Westfalen,44629,Germany,+49 2323 13594,http://www.hannosgegenmassenbierhaltung.de,7.222698099999999,51.54779019999999
-afeb4f72-555d-4169-8e3c-c3291b197db9,Ale Mania,brewpub,10 Alaunbachweg,,,Bonn,Nordrhein-Westfalen,53229,Germany,+49 228 6200016,http://www.ale-mania.de,7.1557662,50.7414074
-7bb77ea1-fc74-4689-bf5e-0ee1e39c244b,Altenrüthener Landbierbrauerei,closed,7 Altenrüthener Straße,,,Rüthen,Nordrhein-Westfalen,59602,Germany,+49 2952 3371,http://www.altenruethener-landbierbrauerei.de,8.407060999999999,51.4974846
-f5df0c68-fc05-42ba-93a6-e0ee945db29c,Anton's,closed,1 Konrad-Adenauer-Platz,,,Erkelenz,Nordrhein-Westfalen,41812,Germany,+49 2431 99911000,http://www.antons-erklenz.de,6.3213419,51.0768089
-93c6a990-ce00-4839-87a5-abc311813ce6,Arnsberger Mühlenbräu,brewpub,20 Mühlenstraße,,,Arnsberg,Nordrhein-Westfalen,59821,Germany,+49 2931 5327716,http://www.arnsberger-muehlenbraeu.de,8.0605326,51.3983754
-821ae891-f6ab-4401-835f-10e5a3f08441,Barre,brewpub,122-124 Berliner Straße,,,Lübbecke,Nordrhein-Westfalen,32312,Germany,+49 5741 27010,http://www.barre.de,8.6182605,52.295858
-24409440-5053-46e4-ab24-f2bf80bdb3fb,Bauerncafe Dieckmann,brewpub,49 Isendorf,,,Emsdetten,Nordrhein-Westfalen,48282,Germany,,http://www.bauerncafe-dieckmann.de,7.525124399999999,52.2051625
-cf734c87-a964-471c-87a0-63b061c47645,Becker,brewpub,65 Ehringhausen,,,Remscheid,Nordrhein-Westfalen,42859,Germany,+49 2191 3746280,http://www.wirtschaft-becker.de,7.171935,51.1597771
-05568be7-ce8c-4ce8-bcc0-571f87651359,Benno's Brauhaus,brewpub,4 Hammerstraße,,,Witten,Nordrhein-Westfalen,58452,Germany,+49 15565 571104,http://www.facebook.com/bennosbrauhaus/,7.333392700000001,51.4373684
-46a0a7e7-d969-4005-936f-19de94e5f278,Bergmann,brewpub,2 Elias-Bahn-Weg,,,Dortmund,Nordrhein-Westfalen,44263,Germany,+49 231 9503901,http://www.harte-arbeit-ehrlicher-lohn.de,7.488054600000001,51.4891427
-268bd37e-bfae-4eaf-979e-fd557a439759,Biber Brauerei,closed,32 Eifelring,,,Euskirchen,Nordrhein-Westfalen,53879,Germany,,http://www.biberbrauerei.de,6.7902,50.65217
-ba551dd6-4850-4682-841c-437673e43ddd,Bierbrauerei Dackel,brewpub,20 Am Mittelhafen,,,Münster,Nordrhein-Westfalen,48155,Germany,+49 251 74867004,http://www.dasdackel.de,7.6424727,51.9511209
-8ad132fc-7e89-4dc0-b1e6-186e937b1d93,Biermanufaktur Dangel,closed,32 An der Bümmert,,,Eslohe (Sauerland),Nordrhein-Westfalen,59889,Germany,+49 160 8984516,http://www.biermanufaktur-dangel.de,8.186409099999999,51.2803953
-f27949c9-c51f-4645-a8d5-53560f26b4da,Birreria - Deuxer Botschaft,closed,24 Am Weidenbach,,,Köln,Nordrhein-Westfalen,50676,Germany,+49 221 3377310,http://www.birreria-koeln.de,6.945498,50.9278981
+e2923681-b2b4-443b-9f90-6d560992e85f,2T,micro,Bismarckstraße 1,,,Lindlar,Nordrhein-Westfalen,51789,Germany,+49 2266 8058830,http://www.2t-brauerei.de,7.375127000000001,51.0241713
+a4c08e73-ecff-4fe1-9911-edb865e75229,Aktionsbrauerei Dähne,brewpub,Eschstraße 48,,,Herne,Nordrhein-Westfalen,44629,Germany,+49 2323 13594,http://www.hannosgegenmassenbierhaltung.de,7.222698099999999,51.54779019999999
+afeb4f72-555d-4169-8e3c-c3291b197db9,Ale Mania,brewpub,Alaunbachweg 10,,,Bonn,Nordrhein-Westfalen,53229,Germany,+49 228 6200016,http://www.ale-mania.de,7.1557662,50.7414074
+7bb77ea1-fc74-4689-bf5e-0ee1e39c244b,Altenrüthener Landbierbrauerei,closed,Altenrüthener Straße 7,,,Rüthen,Nordrhein-Westfalen,59602,Germany,+49 2952 3371,http://www.altenruethener-landbierbrauerei.de,8.407060999999999,51.4974846
+f5df0c68-fc05-42ba-93a6-e0ee945db29c,Anton's,closed,Konrad-Adenauer-Platz 1,,,Erkelenz,Nordrhein-Westfalen,41812,Germany,+49 2431 99911000,http://www.antons-erklenz.de,6.3213419,51.0768089
+93c6a990-ce00-4839-87a5-abc311813ce6,Arnsberger Mühlenbräu,brewpub,Mühlenstraße 20,,,Arnsberg,Nordrhein-Westfalen,59821,Germany,+49 2931 5327716,http://www.arnsberger-muehlenbraeu.de,8.0605326,51.3983754
+821ae891-f6ab-4401-835f-10e5a3f08441,Barre,brewpub,Berliner Straße 122-124,,,Lübbecke,Nordrhein-Westfalen,32312,Germany,+49 5741 27010,http://www.barre.de,8.6182605,52.295858
+24409440-5053-46e4-ab24-f2bf80bdb3fb,Bauerncafe Dieckmann,brewpub,Isendorf 49,,,Emsdetten,Nordrhein-Westfalen,48282,Germany,,http://www.bauerncafe-dieckmann.de,7.525124399999999,52.2051625
+cf734c87-a964-471c-87a0-63b061c47645,Becker,brewpub,Ehringhausen 65,,,Remscheid,Nordrhein-Westfalen,42859,Germany,+49 2191 3746280,http://www.wirtschaft-becker.de,7.171935,51.1597771
+05568be7-ce8c-4ce8-bcc0-571f87651359,Benno's Brauhaus,brewpub,Hammerstraße 4,,,Witten,Nordrhein-Westfalen,58452,Germany,+49 15565 571104,http://www.facebook.com/bennosbrauhaus/,7.333392700000001,51.4373684
+46a0a7e7-d969-4005-936f-19de94e5f278,Bergmann,brewpub,Elias-Bahn-Weg 2,,,Dortmund,Nordrhein-Westfalen,44263,Germany,+49 231 9503901,http://www.harte-arbeit-ehrlicher-lohn.de,7.488054600000001,51.4891427
+268bd37e-bfae-4eaf-979e-fd557a439759,Biber Brauerei,closed,Eifelring 32,,,Euskirchen,Nordrhein-Westfalen,53879,Germany,,http://www.biberbrauerei.de,6.7902,50.65217
+ba551dd6-4850-4682-841c-437673e43ddd,Bierbrauerei Dackel,brewpub,Am Mittelhafen 20,,,Münster,Nordrhein-Westfalen,48155,Germany,+49 251 74867004,http://www.dasdackel.de,7.6424727,51.9511209
+8ad132fc-7e89-4dc0-b1e6-186e937b1d93,Biermanufaktur Dangel,closed,An der Bümmert 32,,,Eslohe (Sauerland),Nordrhein-Westfalen,59889,Germany,+49 160 8984516,http://www.biermanufaktur-dangel.de,8.186409099999999,51.2803953
+f27949c9-c51f-4645-a8d5-53560f26b4da,Birreria - Deuxer Botschaft,closed,Am Weidenbach 24,,,Köln,Nordrhein-Westfalen,50676,Germany,+49 221 3377310,http://www.birreria-koeln.de,6.945498,50.9278981
 696b3ed9-6495-4105-b674-dfc3a55f8824,Bischoff'sche Brauerei,brewpub,Weilerhof,,,Brühl,Nordrhein-Westfalen,50321,Germany,+49 2232 922703,http://www.bischoff-koelsch.de,6.894164,50.8507513
-09f8b4ce-ac8a-415e-877d-38c0c2d3fde0,Blue Cat,closed,6-8 Schloßstraße,,,Erftstadt,Nordrhein-Westfalen,50374,Germany,+49 2235 4779921,http://www.bluecat-restaurant.de,6.766679799999999,50.8005866
-056b36d5-ebb2-4385-bf6b-612840a49709,Böcken-Bräu,brewpub,107 Hullerner Straße,,,Haltern am See,Nordrhein-Westfalen,45721,Germany,+49 2364 5216,http://www.boeckenbraeu.de,7.2268384,51.7406855
-cb4f69cc-52d1-4cd4-bf89-a1d7ad39645a,Boente,brewpub,4 Augustinessenstraße,,,Recklinghausen,Nordrhein-Westfalen,45657,Germany,+49 2361 9044990,http://www.hausbrauerei-boente.de,7.195145399999999,51.6153507
-844f3eab-e8c9-4f93-9eb1-f5aff5e1c1e4,Bolten,brewpub,138 Rheydter Straße,,,Korschenbroich,Nordrhein-Westfalen,41352,Germany,+49 2161 617900,http://www.bolten-brauerei.de,6.4992097,51.183196
-6790b562-2eea-40fb-974a-3b0a2d57b9dd,Bosch,brewpub,15 Steinackerstraße,,,Bad Laasphe,Nordrhein-Westfalen,57334,Germany,+49 2752 1234,http://www.brauerei-bosch.de,8.4093276,50.9279869
-dc2af156-3ad3-4db6-8535-54d2f4e99ccb,Brauerei am Roßtor / Rossberger Bier,brewpub,8 Am Roßtor,,,Wassenberg,Nordrhein-Westfalen,41849,Germany,,http://www.rossberger-bier.de,6.1551445,51.100122
-d42651b9-c4f6-4b86-a09a-566f7343bbe2,Brauerei Kemker,brewpub,1 Wettendorf,,,Everswinkel,Nordrhein-Westfalen,48351,Germany,+49 1512 5267867,http://www.facebook.com/BrauereiKemker/,7.773806199999999,51.907494
-dc0fdbf7-e375-4ad9-bdbb-9830bbe65fba,Brauerei Sandforth,brewpub,9 Wallbrink,,,Steinhagen,Nordrhein-Westfalen,33803,Germany,+49 171 6478855,http://www.brauereisandforth.de,8.34959,52.00773
-9f214182-b70e-4ba3-bba2-b24df06b86fc,Braugemeinschaft Edertal,brewpub,1a Beddelhäuser Straße,,,Bad Berleburg,Nordrhein-Westfalen,57319,Germany,+49 2755 2199995,http://www.braugemeinschaft-edertal.de,8.496089399999999,50.9987964
-5f289e18-a3f6-4cb4-83b6-bc76ee3be3b9,Brauhaus am Ennert,brewpub,1 An den Hecken,,,Bonn,Nordrhein-Westfalen,53229,Germany,+49 228 431784,http://www.brauhausamennert.de,7.150013,50.7353745
-29d38031-b073-4faa-9c04-c9a809cf4d64,Brauhaus Bönnsch,brewpub,4 Sterntorbrücke,,,Bonn,Nordrhein-Westfalen,53111,Germany,+49 228 650610,http://www.brauhaus-boennsch.de,7.097364,50.736781
-a22da4a0-2727-4614-8b1d-78af8569ad89,Brauhaus Gummersbach,brewpub,15 Hindenburgstraße,,,Gummersbach,Nordrhein-Westfalen,51643,Germany,+49 2261 290010,http://www.brauhaus-gummersbach.de,7.567495300000001,51.0255501
-26bb0fa6-32a4-4eaf-9267-bc7ce1b775f7,Brauhaus Rheinbach,brewpub,1 Wilhelmsplatz,,,Rheinbach,Nordrhein-Westfalen,53359,Germany,+49 2226 913800,http://www.brauhaus-rheinbach.de,6.947238899999999,50.6267408
-6a936f12-7174-45dd-99cd-f45ad471fb23,Brauhaus Zwiebel,brewpub,24 Ulricherstraße,,,Soest,Nordrhein-Westfalen,59494,Germany,+49 2921 4424,http://www.brauhaus-zwiebel.de,8.1074006,51.568669
-2b35fae2-a3f5-4bec-b938-c1a95f6a775f,Brauhof Wilshaus,brewpub,46 Baumstraße,,,Hamm,Nordrhein-Westfalen,59071,Germany,+49 2385 8855,http://www.brauhof-wilshaus.de,7.9026863,51.6696485
-c76ecfbb-db83-407f-a558-6473c1b1471c,Brauproject 777,brewpub,48 Friedrich-Wilhelm-Straße,,,Voerde (Niederrhein),Nordrhein-Westfalen,46562,Germany,,http://www.brauproject.de,6.6229793,51.6103903
-7b647253-4bb5-4206-8136-a49900109d29,Braustelle,brewpub,2 Christianstraße,,,Köln,Nordrhein-Westfalen,50825,Germany,+49 221 2856932,http://www.braustelle.com,6.9107515,50.9538745
-502dcb72-9616-4486-981b-8a5eeef1d698,Braustube Bielefelder Biermanufactur,brewpub,22 Brockhagener Straße,,,Bielefeld,Nordrhein-Westfalen,33649,Germany,+49 521 40086333,http://www.braustube.diemeisterwerker.de,8.483653799999999,51.9877274
-5553397a-29cb-429e-98b7-f0a939d77b31,Brauzwerg,closed,42 Otto-Hahn-Straße,,,Unna,Nordrhein-Westfalen,59423,Germany,+49 2303 962049,http://www.brauzwerg.de,7.7133175,51.5269291
-38669160-4c57-46e0-bd23-4c61377601fc,Brennerei Rönsahl,brewpub,23 Hauptstraße,,,Kierspe,Nordrhein-Westfalen,58566,Germany,,http://www.brennerei-roensahl.de,7.506025200000001,51.111336
-2a9b0d1d-2f41-4846-98d0-622097bdb900,Brewing Events,brewpub,14a Alter Kapellener Weg,,,Kevelaer,Nordrhein-Westfalen,47626,Germany,,http://www.schankanlagenservice-dahlmann.de,6.3418963,51.5777637
-07f1fead-779e-4fc5-b163-fb1cc2331f97,Carolinenbräu,brewpub,33 Dörnschlader Weg,,,Wenden,Nordrhein-Westfalen,57482,Germany,+49 2762 1331,http://www.carolinenbräu.de,7.897578200000001,50.9583039
-c9f2036c-bd66-4fc8-baab-de1351ee5b2c,Coltro Brauservice,brewpub,6 Aok-Straße,,,Hürth,Nordrhein-Westfalen,50354,Germany,+49 1573 9261074,http://www.coltro-brauservice.de,6.889989099999999,50.8785564
-91bb7841-ccd9-4be5-a7f9-622f1d5df789,DAB,brewpub,20 Steigerstraße,,,Dortmund,Nordrhein-Westfalen,44145,Germany,+49 231 84000,http://www.dab.de,7.4693638,51.5296291
-ca0c2eb9-15a0-4941-b1d7-ec1bc679f03d,Dalheimer Klosterbräu,brewpub,9 Am Kloster,,,Lichtenau,Nordrhein-Westfalen,33165,Germany,+49 5292 932710,http://www.kloster-dalheim.de,8.8414361,51.5649644
-4f93ab58-85ea-4fd3-83f3-b5fe91e9332f,Dellman's Bräu,brewpub,1 Coenenmühle,,,Wermelskirchen,Nordrhein-Westfalen,42929,Germany,+49 2193 3083,http://www.dellmanns.de,7.192502299999999,51.0856278
-1c46becd-8155-4835-af62-1f7cf152c421,Diebels,brewpub,50 Gelderner Straße,,,Issum,Nordrhein-Westfalen,47661,Germany,+49 2835 300,http://www.diebels.de,6.4193012,51.5347255
-c101bbc6-37e1-4804-9948-fafa4e7ba9a6,Erzquell,brewpub,108 Bielsteiner Straße,,,Wiehl,Nordrhein-Westfalen,51674,Germany,+49 2262 820,http://www.erzquell.de,7.500047599999999,50.96266929999999
-59d129d9-6bf8-416b-9d41-18262b69464c,Esloher Brauhaus,brewpub,1 Sankt-Rochus-Weg,,,Eslohe (Sauerland),Nordrhein-Westfalen,59889,Germany,+49 2973 97650,http://www.essel-braeu.de,8.1654359,51.25404899999999
-e765c70c-9fd9-4dc8-94db-2612cb29c13c,Finne Brauerei,brewpub,20 Am Mittelhafen,,,Münster,Nordrhein-Westfalen,48155,Germany,+49 251 74867004,http://www.finne-brauerei.de,7.6424727,51.9511209
-19741220-dfba-44a1-8886-9f494f29ec61,Flurschütz,brewpub,11 Auf der Jenseite,,,Lennestadt,Nordrhein-Westfalen,57368,Germany,+49 2723 91460,http://www.hotel-flurschuetz.de,8.1675319,51.11639779999999
-4811a5c0-1ada-489a-9587-a0f190603e34,Früh,brewpub,12-18 Am Hof,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 2613215,http://www.frueh.de,6.956944099999999,50.9398732
-06ed7500-ab62-4b9b-95a9-7cb225e2bee7,Füchschen,brewpub,28 Ratinger Straße,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 137470,http://www.fuechschen.de,6.775249899999999,51.2295321
-e73fc1e8-f9b5-41a9-850f-1bac07f3e57e,Gaffel,brewpub,1 Bahnhofsvorplatz,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 9139260,http://www.gaffel.de,6.9568941,50.9419076
-79b4d7f1-68da-4834-a478-93ac8b555b8f,Gasthaus Himmelpforten,brewpub,2 Bahnhofstraße,,,Ense,Nordrhein-Westfalen,59469,Germany,+49 2938 49343,http://www.gasthaus-himmelpforten.de,7.9988889,51.4894444
-8bd6d5e0-2976-4cb6-83aa-04b3b60dbdab,Geilings Bräu,brewpub,327 Saalhoffer Straße,,,Kamp-Lintfort,Nordrhein-Westfalen,47475,Germany,+49 2842 404523,http://www.geilings-braeu.de,6.530769299999999,51.5411747
-6ee1f75c-7a68-4120-8b36-92b5496c6942,Gemünder,brewpub,69 Kölner Straße,,,Schleiden,Nordrhein-Westfalen,53937,Germany,+49 2444 2723,http://www.gemuender-brauerei.de,6.5193157,50.569354
-408c9a27-33d4-4ce8-9eac-144a26359557,Gleumes,brewpub,12 Sternstraße,,,Krefeld,Nordrhein-Westfalen,47798,Germany,+49 2151 20521,http://www.gleumes-krefeld.de,6.5596144,51.3379482
-ef5f3345-78e4-466e-aa06-c97729145434,Gruthaus,closed,61 Krummer Timpen,,,Münster,Nordrhein-Westfalen,48143,Germany,+49 251 132917,http://www.gruthaus.de,7.619803999999999,51.9630653
-8f1d7c66-fdee-4882-a9ba-99863b383556,Gulasch Bräu,brewpub,1 Berger Straße,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 866990,http://www.brauhaus-alterbahnhof.de,6.7722509,51.2249992
-d63493f8-b91e-44d2-a387-10b0ab77b6fc,Gütersloher Brauhaus,brewpub,9 Unter den Ulmen,,,Gütersloh,Nordrhein-Westfalen,33330,Germany,+49 5241 25166,http://www.guetersloher-brauhaus.de,8.3756106,51.9023048
-aa4ee334-144e-4077-9544-35af3fd00745,Hau's / Waldmoor,brewpub,2 Meigermühle,,,Lohmar,Nordrhein-Westfalen,53797,Germany,+49 2246 3038265,http://www.erlebnisbrauerei-lohmar.de,7.2139544,50.86302999999999
-0e1a9fb2-0082-471f-b9f6-7f1de44ed440,Haus Kölscher Brautradition,brewpub,121-123 Eigelstein,,,Köln,Nordrhein-Westfalen,50668,Germany,+49 221 135227,http://www.haus-koelscher-brautradition.de,6.9566887,50.9487238
+09f8b4ce-ac8a-415e-877d-38c0c2d3fde0,Blue Cat,closed,Schloßstraße 6-8,,,Erftstadt,Nordrhein-Westfalen,50374,Germany,+49 2235 4779921,http://www.bluecat-restaurant.de,6.766679799999999,50.8005866
+056b36d5-ebb2-4385-bf6b-612840a49709,Böcken-Bräu,brewpub,Hullerner Straße 107,,,Haltern am See,Nordrhein-Westfalen,45721,Germany,+49 2364 5216,http://www.boeckenbraeu.de,7.2268384,51.7406855
+cb4f69cc-52d1-4cd4-bf89-a1d7ad39645a,Boente,brewpub,Augustinessenstraße 4,,,Recklinghausen,Nordrhein-Westfalen,45657,Germany,+49 2361 9044990,http://www.hausbrauerei-boente.de,7.195145399999999,51.6153507
+844f3eab-e8c9-4f93-9eb1-f5aff5e1c1e4,Bolten,brewpub,Rheydter Straße 138,,,Korschenbroich,Nordrhein-Westfalen,41352,Germany,+49 2161 617900,http://www.bolten-brauerei.de,6.4992097,51.183196
+6790b562-2eea-40fb-974a-3b0a2d57b9dd,Bosch,brewpub,Steinackerstraße 15,,,Bad Laasphe,Nordrhein-Westfalen,57334,Germany,+49 2752 1234,http://www.brauerei-bosch.de,8.4093276,50.9279869
+dc2af156-3ad3-4db6-8535-54d2f4e99ccb,Brauerei am Roßtor / Rossberger Bier,brewpub,Am Roßtor 8,,,Wassenberg,Nordrhein-Westfalen,41849,Germany,,http://www.rossberger-bier.de,6.1551445,51.100122
+d42651b9-c4f6-4b86-a09a-566f7343bbe2,Brauerei Kemker,brewpub,Wettendorf 1,,,Everswinkel,Nordrhein-Westfalen,48351,Germany,+49 1512 5267867,http://www.facebook.com/BrauereiKemker/,7.773806199999999,51.907494
+dc0fdbf7-e375-4ad9-bdbb-9830bbe65fba,Brauerei Sandforth,brewpub,Wallbrink 9,,,Steinhagen,Nordrhein-Westfalen,33803,Germany,+49 171 6478855,http://www.brauereisandforth.de,8.34959,52.00773
+9f214182-b70e-4ba3-bba2-b24df06b86fc,Braugemeinschaft Edertal,brewpub,Beddelhäuser Straße 1a,,,Bad Berleburg,Nordrhein-Westfalen,57319,Germany,+49 2755 2199995,http://www.braugemeinschaft-edertal.de,8.496089399999999,50.9987964
+5f289e18-a3f6-4cb4-83b6-bc76ee3be3b9,Brauhaus am Ennert,brewpub,An den Hecken 1,,,Bonn,Nordrhein-Westfalen,53229,Germany,+49 228 431784,http://www.brauhausamennert.de,7.150013,50.7353745
+29d38031-b073-4faa-9c04-c9a809cf4d64,Brauhaus Bönnsch,brewpub,Sterntorbrücke 4,,,Bonn,Nordrhein-Westfalen,53111,Germany,+49 228 650610,http://www.brauhaus-boennsch.de,7.097364,50.736781
+a22da4a0-2727-4614-8b1d-78af8569ad89,Brauhaus Gummersbach,brewpub,Hindenburgstraße 15,,,Gummersbach,Nordrhein-Westfalen,51643,Germany,+49 2261 290010,http://www.brauhaus-gummersbach.de,7.567495300000001,51.0255501
+26bb0fa6-32a4-4eaf-9267-bc7ce1b775f7,Brauhaus Rheinbach,brewpub,Wilhelmsplatz 1,,,Rheinbach,Nordrhein-Westfalen,53359,Germany,+49 2226 913800,http://www.brauhaus-rheinbach.de,6.947238899999999,50.6267408
+6a936f12-7174-45dd-99cd-f45ad471fb23,Brauhaus Zwiebel,brewpub,Ulricherstraße 24,,,Soest,Nordrhein-Westfalen,59494,Germany,+49 2921 4424,http://www.brauhaus-zwiebel.de,8.1074006,51.568669
+2b35fae2-a3f5-4bec-b938-c1a95f6a775f,Brauhof Wilshaus,brewpub,Baumstraße 46,,,Hamm,Nordrhein-Westfalen,59071,Germany,+49 2385 8855,http://www.brauhof-wilshaus.de,7.9026863,51.6696485
+c76ecfbb-db83-407f-a558-6473c1b1471c,Brauproject 777,brewpub,Friedrich-Wilhelm-Straße 48,,,Voerde (Niederrhein),Nordrhein-Westfalen,46562,Germany,,http://www.brauproject.de,6.6229793,51.6103903
+7b647253-4bb5-4206-8136-a49900109d29,Braustelle,brewpub,Christianstraße 2,,,Köln,Nordrhein-Westfalen,50825,Germany,+49 221 2856932,http://www.braustelle.com,6.9107515,50.9538745
+502dcb72-9616-4486-981b-8a5eeef1d698,Braustube Bielefelder Biermanufactur,brewpub,Brockhagener Straße 22,,,Bielefeld,Nordrhein-Westfalen,33649,Germany,+49 521 40086333,http://www.braustube.diemeisterwerker.de,8.483653799999999,51.9877274
+5553397a-29cb-429e-98b7-f0a939d77b31,Brauzwerg,closed,Otto-Hahn-Straße 42,,,Unna,Nordrhein-Westfalen,59423,Germany,+49 2303 962049,http://www.brauzwerg.de,7.7133175,51.5269291
+38669160-4c57-46e0-bd23-4c61377601fc,Brennerei Rönsahl,brewpub,Hauptstraße 23,,,Kierspe,Nordrhein-Westfalen,58566,Germany,,http://www.brennerei-roensahl.de,7.506025200000001,51.111336
+2a9b0d1d-2f41-4846-98d0-622097bdb900,Brewing Events,brewpub,Alter Kapellener Weg 14a,,,Kevelaer,Nordrhein-Westfalen,47626,Germany,,http://www.schankanlagenservice-dahlmann.de,6.3418963,51.5777637
+07f1fead-779e-4fc5-b163-fb1cc2331f97,Carolinenbräu,brewpub,Dörnschlader Weg 33,,,Wenden,Nordrhein-Westfalen,57482,Germany,+49 2762 1331,http://www.carolinenbräu.de,7.897578200000001,50.9583039
+c9f2036c-bd66-4fc8-baab-de1351ee5b2c,Coltro Brauservice,brewpub,Aok-Straße 6,,,Hürth,Nordrhein-Westfalen,50354,Germany,+49 1573 9261074,http://www.coltro-brauservice.de,6.889989099999999,50.8785564
+91bb7841-ccd9-4be5-a7f9-622f1d5df789,DAB,brewpub,Steigerstraße 20,,,Dortmund,Nordrhein-Westfalen,44145,Germany,+49 231 84000,http://www.dab.de,7.4693638,51.5296291
+ca0c2eb9-15a0-4941-b1d7-ec1bc679f03d,Dalheimer Klosterbräu,brewpub,Am Kloster 9,,,Lichtenau,Nordrhein-Westfalen,33165,Germany,+49 5292 932710,http://www.kloster-dalheim.de,8.8414361,51.5649644
+4f93ab58-85ea-4fd3-83f3-b5fe91e9332f,Dellman's Bräu,brewpub,Coenenmühle 1,,,Wermelskirchen,Nordrhein-Westfalen,42929,Germany,+49 2193 3083,http://www.dellmanns.de,7.192502299999999,51.0856278
+1c46becd-8155-4835-af62-1f7cf152c421,Diebels,brewpub,Gelderner Straße 50,,,Issum,Nordrhein-Westfalen,47661,Germany,+49 2835 300,http://www.diebels.de,6.4193012,51.5347255
+c101bbc6-37e1-4804-9948-fafa4e7ba9a6,Erzquell,brewpub,Bielsteiner Straße 108,,,Wiehl,Nordrhein-Westfalen,51674,Germany,+49 2262 820,http://www.erzquell.de,7.500047599999999,50.96266929999999
+59d129d9-6bf8-416b-9d41-18262b69464c,Esloher Brauhaus,brewpub,Sankt-Rochus-Weg 1,,,Eslohe (Sauerland),Nordrhein-Westfalen,59889,Germany,+49 2973 97650,http://www.essel-braeu.de,8.1654359,51.25404899999999
+e765c70c-9fd9-4dc8-94db-2612cb29c13c,Finne Brauerei,brewpub,Am Mittelhafen 20,,,Münster,Nordrhein-Westfalen,48155,Germany,+49 251 74867004,http://www.finne-brauerei.de,7.6424727,51.9511209
+19741220-dfba-44a1-8886-9f494f29ec61,Flurschütz,brewpub,Auf der Jenseite 11,,,Lennestadt,Nordrhein-Westfalen,57368,Germany,+49 2723 91460,http://www.hotel-flurschuetz.de,8.1675319,51.11639779999999
+4811a5c0-1ada-489a-9587-a0f190603e34,Früh,brewpub,Am Hof 12-18,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 2613215,http://www.frueh.de,6.956944099999999,50.9398732
+06ed7500-ab62-4b9b-95a9-7cb225e2bee7,Füchschen,brewpub,Ratinger Straße 28,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 137470,http://www.fuechschen.de,6.775249899999999,51.2295321
+e73fc1e8-f9b5-41a9-850f-1bac07f3e57e,Gaffel,brewpub,Bahnhofsvorplatz 1,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 9139260,http://www.gaffel.de,6.9568941,50.9419076
+79b4d7f1-68da-4834-a478-93ac8b555b8f,Gasthaus Himmelpforten,brewpub,Bahnhofstraße 2,,,Ense,Nordrhein-Westfalen,59469,Germany,+49 2938 49343,http://www.gasthaus-himmelpforten.de,7.9988889,51.4894444
+8bd6d5e0-2976-4cb6-83aa-04b3b60dbdab,Geilings Bräu,brewpub,Saalhoffer Straße 327,,,Kamp-Lintfort,Nordrhein-Westfalen,47475,Germany,+49 2842 404523,http://www.geilings-braeu.de,6.530769299999999,51.5411747
+6ee1f75c-7a68-4120-8b36-92b5496c6942,Gemünder,brewpub,Kölner Straße 69,,,Schleiden,Nordrhein-Westfalen,53937,Germany,+49 2444 2723,http://www.gemuender-brauerei.de,6.5193157,50.569354
+408c9a27-33d4-4ce8-9eac-144a26359557,Gleumes,brewpub,Sternstraße 12,,,Krefeld,Nordrhein-Westfalen,47798,Germany,+49 2151 20521,http://www.gleumes-krefeld.de,6.5596144,51.3379482
+ef5f3345-78e4-466e-aa06-c97729145434,Gruthaus,closed,Krummer Timpen 61,,,Münster,Nordrhein-Westfalen,48143,Germany,+49 251 132917,http://www.gruthaus.de,7.619803999999999,51.9630653
+8f1d7c66-fdee-4882-a9ba-99863b383556,Gulasch Bräu,brewpub,Berger Straße 1,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 866990,http://www.brauhaus-alterbahnhof.de,6.7722509,51.2249992
+d63493f8-b91e-44d2-a387-10b0ab77b6fc,Gütersloher Brauhaus,brewpub,Unter den Ulmen 9,,,Gütersloh,Nordrhein-Westfalen,33330,Germany,+49 5241 25166,http://www.guetersloher-brauhaus.de,8.3756106,51.9023048
+aa4ee334-144e-4077-9544-35af3fd00745,Hau's / Waldmoor,brewpub,Meigermühle 2,,,Lohmar,Nordrhein-Westfalen,53797,Germany,+49 2246 3038265,http://www.erlebnisbrauerei-lohmar.de,7.2139544,50.86302999999999
+0e1a9fb2-0082-471f-b9f6-7f1de44ed440,Haus Kölscher Brautradition,brewpub,Eigelstein 121-123,,,Köln,Nordrhein-Westfalen,50668,Germany,+49 221 135227,http://www.haus-koelscher-brautradition.de,6.9566887,50.9487238
 0aa08603-b582-493f-9b6e-d72c69c8549c,Heinenhof,micro,,,,Orr,Nordrhein-Westfalen,,Germany,,http://www.heinenhof.de,,
-8cc4fd3c-3f46-45a4-9ad9-5fd04b71cf3a,Hellers,brewpub,33 Roonstraße,,,Köln,Nordrhein-Westfalen,50674,Germany,+49 221 2401881,http://www.hellers-brauhaus.de,6.9382923,50.9306759
-438e70f7-3ed2-4545-830a-42259a7acca1,Hensen,brewpub,133-135 Untere Straße,,,Mönchengladbach,Nordrhein-Westfalen,41068,Germany,+49 175 3338076,http://www.brauerei-hensen.de,6.4098608,51.1974767
-245feec2-364b-4627-bd7e-2a805060071f,Herforder,brewpub,1 Gebrüder-Uekermann-Straße,,,Hiddenhausen,Nordrhein-Westfalen,32120,Germany,+49 5221 9650,http://www.herforder.de,8.6599599,52.1375435
-15d0bc2f-60e7-4ac2-85c3-eef42ef51b33,Hilfarther Brauhaus,brewpub,72 Kaphofstraße,,,Hückelhoven,Nordrhein-Westfalen,41836,Germany,+49 2433 42533,http://www.hilfarther-brauhaus.de,6.2113419,51.0399434
-9ffb4d68-ffbc-4aaf-b9cc-84ef2b553fbd,Hofbrauerei Bruchhausen,brewpub,1 Schloßhof,,,Olsberg,Nordrhein-Westfalen,59939,Germany,+49 2962 97670,http://www.fuerstenberg-gaugreben.de,8.530038099999999,51.3201969
-aae00729-a6fb-4d8d-8fbf-26b1b91b4dde,Hofbrauerei Marienhof Marks,brewpub,1 Lüchtenweg,,,Delbrück,Nordrhein-Westfalen,33129,Germany,+49 5250 930525,http://www.marienhof-marks.de,8.6290712,51.7365455
-e7ff48d8-3e73-46e5-9496-c3667d42ee6e,Hohenfelder,brewpub,155 Wiedenbrücker Straße,,,Langenberg,Nordrhein-Westfalen,33449,Germany,+49 5248 80040,http://www.hohenfelder.de,8.3189245,51.7921375
-b13935c2-459c-482a-baa4-2df1a240d45d,Hohler Landbier,closed,8 Im Hohl,,,Olpe,Nordrhein-Westfalen,57462,Germany,+49 1590 1300831,http://www.hohler-landbier.de,7.858694900000001,51.0463397
-9a58ee02-b600-4a66-97ec-9564aaefa758,Hövels Hausbrauerei,brewpub,5-7 Hoher Wall,,,Dortmund,Nordrhein-Westfalen,44137,Germany,+49 231 9145470,http://www.hoevels-hausbrauerei.de,7.458608399999999,51.5124968
-b7b9ff4c-3730-46b4-8eb4-c64d1d2e6155,Ilsen-Bräu,brewpub,29 In den Erlen,,,Kreuztal,Nordrhein-Westfalen,57223,Germany,+49 2732 82396,http://www.ilsen-brauerei.de,7.98947,51.00513
-8b762a1b-5b19-4393-8979-ee1853048c42,Im Dom,brewpub,75-77 Michaelstraße,,,Neuss,Nordrhein-Westfalen,41460,Germany,+49 2131 275599,http://www.imdom1601.de,6.6933548,51.1962755
-5b43ab23-8aed-415f-b5fc-58c846fdcdfc,Irle,brewpub,18 Hauptstraße,,,Siegen,Nordrhein-Westfalen,57074,Germany,+49 271 31772910,http://www.der-biermacher.de,8.048752,50.8730264
-3494e8ef-4984-4190-9564-b86cbcd6edef,Josefsbräu,brewpub,1s Raiffeisenstraße,,,Bad Lippspringe,Nordrhein-Westfalen,33175,Germany,+49 5252 9154270,http://www.trink-gutes.de,8.7952985,51.7793235
-bc04ad9c-3fbf-434f-a1dd-d2e418a1bbad,Kaiser Craft,brewpub,72 Bahnhofstraße,,,Bünde,Nordrhein-Westfalen,32257,Germany,+49 5223 178898,http://www.kaisercraft.de,8.574354,52.2012436
-9e42d740-f3f1-4b90-a5a0-62dc5f2c0f20,Kalkarer Mühle,brewpub,8 Mühlenstege,,,Kalkar,Nordrhein-Westfalen,47546,Germany,+49 2824 93230,http://www.kalkarermuehle.de,6.2955443,51.7396269
-2011647c-05c8-4c41-a628-37d47a491fb1,Kleines Eifeler-Brauhaus,brewpub,12 Wertherstraße,,,Bad Münstereifel,Nordrhein-Westfalen,53902,Germany,+49 2253 5448760,http://www.eifelburg.de,6.7652734,50.55595169999999
-b388363e-4be0-4c07-9730-750ff2025cb2,Klute's,brewpub,28 Poppenbeck,,,Havixbeck,Nordrhein-Westfalen,48329,Germany,+49 2507 98390,http://www.klutes.de,7.393216199999999,51.9893138
-8f4c0e0b-d587-4ee9-ad8f-2209ad1aff9c,König,brewpub,308 Friedrich-Ebert-Straße,,,Duisburg,Nordrhein-Westfalen,47139,Germany,+49 203 93330,http://www.koenig.de,6.7347563,51.47633219999999
-6948e42b-b78a-4f46-b2a7-985d8e624cba,Königshof,brewpub,68 Obergath,,,Krefeld,Nordrhein-Westfalen,47805,Germany,+49 2151 3330,http://www.brauerei-koenigshof.de,6.5696884,51.3147615
-404f4ac8-9265-4f3a-89c8-14941353fcb4,Krombacher,brewpub,261 Hagener Straße,,,Kreuztal,Nordrhein-Westfalen,57223,Germany,+49 2732 880880,http://www.krombacher.de,7.956437399999999,50.9910349
-1c397c68-2514-4757-913d-77461983f25d,Kürzer,brewpub,20 Kurze Straße,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 322696,http://www.brauerei-kuerzer.de,6.7733364,51.2269707
-97b59075-427c-43e4-bf15-559e52773b77,Läuterwerk,closed,371 Hammer Straße,,,Münster,Nordrhein-Westfalen,48153,Germany,+49 251 20817052,http://www.laeuterwerk.de,7.628756300000001,51.92818510000001
-9f133e93-70a1-4c3b-bee4-60603d46021d,Liebhart's,brewpub,6 Am Gelskamp,,,Detmold,Nordrhein-Westfalen,32756,Germany,+49 5231 630506,http://www.residenz-bier.de,8.8619474,51.94823419999999
-6ae55cd5-815a-4033-9595-0681af5cb009,Lippstädter Brauhaus,brewpub,12 Rathausstraße,,,Lippstadt,Nordrhein-Westfalen,59555,Germany,,http://www.lippstaedter-brauerei.de,8.3444252,51.6754884
-5df1fc95-6449-4e5c-b84c-7c3894e7396a,Lohmann,brewpub,19 Opladener Straße,,,Langenfeld (Rheinland),Nordrhein-Westfalen,40764,Germany,+49 2173 91610,http://www.landhotel-lohmann.de,6.9603568,51.089824
-15100f1d-57f3-43d3-b8c1-16530be2b30a,Lüdinghauser Brauwerkstatt,brewpub,1 Adam-Stegerwald-Straße,,,Lüdinghausen,Nordrhein-Westfalen,59348,Germany,,http://www.luedinghauser-brauwerkstatt.de,7.4278214,51.76618209999999
-8197a1c0-35cb-4dfc-8938-e52ced41781d,Malzmühle,brewpub,6 Heumarkt,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 92160613,http://www.muehlenkoelsch.de,6.9605091,50.93471049999999
-c6a3cb42-8017-49e4-a0a5-969d4d221c11,Marienfelder Klosterbräu,brewpub,2 Klosterhof,,,Harsewinkel,Nordrhein-Westfalen,33428,Germany,,http://www.klosterpforte.de,8.2791785,51.9473492
-48adfe82-b6e0-4cb2-9b03-db3a43f40e22,Maueler Hofbräu,micro,11 Preschlin-Allee,,,Windeck,Nordrhein-Westfalen,51570,Germany,+49 2292 91330,http://www.gasthof-willmeroth.de,7.600813800000001,50.8039271
-4af48a5c-33a6-40eb-827d-f2e3e56ea2a5,McMüller's,brewpub,54 Neußer Straße,,,Linnich,Nordrhein-Westfalen,52441,Germany,+49 2462 4457,http://www.mcmuellers.de,6.3218638,50.9999225
-a030d14e-ed28-4018-8f63-00e36e1e4eb3,Metten Hefemännchen,brewpub,18 Hohle Straße,,,Finnentrop,Nordrhein-Westfalen,57413,Germany,+49 2724 949054,http://www.hefemaennchen.de,8.0823897,51.23199839999999
-ba853ca5-ee89-41e4-a23a-8e0e3b3dd246,Mönchengladbach,brewpub,29 Senefelderstraße,,,Mönchengladbach,Nordrhein-Westfalen,41066,Germany,+49 2161 57690,http://www.oettinger-bier.de,6.473011899999999,51.2305467
-0267ecb8-fed1-4ed4-a6af-91253d831b25,Monheimer Biermanufactur,micro,5 Dachsbau,,,Monheim am Rhein,Nordrhein-Westfalen,40789,Germany,+49 1525 3985959,http://monheimer-biermanufactur.de,6.9046791,51.0981402
-ac8e4ac9-a869-4123-a98b-232d43291886,Moritz Fiege,brewpub,1 Moritz-Fiege-Straße,,,Bochum,Nordrhein-Westfalen,44787,Germany,+49 234 68980,http://www.moritzfiege.de,7.227264799999999,51.4809454
-34846875-edfb-4d9b-9b37-170fffa3e955,Paderborner,brewpub,45 Halberstädter Straße,,,Paderborn,Nordrhein-Westfalen,33106,Germany,+49 5251 7070,http://www.paderborner-brauerei.de,8.7476083,51.6876965
-df616605-958c-416e-ab7a-486e6635c9eb,Päffgen,brewpub,64-66 Friesenstraße,,,Köln,Nordrhein-Westfalen,50670,Germany,+49 221 135461,http://www.paeffgen-koelsch.de,6.9419115,50.9407688
-df33a039-e1e0-47a7-b0ac-ce798c1abc2c,Pinkus Müller,brewpub,7 - 10 Kreuzstraße,,,Münster,Nordrhein-Westfalen,48143,Germany,+49 251 55567,http://www.pinkus.de,7.621640900000001,51.9656444
-b9709f6b-f595-4ed4-86bb-58cde52f093a,Pott's,brewpub,120 In der Geist,,,Oelde,Nordrhein-Westfalen,59302,Germany,+49 2522 93320,http://www.potts.de,8.1318098,51.81089619999999
-dcee4787-93e3-4777-b4e6-2e2553c486ff,Privatbrauerei Haverkamp,brewpub,38 Ibbenbürener Straße,,,Ibbenbüren,Nordrhein-Westfalen,49479,Germany,+49 170 9341920,http://www.laggenbecker.de,7.779753599999999,52.2615276
-103814d2-c1db-4701-bfb9-2a16a1c2b279,Quercus,brewpub,71 Sternbuschweg,,,Duisburg,Nordrhein-Westfalen,47057,Germany,+49 203 373200,http://www.imeichwaeldchen.de,6.794072,51.429291
-077523f3-527d-4c0d-95a4-23f48dd078c2,Rainer,brewpub,31 Kreisstraße,,,Linnich,Nordrhein-Westfalen,52441,Germany,,http://www.brauerei-rainer.de,6.2593861,50.95942609999999
-383d4e73-0642-46ac-98b3-00dd2fc9fd18,Ratinger Brauhaus,brewpub,15 Bahnstraße,,,Ratingen,Nordrhein-Westfalen,40878,Germany,+49 2102 21981,http://www.poensgen-gastronomie-ratingen.de,6.855952299999999,51.298157
-d5f1957d-a136-4c45-9cb5-bf236434bee1,Reissdorf,brewpub,4-10 Emil-Hoffmann-Straße,,,Köln,Nordrhein-Westfalen,50996,Germany,+49 2236 96550,http://www.reissdorf.de,6.994972499999999,50.87607029999999
-b96755df-f060-4736-937b-7691b15ec85f,Remscheider Bräu,brewpub,39 Bismarckstraße,,,Remscheid,Nordrhein-Westfalen,42853,Germany,+49 2191 5646954,http://www.remscheider-brau.de,7.199113199999998,51.1785649
-e5b745d1-ae82-4e12-9107-cb70e6a17df0,Rolinck,brewpub,1 Alexander-Rolinck-Straße,,,Steinfurt,Nordrhein-Westfalen,48565,Germany,+49 2732 880880,http://www.rolinck.de,7.3402593,52.1530462
-0e86940b-8304-4a12-8ea8-7a2ced43cabf,Rotingdorfer,brewpub,10 Rotingdorfer Straße,,,Werther (Westfalen),Nordrhein-Westfalen,33824,Germany,+49 5203 902170,http://www.rotingdorfer.de,8.3905172,52.0881593
+8cc4fd3c-3f46-45a4-9ad9-5fd04b71cf3a,Hellers,brewpub,Roonstraße 33,,,Köln,Nordrhein-Westfalen,50674,Germany,+49 221 2401881,http://www.hellers-brauhaus.de,6.9382923,50.9306759
+438e70f7-3ed2-4545-830a-42259a7acca1,Hensen,brewpub,Untere Straße 133-135,,,Mönchengladbach,Nordrhein-Westfalen,41068,Germany,+49 175 3338076,http://www.brauerei-hensen.de,6.4098608,51.1974767
+245feec2-364b-4627-bd7e-2a805060071f,Herforder,brewpub,Gebrüder-Uekermann-Straße 1,,,Hiddenhausen,Nordrhein-Westfalen,32120,Germany,+49 5221 9650,http://www.herforder.de,8.6599599,52.1375435
+15d0bc2f-60e7-4ac2-85c3-eef42ef51b33,Hilfarther Brauhaus,brewpub,Kaphofstraße 72,,,Hückelhoven,Nordrhein-Westfalen,41836,Germany,+49 2433 42533,http://www.hilfarther-brauhaus.de,6.2113419,51.0399434
+9ffb4d68-ffbc-4aaf-b9cc-84ef2b553fbd,Hofbrauerei Bruchhausen,brewpub,Schloßhof 1,,,Olsberg,Nordrhein-Westfalen,59939,Germany,+49 2962 97670,http://www.fuerstenberg-gaugreben.de,8.530038099999999,51.3201969
+aae00729-a6fb-4d8d-8fbf-26b1b91b4dde,Hofbrauerei Marienhof Marks,brewpub,Lüchtenweg 1,,,Delbrück,Nordrhein-Westfalen,33129,Germany,+49 5250 930525,http://www.marienhof-marks.de,8.6290712,51.7365455
+e7ff48d8-3e73-46e5-9496-c3667d42ee6e,Hohenfelder,brewpub,Wiedenbrücker Straße 155,,,Langenberg,Nordrhein-Westfalen,33449,Germany,+49 5248 80040,http://www.hohenfelder.de,8.3189245,51.7921375
+b13935c2-459c-482a-baa4-2df1a240d45d,Hohler Landbier,closed,Im Hohl 8,,,Olpe,Nordrhein-Westfalen,57462,Germany,+49 1590 1300831,http://www.hohler-landbier.de,7.858694900000001,51.0463397
+9a58ee02-b600-4a66-97ec-9564aaefa758,Hövels Hausbrauerei,brewpub,Hoher Wall 5-7,,,Dortmund,Nordrhein-Westfalen,44137,Germany,+49 231 9145470,http://www.hoevels-hausbrauerei.de,7.458608399999999,51.5124968
+b7b9ff4c-3730-46b4-8eb4-c64d1d2e6155,Ilsen-Bräu,brewpub,In den Erlen 29,,,Kreuztal,Nordrhein-Westfalen,57223,Germany,+49 2732 82396,http://www.ilsen-brauerei.de,7.98947,51.00513
+8b762a1b-5b19-4393-8979-ee1853048c42,Im Dom,brewpub,Michaelstraße 75-77,,,Neuss,Nordrhein-Westfalen,41460,Germany,+49 2131 275599,http://www.imdom1601.de,6.6933548,51.1962755
+5b43ab23-8aed-415f-b5fc-58c846fdcdfc,Irle,brewpub,Hauptstraße 18,,,Siegen,Nordrhein-Westfalen,57074,Germany,+49 271 31772910,http://www.der-biermacher.de,8.048752,50.8730264
+3494e8ef-4984-4190-9564-b86cbcd6edef,Josefsbräu,brewpub,Raiffeisenstraße 1s,,,Bad Lippspringe,Nordrhein-Westfalen,33175,Germany,+49 5252 9154270,http://www.trink-gutes.de,8.7952985,51.7793235
+bc04ad9c-3fbf-434f-a1dd-d2e418a1bbad,Kaiser Craft,brewpub,Bahnhofstraße 72,,,Bünde,Nordrhein-Westfalen,32257,Germany,+49 5223 178898,http://www.kaisercraft.de,8.574354,52.2012436
+9e42d740-f3f1-4b90-a5a0-62dc5f2c0f20,Kalkarer Mühle,brewpub,Mühlenstege 8,,,Kalkar,Nordrhein-Westfalen,47546,Germany,+49 2824 93230,http://www.kalkarermuehle.de,6.2955443,51.7396269
+2011647c-05c8-4c41-a628-37d47a491fb1,Kleines Eifeler-Brauhaus,brewpub,Wertherstraße 12,,,Bad Münstereifel,Nordrhein-Westfalen,53902,Germany,+49 2253 5448760,http://www.eifelburg.de,6.7652734,50.55595169999999
+b388363e-4be0-4c07-9730-750ff2025cb2,Klute's,brewpub,Poppenbeck 28,,,Havixbeck,Nordrhein-Westfalen,48329,Germany,+49 2507 98390,http://www.klutes.de,7.393216199999999,51.9893138
+8f4c0e0b-d587-4ee9-ad8f-2209ad1aff9c,König,brewpub,Friedrich-Ebert-Straße 308,,,Duisburg,Nordrhein-Westfalen,47139,Germany,+49 203 93330,http://www.koenig.de,6.7347563,51.47633219999999
+6948e42b-b78a-4f46-b2a7-985d8e624cba,Königshof,brewpub,Obergath 68,,,Krefeld,Nordrhein-Westfalen,47805,Germany,+49 2151 3330,http://www.brauerei-koenigshof.de,6.5696884,51.3147615
+404f4ac8-9265-4f3a-89c8-14941353fcb4,Krombacher,brewpub,Hagener Straße 261,,,Kreuztal,Nordrhein-Westfalen,57223,Germany,+49 2732 880880,http://www.krombacher.de,7.956437399999999,50.9910349
+1c397c68-2514-4757-913d-77461983f25d,Kürzer,brewpub,Kurze Straße 20,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 322696,http://www.brauerei-kuerzer.de,6.7733364,51.2269707
+97b59075-427c-43e4-bf15-559e52773b77,Läuterwerk,closed,Hammer Straße 371,,,Münster,Nordrhein-Westfalen,48153,Germany,+49 251 20817052,http://www.laeuterwerk.de,7.628756300000001,51.92818510000001
+9f133e93-70a1-4c3b-bee4-60603d46021d,Liebhart's,brewpub,Am Gelskamp 6,,,Detmold,Nordrhein-Westfalen,32756,Germany,+49 5231 630506,http://www.residenz-bier.de,8.8619474,51.94823419999999
+6ae55cd5-815a-4033-9595-0681af5cb009,Lippstädter Brauhaus,brewpub,Rathausstraße 12,,,Lippstadt,Nordrhein-Westfalen,59555,Germany,,http://www.lippstaedter-brauerei.de,8.3444252,51.6754884
+5df1fc95-6449-4e5c-b84c-7c3894e7396a,Lohmann,brewpub,Opladener Straße 19,,,Langenfeld (Rheinland),Nordrhein-Westfalen,40764,Germany,+49 2173 91610,http://www.landhotel-lohmann.de,6.9603568,51.089824
+15100f1d-57f3-43d3-b8c1-16530be2b30a,Lüdinghauser Brauwerkstatt,brewpub,Adam-Stegerwald-Straße 1,,,Lüdinghausen,Nordrhein-Westfalen,59348,Germany,,http://www.luedinghauser-brauwerkstatt.de,7.4278214,51.76618209999999
+8197a1c0-35cb-4dfc-8938-e52ced41781d,Malzmühle,brewpub,Heumarkt 6,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 92160613,http://www.muehlenkoelsch.de,6.9605091,50.93471049999999
+c6a3cb42-8017-49e4-a0a5-969d4d221c11,Marienfelder Klosterbräu,brewpub,Klosterhof 2,,,Harsewinkel,Nordrhein-Westfalen,33428,Germany,,http://www.klosterpforte.de,8.2791785,51.9473492
+48adfe82-b6e0-4cb2-9b03-db3a43f40e22,Maueler Hofbräu,micro,Preschlin-Allee 11,,,Windeck,Nordrhein-Westfalen,51570,Germany,+49 2292 91330,http://www.gasthof-willmeroth.de,7.600813800000001,50.8039271
+4af48a5c-33a6-40eb-827d-f2e3e56ea2a5,McMüller's,brewpub,Neußer Straße 54,,,Linnich,Nordrhein-Westfalen,52441,Germany,+49 2462 4457,http://www.mcmuellers.de,6.3218638,50.9999225
+a030d14e-ed28-4018-8f63-00e36e1e4eb3,Metten Hefemännchen,brewpub,Hohle Straße 18,,,Finnentrop,Nordrhein-Westfalen,57413,Germany,+49 2724 949054,http://www.hefemaennchen.de,8.0823897,51.23199839999999
+ba853ca5-ee89-41e4-a23a-8e0e3b3dd246,Mönchengladbach,brewpub,Senefelderstraße 29,,,Mönchengladbach,Nordrhein-Westfalen,41066,Germany,+49 2161 57690,http://www.oettinger-bier.de,6.473011899999999,51.2305467
+0267ecb8-fed1-4ed4-a6af-91253d831b25,Monheimer Biermanufactur,micro,Dachsbau 5,,,Monheim am Rhein,Nordrhein-Westfalen,40789,Germany,+49 1525 3985959,http://monheimer-biermanufactur.de,6.9046791,51.0981402
+ac8e4ac9-a869-4123-a98b-232d43291886,Moritz Fiege,brewpub,Moritz-Fiege-Straße 1,,,Bochum,Nordrhein-Westfalen,44787,Germany,+49 234 68980,http://www.moritzfiege.de,7.227264799999999,51.4809454
+34846875-edfb-4d9b-9b37-170fffa3e955,Paderborner,brewpub,Halberstädter Straße 45,,,Paderborn,Nordrhein-Westfalen,33106,Germany,+49 5251 7070,http://www.paderborner-brauerei.de,8.7476083,51.6876965
+df616605-958c-416e-ab7a-486e6635c9eb,Päffgen,brewpub,Friesenstraße 64-66,,,Köln,Nordrhein-Westfalen,50670,Germany,+49 221 135461,http://www.paeffgen-koelsch.de,6.9419115,50.9407688
+df33a039-e1e0-47a7-b0ac-ce798c1abc2c,Pinkus Müller,brewpub,- 10 Kreuzstraße 7,,,Münster,Nordrhein-Westfalen,48143,Germany,+49 251 55567,http://www.pinkus.de,7.621640900000001,51.9656444
+b9709f6b-f595-4ed4-86bb-58cde52f093a,Pott's,brewpub,In der Geist 120,,,Oelde,Nordrhein-Westfalen,59302,Germany,+49 2522 93320,http://www.potts.de,8.1318098,51.81089619999999
+dcee4787-93e3-4777-b4e6-2e2553c486ff,Privatbrauerei Haverkamp,brewpub,Ibbenbürener Straße 38,,,Ibbenbüren,Nordrhein-Westfalen,49479,Germany,+49 170 9341920,http://www.laggenbecker.de,7.779753599999999,52.2615276
+103814d2-c1db-4701-bfb9-2a16a1c2b279,Quercus,brewpub,Sternbuschweg 71,,,Duisburg,Nordrhein-Westfalen,47057,Germany,+49 203 373200,http://www.imeichwaeldchen.de,6.794072,51.429291
+077523f3-527d-4c0d-95a4-23f48dd078c2,Rainer,brewpub,Kreisstraße 31,,,Linnich,Nordrhein-Westfalen,52441,Germany,,http://www.brauerei-rainer.de,6.2593861,50.95942609999999
+383d4e73-0642-46ac-98b3-00dd2fc9fd18,Ratinger Brauhaus,brewpub,Bahnstraße 15,,,Ratingen,Nordrhein-Westfalen,40878,Germany,+49 2102 21981,http://www.poensgen-gastronomie-ratingen.de,6.855952299999999,51.298157
+d5f1957d-a136-4c45-9cb5-bf236434bee1,Reissdorf,brewpub,Emil-Hoffmann-Straße 4-10,,,Köln,Nordrhein-Westfalen,50996,Germany,+49 2236 96550,http://www.reissdorf.de,6.994972499999999,50.87607029999999
+b96755df-f060-4736-937b-7691b15ec85f,Remscheider Bräu,brewpub,Bismarckstraße 39,,,Remscheid,Nordrhein-Westfalen,42853,Germany,+49 2191 5646954,http://www.remscheider-brau.de,7.199113199999998,51.1785649
+e5b745d1-ae82-4e12-9107-cb70e6a17df0,Rolinck,brewpub,Alexander-Rolinck-Straße 1,,,Steinfurt,Nordrhein-Westfalen,48565,Germany,+49 2732 880880,http://www.rolinck.de,7.3402593,52.1530462
+0e86940b-8304-4a12-8ea8-7a2ced43cabf,Rotingdorfer,brewpub,Rotingdorfer Straße 10,,,Werther (Westfalen),Nordrhein-Westfalen,33824,Germany,+49 5203 902170,http://www.rotingdorfer.de,8.3905172,52.0881593
 80a85225-dcb6-472b-9a2e-71f39a2735cb,Ruhrtal,micro,Ruhrtal,,,Witten,Nordrhein-Westfalen,58456,Germany,,http://www.sonnenscheiner.de,7.2878548,51.4246441
-cea32a33-8673-40a0-bdae-9b580e46f023,Rütershoff,brewpub,33 Schillerstraße,,,Castrop-Rauxel,Nordrhein-Westfalen,44575,Germany,+49 2305 24923,http://www.brauhaus-ruetershoff.de,7.310921899999999,51.5416422
-446f1750-7fde-4151-b261-d337118ada43,Rüttenscheider Hausbrauerei,closed,4 Girardetstraße,,,Essen,Nordrhein-Westfalen,45131,Germany,+49 201 790060,http://www.ruettenscheider-hausbrauerei.de,7.0043384,51.4312867
-feba3f3b-eb61-4681-9382-edd04b36e304,Scharrenbräu,brewpub,260 Kalker Hauptstraße,262,,Köln,Nordrhein-Westfalen,51103,Germany,+49 221 9879950,http://www.scharrenbraeu.de,7.011139999999999,50.939149
-64adc315-4c14-45e7-81d8-61f0f58b9d2c,Schloßbrauerei Rheder,brewpub,10 Nethetalstraße,,,Brakel,Nordrhein-Westfalen,33034,Germany,+49 5272 39230,http://www.schlossbrauerei-rheder.de,9.163372299999999,51.6787133
-ed8db1c9-d81a-449f-9496-2e8c3cece558,Schlüssel,brewpub,41-47 Bolkerstraße,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 8289550,http://www.zumschluessel.de,6.774435,51.226086
-1f9c3f0f-76d6-419f-a46d-8faaf3a7848a,Schmitz-Mönk,brewpub,28 Jakob-Krebs-Straße,,,Willich,Nordrhein-Westfalen,47877,Germany,+49 2156 2531,http://www.schmitzmoenk.de,6.461055,51.279098
-e3660c32-840d-4ae9-9812-6bb4fd3796b5,Schnaff,brewpub,11B Heidenstraße,,,Hückeswagen,Nordrhein-Westfalen,42499,Germany,+49 2192 9355762,http://www.schnaff.beer,7.336294299999999,51.1501291
-30deb39e-c048-4973-b71d-0ffac2434892,Schumacher,brewpub,123 Oststraße,,,Düsseldorf,Nordrhein-Westfalen,40210,Germany,+49 211 8289020,http://www.brauerei-schumacher.de,6.785279999999999,51.2215533
+cea32a33-8673-40a0-bdae-9b580e46f023,Rütershoff,brewpub,Schillerstraße 33,,,Castrop-Rauxel,Nordrhein-Westfalen,44575,Germany,+49 2305 24923,http://www.brauhaus-ruetershoff.de,7.310921899999999,51.5416422
+446f1750-7fde-4151-b261-d337118ada43,Rüttenscheider Hausbrauerei,closed,Girardetstraße 4,,,Essen,Nordrhein-Westfalen,45131,Germany,+49 201 790060,http://www.ruettenscheider-hausbrauerei.de,7.0043384,51.4312867
+feba3f3b-eb61-4681-9382-edd04b36e304,Scharrenbräu,brewpub,Kalker Hauptstraße 260,262,,Köln,Nordrhein-Westfalen,51103,Germany,+49 221 9879950,http://www.scharrenbraeu.de,7.011139999999999,50.939149
+64adc315-4c14-45e7-81d8-61f0f58b9d2c,Schloßbrauerei Rheder,brewpub,Nethetalstraße 10,,,Brakel,Nordrhein-Westfalen,33034,Germany,+49 5272 39230,http://www.schlossbrauerei-rheder.de,9.163372299999999,51.6787133
+ed8db1c9-d81a-449f-9496-2e8c3cece558,Schlüssel,brewpub,Bolkerstraße 41-47,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 8289550,http://www.zumschluessel.de,6.774435,51.226086
+1f9c3f0f-76d6-419f-a46d-8faaf3a7848a,Schmitz-Mönk,brewpub,Jakob-Krebs-Straße 28,,,Willich,Nordrhein-Westfalen,47877,Germany,+49 2156 2531,http://www.schmitzmoenk.de,6.461055,51.279098
+e3660c32-840d-4ae9-9812-6bb4fd3796b5,Schnaff,brewpub,Heidenstraße 11B,,,Hückeswagen,Nordrhein-Westfalen,42499,Germany,+49 2192 9355762,http://www.schnaff.beer,7.336294299999999,51.1501291
+30deb39e-c048-4973-b71d-0ffac2434892,Schumacher,brewpub,Oststraße 123,,,Düsseldorf,Nordrhein-Westfalen,40210,Germany,+49 211 8289020,http://www.brauerei-schumacher.de,6.785279999999999,51.2215533
 9a8baa89-1ef5-43f6-949d-afde9643121d,Seven Craft,micro,Kirchstraße 35,,,Koenigswinter,Nordrhein-Westfalen,53639,Germany,,http://www.sevencraft.de,,
-19d0e82e-191e-4856-8534-b8bfb158da7e,Siegburger Brauhaus,brewpub,37-39 Holzgasse,,,Siegburg,Nordrhein-Westfalen,53721,Germany,+49 2241 55999,http://www.siegburger-brauhaus.de,7.210516,50.798213
-34b23f93-0cb0-485e-a26d-0258f4d39015,Simian Ales,brewpub,57 Mühlenweg,,,Krefeld,Nordrhein-Westfalen,47839,Germany,,http://www.simian-ales.com,6.504070899999999,51.3689281
-44fb680d-78a3-451b-a70d-99225d2e288b,Stauder,brewpub,88 Stauderstraße,,,Essen,Nordrhein-Westfalen,45326,Germany,+49 201 36160,http://www.stauder.de,7.020521899999999,51.49664749999999
-53e5f9fa-b3f7-4b8f-9588-4686bb432d0c,Stephanus,brewpub,1 Overhagenweg,,,Coesfeld,Nordrhein-Westfalen,48653,Germany,+49 2541 1000,http://www.brauhaus-stephanus.de,7.1566151,51.9369166
-2fa6b918-3fb5-46bd-9b2a-04e7436923cf,Stiefel-Jürgens,brewpub,6 Hühlstraße,,,Beckum,Nordrhein-Westfalen,59269,Germany,+49 2521 3351,http://www.stiefel-juergens.de,8.039539999999999,51.7554452
-29267357-8ae0-42ee-bb56-6ee8f4f03813,Straelener Brauhaus,brewpub,68 Sanger Weg,,,Straelen,Nordrhein-Westfalen,47638,Germany,+49 2834 7000050,http://www.straelener-brauhaus.de,6.277959999999999,51.41661
-1b9ae1a5-83b8-4f39-8d46-284559b7ca5d,Strate,brewpub,1 Palaisstraße,,,Detmold,Nordrhein-Westfalen,32756,Germany,+49 5231 944000,http://www.brauerei-strate.de,8.8698443,51.933643
-143c52fc-1c2d-44e4-a40f-572d61fba594,Sünner,brewpub,13 Salzgasse,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 2577879,http://www.suenner-koelsch.de,6.9618973,50.9377136
+19d0e82e-191e-4856-8534-b8bfb158da7e,Siegburger Brauhaus,brewpub,Holzgasse 37-39,,,Siegburg,Nordrhein-Westfalen,53721,Germany,+49 2241 55999,http://www.siegburger-brauhaus.de,7.210516,50.798213
+34b23f93-0cb0-485e-a26d-0258f4d39015,Simian Ales,brewpub,Mühlenweg 57,,,Krefeld,Nordrhein-Westfalen,47839,Germany,,http://www.simian-ales.com,6.504070899999999,51.3689281
+44fb680d-78a3-451b-a70d-99225d2e288b,Stauder,brewpub,Stauderstraße 88,,,Essen,Nordrhein-Westfalen,45326,Germany,+49 201 36160,http://www.stauder.de,7.020521899999999,51.49664749999999
+53e5f9fa-b3f7-4b8f-9588-4686bb432d0c,Stephanus,brewpub,Overhagenweg 1,,,Coesfeld,Nordrhein-Westfalen,48653,Germany,+49 2541 1000,http://www.brauhaus-stephanus.de,7.1566151,51.9369166
+2fa6b918-3fb5-46bd-9b2a-04e7436923cf,Stiefel-Jürgens,brewpub,Hühlstraße 6,,,Beckum,Nordrhein-Westfalen,59269,Germany,+49 2521 3351,http://www.stiefel-juergens.de,8.039539999999999,51.7554452
+29267357-8ae0-42ee-bb56-6ee8f4f03813,Straelener Brauhaus,brewpub,Sanger Weg 68,,,Straelen,Nordrhein-Westfalen,47638,Germany,+49 2834 7000050,http://www.straelener-brauhaus.de,6.277959999999999,51.41661
+1b9ae1a5-83b8-4f39-8d46-284559b7ca5d,Strate,brewpub,Palaisstraße 1,,,Detmold,Nordrhein-Westfalen,32756,Germany,+49 5231 944000,http://www.brauerei-strate.de,8.8698443,51.933643
+143c52fc-1c2d-44e4-a40f-572d61fba594,Sünner,brewpub,Salzgasse 13,,,Köln,Nordrhein-Westfalen,50667,Germany,+49 221 2577879,http://www.suenner-koelsch.de,6.9618973,50.9377136
 a9bee18c-34d7-4d58-ac02-4076c3a75bbc,Teutoburger Brauerei,micro,Teutoburger Straße,,,Lengerich,Nordrhein-Westfalen,49525,Germany,,http://www.teutoburger-bier.de,7.8587043,52.1882637
-c441939d-aa51-4e1d-873e-27db810bec7a,Toms Hütte,closed,38 Oderstraße,,,Bonn,Nordrhein-Westfalen,53127,Germany,,http://www.tomshuette-bier.de,7.087916099999999,50.693879
-50dd34f1-87e5-47d6-9170-8f1f11a6b2f9,Troll's Brauhaus,brewpub,28-30 Oberstraße,,,Medebach,Nordrhein-Westfalen,59964,Germany,+49 2982 9298490,http://www.trolls-brauhaus.de,8.7011449,51.2004452
-f56e41df-11bb-43bc-8dd0-d62804f4d89d,Uerige,brewpub,1 Berger Straße,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 866990,http://www.uerige.de,6.7722509,51.2249992
+c441939d-aa51-4e1d-873e-27db810bec7a,Toms Hütte,closed,Oderstraße 38,,,Bonn,Nordrhein-Westfalen,53127,Germany,,http://www.tomshuette-bier.de,7.087916099999999,50.693879
+50dd34f1-87e5-47d6-9170-8f1f11a6b2f9,Troll's Brauhaus,brewpub,Oberstraße 28-30,,,Medebach,Nordrhein-Westfalen,59964,Germany,+49 2982 9298490,http://www.trolls-brauhaus.de,8.7011449,51.2004452
+f56e41df-11bb-43bc-8dd0-d62804f4d89d,Uerige,brewpub,Berger Straße 1,,,Düsseldorf,Nordrhein-Westfalen,40213,Germany,+49 211 866990,http://www.uerige.de,6.7722509,51.2249992
 77b315d2-aab1-4a23-a803-87e6f53e548c,Veltins,brewpub,An der Streue,,,Meschede,Nordrhein-Westfalen,59872,Germany,+49 2934 9590,http://www.veltins.de,8.1268063,51.3052502
-fa5bf5af-b4f8-44f8-b4c6-b5fa2345ce34,Vormann,brewpub,5 Braugasse,,,Hagen,Nordrhein-Westfalen,58091,Germany,+49 2337 445,http://www.vormann-brauerei.de,7.53114,51.30367
-95812ebd-7f1f-45be-9cf8-61dcab05f445,Waldgasthaus Steinbach,brewpub,3 Schweizer Straße,,,Euskirchen,Nordrhein-Westfalen,53881,Germany,+49 2255 8833,http://www.waldgasthaus-steinbach.de,6.870650299999999,50.6128724
-2651b4b4-ba91-46a3-b8bb-c83e9c9ec18a,Waldstadtbrauerei Iserlohn,brewpub,71 Grüner Talstraße,,,Iserlohn,Nordrhein-Westfalen,58644,Germany,+49 2371 7839280,http://www.waldstadtbrauerei-iserlohn.de,7.676152200000001,51.3606945
-b02b72be-70ea-4685-b319-abfafb84db4e,Walsumer Brauhaus Urfels,brewpub,109 Römerstraße,,,Duisburg,Nordrhein-Westfalen,47179,Germany,+49 203 9919450,http://www.brauhaus-urfels.de,6.7258939,51.5234331
-35b7e7b9-1b1c-4d8f-b9a9-cbe4cd5bf487,Walter Bräu,brewpub,54C Perricher Weg,,,Wesel,Nordrhein-Westfalen,46487,Germany,+49 2803 1597,http://www.walterbrau.de,6.5835035,51.6363352
-cdb1ed99-0b85-4719-957b-e52e52d772a0,Warburger,brewpub,58 Kuhlemühler Weg,,,Warburg,Nordrhein-Westfalen,34414,Germany,+49 5641 90000,http://www.warburger-brauerei.de,9.1933475,51.4859788
+fa5bf5af-b4f8-44f8-b4c6-b5fa2345ce34,Vormann,brewpub,Braugasse 5,,,Hagen,Nordrhein-Westfalen,58091,Germany,+49 2337 445,http://www.vormann-brauerei.de,7.53114,51.30367
+95812ebd-7f1f-45be-9cf8-61dcab05f445,Waldgasthaus Steinbach,brewpub,Schweizer Straße 3,,,Euskirchen,Nordrhein-Westfalen,53881,Germany,+49 2255 8833,http://www.waldgasthaus-steinbach.de,6.870650299999999,50.6128724
+2651b4b4-ba91-46a3-b8bb-c83e9c9ec18a,Waldstadtbrauerei Iserlohn,brewpub,Grüner Talstraße 71,,,Iserlohn,Nordrhein-Westfalen,58644,Germany,+49 2371 7839280,http://www.waldstadtbrauerei-iserlohn.de,7.676152200000001,51.3606945
+b02b72be-70ea-4685-b319-abfafb84db4e,Walsumer Brauhaus Urfels,brewpub,Römerstraße 109,,,Duisburg,Nordrhein-Westfalen,47179,Germany,+49 203 9919450,http://www.brauhaus-urfels.de,6.7258939,51.5234331
+35b7e7b9-1b1c-4d8f-b9a9-cbe4cd5bf487,Walter Bräu,brewpub,Perricher Weg 54C,,,Wesel,Nordrhein-Westfalen,46487,Germany,+49 2803 1597,http://www.walterbrau.de,6.5835035,51.6363352
+cdb1ed99-0b85-4719-957b-e52e52d772a0,Warburger,brewpub,Kuhlemühler Weg 58,,,Warburg,Nordrhein-Westfalen,34414,Germany,+49 5641 90000,http://www.warburger-brauerei.de,9.1933475,51.4859788
 adb4834c-819f-4163-8280-8cf998dc89f7,Warsteiner,brewpub,Zu Hause im Waldpark,,,Warstein,Nordrhein-Westfalen,59581,Germany,+49 2902 885001,http://www.warsteiner.de,8.354812599999999,51.4255554
-6e8ddae5-3588-4948-916e-2ec830bfac6d,Webster,brewpub,14 Dellplatz,,,Duisburg,Nordrhein-Westfalen,47051,Germany,+49 203 23078,http://www.webster-brauhaus.de,6.7613736,51.4305058
-7ca05c0f-66dd-4c7e-8d43-8c8a35081376,Westfälisches Bier-/Schnapsmus.,brewpub,5 Lange Straße,,,Nieheim,Nordrhein-Westfalen,33039,Germany,,http://www.westfalen-culinarium.de/pages/museen/biermuseum.php,9.1082916,51.8043136
-0a77ea0d-3276-4233-a512-f8b526259327,Westheimer,brewpub,7 Kasseler Straße,,,Marsberg,Nordrhein-Westfalen,34431,Germany,+49 2994 8890,http://www.brauerei-westheim.de,8.9038601,51.4934988
-f7f09d02-502e-40ad-b28f-3f46debcb8a2,Wolfsbier,brewpub,176 Durchholzer Straße,,,Witten,Nordrhein-Westfalen,58456,Germany,+49 2302 429889,,7.287007799999999,51.3817944
-5894e4ab-99b8-490b-aa7b-4f2b82e97b61,Wuppertaler Brauhaus,brewpub,5 Kleine Flurstraße,,,Wuppertal,Nordrhein-Westfalen,42275,Germany,+49 202 255050,http://www.wuppertalerbrauhaus.de,7.200787999999999,51.2724838
-76de477c-630d-4047-8d34-d9586b7fc56b,Zeche Jacobi,closed,30 CentrO-Promenade,,,Oberhausen,Nordrhein-Westfalen,46047,Germany,+49 208 802200,http://www.brauhaus-zeche-jacobi.de,6.876862099999999,51.4922523
-3aa69a14-42f6-473a-88aa-6d6084d9560b,Zum Pfaffen,brewpub,2 Klasberg,,,Lohmar,Nordrhein-Westfalen,53797,Germany,+49 2205 85396,http://www.max-paeffgen.de,7.2167562,50.8792543
-5bef9912-cd10-4a99-b9b9-259707b29c4d,Zum Stefanus,brewpub,59 Mennrath,,,Mönchengladbach,Nordrhein-Westfalen,41179,Germany,+49 2161 580154,http://www.zum-stefanus.de,6.384429,51.137341
-71c683a7-5c38-4e2a-b32e-6c6fa516e301,Zur Spitze,brewpub,22 Brockhagener Straße,,,Bielefeld,Nordrhein-Westfalen,33649,Germany,+49 521 40086333,http://www.hotel-zur-spitze.de,8.483653799999999,51.9877274
+6e8ddae5-3588-4948-916e-2ec830bfac6d,Webster,brewpub,Dellplatz 14,,,Duisburg,Nordrhein-Westfalen,47051,Germany,+49 203 23078,http://www.webster-brauhaus.de,6.7613736,51.4305058
+7ca05c0f-66dd-4c7e-8d43-8c8a35081376,Westfälisches Bier-/Schnapsmus.,brewpub,Lange Straße 5,,,Nieheim,Nordrhein-Westfalen,33039,Germany,,http://www.westfalen-culinarium.de/pages/museen/biermuseum.php,9.1082916,51.8043136
+0a77ea0d-3276-4233-a512-f8b526259327,Westheimer,brewpub,Kasseler Straße 7,,,Marsberg,Nordrhein-Westfalen,34431,Germany,+49 2994 8890,http://www.brauerei-westheim.de,8.9038601,51.4934988
+f7f09d02-502e-40ad-b28f-3f46debcb8a2,Wolfsbier,brewpub,Durchholzer Straße 176,,,Witten,Nordrhein-Westfalen,58456,Germany,+49 2302 429889,,7.287007799999999,51.3817944
+5894e4ab-99b8-490b-aa7b-4f2b82e97b61,Wuppertaler Brauhaus,brewpub,Kleine Flurstraße 5,,,Wuppertal,Nordrhein-Westfalen,42275,Germany,+49 202 255050,http://www.wuppertalerbrauhaus.de,7.200787999999999,51.2724838
+76de477c-630d-4047-8d34-d9586b7fc56b,Zeche Jacobi,closed,CentrO-Promenade 30,,,Oberhausen,Nordrhein-Westfalen,46047,Germany,+49 208 802200,http://www.brauhaus-zeche-jacobi.de,6.876862099999999,51.4922523
+3aa69a14-42f6-473a-88aa-6d6084d9560b,Zum Pfaffen,brewpub,Klasberg 2,,,Lohmar,Nordrhein-Westfalen,53797,Germany,+49 2205 85396,http://www.max-paeffgen.de,7.2167562,50.8792543
+5bef9912-cd10-4a99-b9b9-259707b29c4d,Zum Stefanus,brewpub,Mennrath 59,,,Mönchengladbach,Nordrhein-Westfalen,41179,Germany,+49 2161 580154,http://www.zum-stefanus.de,6.384429,51.137341
+71c683a7-5c38-4e2a-b32e-6c6fa516e301,Zur Spitze,brewpub,Brockhagener Straße 22,,,Bielefeld,Nordrhein-Westfalen,33649,Germany,+49 521 40086333,http://www.hotel-zur-spitze.de,8.483653799999999,51.9877274

--- a/data/germany/rheinland-pfalz.csv
+++ b/data/germany/rheinland-pfalz.csv
@@ -1,59 +1,59 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-7d13be05-4aff-4b36-8ac0-0561d6a918fc,Bahnhof Cues,brewpub,8 Bahnhofstraße,,,Bernkastel-Kues,Rheinland-Pfalz,54470,Germany,+49 6531 9739705,http://www.bahnhof-kues.de,7.0692808,49.9157156
-7bee8fbd-fb43-4c7a-a5b6-53c80d9f5ad3,Bellheimer,brewpub,20-22 Karl-Silbernagel-Straße,,,Bellheim,Rheinland-Pfalz,76756,Germany,+49 7272 7010,http://www.bellheimer.de,8.2789512,49.189647
-7554565b-edb0-4dbc-89b6-dda7b5f0ef3f,Bells,brewpub,27 Niederhutstraße,,,Bad Neuenahr-Ahrweiler,Rheinland-Pfalz,53474,Germany,+49 2641 900243,http://www.apbells.de,7.0972532,50.5431775
-11ceebc9-8b61-4d50-97ea-9160f2236f5e,Bier-Schmiede,brewpub,88 Hauptstraße,,,Bendorf,Rheinland-Pfalz,56170,Germany,+49 2622 8954696,http://www.bierschmiede-bendorf.de,7.577593599999999,50.4229226
-80a4dc31-7d52-4eee-b40b-adc0687e6935,Bierprojekt Landau,closed,8 Mühlweg,,,Siebeldingen,Rheinland-Pfalz,76833,Germany,,http://www.bierprojekt-landau.de,8.046619399999999,49.2093826
-efbc4c79-d23e-4cc5-877f-e1c1922a7649,Bischoff,closed,6 An den Hopfengärten,,,Winnweiler,Rheinland-Pfalz,67722,Germany,+49 6302 9120,http://www.bischoff-bier.de,7.858153600000001,49.5720399
-aa1c1b26-722e-42d7-9d2d-74c0eca0a110,Bitburger,brewpub,3 Römermauer,,,Bitburg,Rheinland-Pfalz,54634,Germany,+49 6561 142497,http://www.bitburger.de,6.5223335,49.9744776
-81f66e31-e29e-423b-be6c-4270ac528313,BrauArt,brewpub,2-4 Angelgasse,,,Grünstadt,Rheinland-Pfalz,67269,Germany,+49 170 1697666,http://www.brau-art.com,8.15935,49.54849
+7d13be05-4aff-4b36-8ac0-0561d6a918fc,Bahnhof Cues,brewpub,Bahnhofstraße 8,,,Bernkastel-Kues,Rheinland-Pfalz,54470,Germany,+49 6531 9739705,http://www.bahnhof-kues.de,7.0692808,49.9157156
+7bee8fbd-fb43-4c7a-a5b6-53c80d9f5ad3,Bellheimer,brewpub,Karl-Silbernagel-Straße 20-22,,,Bellheim,Rheinland-Pfalz,76756,Germany,+49 7272 7010,http://www.bellheimer.de,8.2789512,49.189647
+7554565b-edb0-4dbc-89b6-dda7b5f0ef3f,Bells,brewpub,Niederhutstraße 27,,,Bad Neuenahr-Ahrweiler,Rheinland-Pfalz,53474,Germany,+49 2641 900243,http://www.apbells.de,7.0972532,50.5431775
+11ceebc9-8b61-4d50-97ea-9160f2236f5e,Bier-Schmiede,brewpub,Hauptstraße 88,,,Bendorf,Rheinland-Pfalz,56170,Germany,+49 2622 8954696,http://www.bierschmiede-bendorf.de,7.577593599999999,50.4229226
+80a4dc31-7d52-4eee-b40b-adc0687e6935,Bierprojekt Landau,closed,Mühlweg 8,,,Siebeldingen,Rheinland-Pfalz,76833,Germany,,http://www.bierprojekt-landau.de,8.046619399999999,49.2093826
+efbc4c79-d23e-4cc5-877f-e1c1922a7649,Bischoff,closed,An den Hopfengärten 6,,,Winnweiler,Rheinland-Pfalz,67722,Germany,+49 6302 9120,http://www.bischoff-bier.de,7.858153600000001,49.5720399
+aa1c1b26-722e-42d7-9d2d-74c0eca0a110,Bitburger,brewpub,Römermauer 3,,,Bitburg,Rheinland-Pfalz,54634,Germany,+49 6561 142497,http://www.bitburger.de,6.5223335,49.9744776
+81f66e31-e29e-423b-be6c-4270ac528313,BrauArt,brewpub,Angelgasse 2-4,,,Grünstadt,Rheinland-Pfalz,67269,Germany,+49 170 1697666,http://www.brau-art.com,8.15935,49.54849
 cd17edb8-b0d7-45af-b5f1-812737bcc315,Brauerei Schnorres,micro,Hauptstraße 28,,,Mehlingen,Rheinland-Pfalz,67678,Germany,,http://www.schnorres.net,,
-92c70439-3435-4d7b-b3a2-ebe570015a1f,Brauhaus am Markt,brewpub,2 Stiftsplatz,,,Kaiserslautern,Rheinland-Pfalz,67655,Germany,+49 631 61944,http://www.brauhaus-am-markt.com,7.771735499999998,49.4447742
-fc2a2892-0ae7-418d-891c-8fbca075c821,Brauhaus am Turm,brewpub,1 Schlossstraße,,,Kirchheimbolanden,Rheinland-Pfalz,67292,Germany,+49 6352 3841,http://www.brauhaus-am-turm.de,8.0109962,49.6642482
-5822d6c5-e10d-4bb3-bcf7-d20893d5ec58,Brauhaus Ehrstein,brewpub,3 Im Handschuhteich,,,Hinterweidenthal,Rheinland-Pfalz,66999,Germany,+49 6396 1680000,http://www.brauhaus-ehrstein.de,7.749108399999999,49.1965741
-e25ed5ba-8880-4af5-a9d4-2501e55d8d1e,Brauhaus Grünstadt,brewpub,11 Turnstraße,,,Grünstadt,Rheinland-Pfalz,67269,Germany,+49 176 41723945,http://www.brauhaus-gruenstadt.de.tl,8.1649154,49.56363690000001
-77250acb-fa3d-4e4a-ab5b-c2a552e4acee,Brauhaus K,brewpub,8 Bahnhofstraße,,,Bernkastel-Kues,Rheinland-Pfalz,54470,Germany,+49 6531 9739705,http://www.brauhaus-kloster-machern.de,7.0692808,49.9157156
-3d2500c7-054b-4f6d-b02a-0d926b526cd1,Brauhaus Lauterecken,brewpub,1 Bahnhofstraße,,,Lauterecken,Rheinland-Pfalz,67742,Germany,+49 176 64350781,http://www.brauhauslauterecken.de,7.5911572,49.6537622
-0a8b3fa3-dfd4-4c73-bca0-42670a84018b,Brauhaus zur Post,brewpub,45 Neumayerring,,,Frankenthal (Pfalz),Rheinland-Pfalz,67227,Germany,+49 6233 220286,http://www.brauhaus-zur-post.de,8.3503927,49.534615
-6bf1bb5e-d959-419b-9d42-bf558bda65ff,Braukeller Bobenheim,closed,6 Im Pflänzer,,,Bobenheim am Berg,Rheinland-Pfalz,67273,Germany,+49 6353 932211,http://www.braukeller-bobenheim.de,8.14555,49.52364
-08791b8f-54fd-41d7-a74e-571f531fa6ff,Brauwerk,brewpub,11 Saline Karlshalle,,,Bad Kreuznach,Rheinland-Pfalz,55543,Germany,+49 671 29843330,http://www.brauwerk.info,7.849343999999999,49.82858299999999
-a98d6d6b-24a8-4df1-93d5-3c4d7cc933bf,BREXX,brewpub,11-17 Brexbachstraße,,,Höhr-Grenzhausen,Rheinland-Pfalz,56203,Germany,+49 2624 105637,http://www.brexx-grenzau.de,7.6613335,50.4522206
-087d5cec-91fe-4a1d-9ecb-e8b0adcde25d,Denkmalz,brewpub,5 Kapellenstraße,,,Bad Sobernheim,Rheinland-Pfalz,55566,Germany,+49 6751 8577080,http://www.denkmalz.de,7.654766400000001,49.7837173
-64bc1a63-f967-45a7-ae00-d5347f804ca7,Domhof,brewpub,6 Große Himmelsgasse,,,Speyer,Rheinland-Pfalz,67346,Germany,+49 6232 67440,http://www.domhof.de,8.4406211,49.3176503
-57b2b737-11df-4a06-a9e8-ea92da1ba188,Eisgrub-Bräu,brewpub,1A Weißliliengasse,,,Mainz,Rheinland-Pfalz,55116,Germany,+49 6131 221104,http://www.eisgrub.de,8.2730661,49.9952753
+92c70439-3435-4d7b-b3a2-ebe570015a1f,Brauhaus am Markt,brewpub,Stiftsplatz 2,,,Kaiserslautern,Rheinland-Pfalz,67655,Germany,+49 631 61944,http://www.brauhaus-am-markt.com,7.771735499999998,49.4447742
+fc2a2892-0ae7-418d-891c-8fbca075c821,Brauhaus am Turm,brewpub,Schlossstraße 1,,,Kirchheimbolanden,Rheinland-Pfalz,67292,Germany,+49 6352 3841,http://www.brauhaus-am-turm.de,8.0109962,49.6642482
+5822d6c5-e10d-4bb3-bcf7-d20893d5ec58,Brauhaus Ehrstein,brewpub,Im Handschuhteich 3,,,Hinterweidenthal,Rheinland-Pfalz,66999,Germany,+49 6396 1680000,http://www.brauhaus-ehrstein.de,7.749108399999999,49.1965741
+e25ed5ba-8880-4af5-a9d4-2501e55d8d1e,Brauhaus Grünstadt,brewpub,Turnstraße 11,,,Grünstadt,Rheinland-Pfalz,67269,Germany,+49 176 41723945,http://www.brauhaus-gruenstadt.de.tl,8.1649154,49.56363690000001
+77250acb-fa3d-4e4a-ab5b-c2a552e4acee,Brauhaus K,brewpub,Bahnhofstraße 8,,,Bernkastel-Kues,Rheinland-Pfalz,54470,Germany,+49 6531 9739705,http://www.brauhaus-kloster-machern.de,7.0692808,49.9157156
+3d2500c7-054b-4f6d-b02a-0d926b526cd1,Brauhaus Lauterecken,brewpub,Bahnhofstraße 1,,,Lauterecken,Rheinland-Pfalz,67742,Germany,+49 176 64350781,http://www.brauhauslauterecken.de,7.5911572,49.6537622
+0a8b3fa3-dfd4-4c73-bca0-42670a84018b,Brauhaus zur Post,brewpub,Neumayerring 45,,,Frankenthal (Pfalz),Rheinland-Pfalz,67227,Germany,+49 6233 220286,http://www.brauhaus-zur-post.de,8.3503927,49.534615
+6bf1bb5e-d959-419b-9d42-bf558bda65ff,Braukeller Bobenheim,closed,Im Pflänzer 6,,,Bobenheim am Berg,Rheinland-Pfalz,67273,Germany,+49 6353 932211,http://www.braukeller-bobenheim.de,8.14555,49.52364
+08791b8f-54fd-41d7-a74e-571f531fa6ff,Brauwerk,brewpub,Saline Karlshalle 11,,,Bad Kreuznach,Rheinland-Pfalz,55543,Germany,+49 671 29843330,http://www.brauwerk.info,7.849343999999999,49.82858299999999
+a98d6d6b-24a8-4df1-93d5-3c4d7cc933bf,BREXX,brewpub,Brexbachstraße 11-17,,,Höhr-Grenzhausen,Rheinland-Pfalz,56203,Germany,+49 2624 105637,http://www.brexx-grenzau.de,7.6613335,50.4522206
+087d5cec-91fe-4a1d-9ecb-e8b0adcde25d,Denkmalz,brewpub,Kapellenstraße 5,,,Bad Sobernheim,Rheinland-Pfalz,55566,Germany,+49 6751 8577080,http://www.denkmalz.de,7.654766400000001,49.7837173
+64bc1a63-f967-45a7-ae00-d5347f804ca7,Domhof,brewpub,Große Himmelsgasse 6,,,Speyer,Rheinland-Pfalz,67346,Germany,+49 6232 67440,http://www.domhof.de,8.4406211,49.3176503
+57b2b737-11df-4a06-a9e8-ea92da1ba188,Eisgrub-Bräu,brewpub,Weißliliengasse 1A,,,Mainz,Rheinland-Pfalz,55116,Germany,+49 6131 221104,http://www.eisgrub.de,8.2730661,49.9952753
 955b335d-3049-4b3d-8ec7-274a0b5b1c36,Fohr,brewpub,An der Brauerei,,,Ransbach-Baumbach,Rheinland-Pfalz,56235,Germany,+49 2623 9294930,http://www.brauerei-fohr.de,7.7164481,50.4712702
-29f54fa5-e9a5-43ee-bc7f-594a2af3edc4,Froschbräu,brewpub,5 Buchstraße,,,Jockgrim,Rheinland-Pfalz,76751,Germany,+49 7271 5478,http://www.froschl.de,8.2713916,49.0913875
-0083a107-6d0c-4def-9dc2-ab1160789279,Göcklinger Hausbräu,brewpub,2 Münsterweg,,,Göcklingen,Rheinland-Pfalz,76831,Germany,+49 6349 5335,http://www.goecklingerhausbraeu.de,8.0401077,49.1603553
-de4a7f2b-dcdc-48ce-ad9b-59fca0229ad8,Hagenbräu,brewpub,3 Am Rhein,,,Worms,Rheinland-Pfalz,67547,Germany,+49 6241 921100,http://www.hagenbraeu.de,8.3769918,49.6322419
-b8732ad1-0459-4a93-8e71-84b499048004,Hasslocher Brauhof,closed,151 Rennbahnstraße,,,Haßloch,Rheinland-Pfalz,67454,Germany,+49 6324 9114463,,8.2736087,49.3486088
+29f54fa5-e9a5-43ee-bc7f-594a2af3edc4,Froschbräu,brewpub,Buchstraße 5,,,Jockgrim,Rheinland-Pfalz,76751,Germany,+49 7271 5478,http://www.froschl.de,8.2713916,49.0913875
+0083a107-6d0c-4def-9dc2-ab1160789279,Göcklinger Hausbräu,brewpub,Münsterweg 2,,,Göcklingen,Rheinland-Pfalz,76831,Germany,+49 6349 5335,http://www.goecklingerhausbraeu.de,8.0401077,49.1603553
+de4a7f2b-dcdc-48ce-ad9b-59fca0229ad8,Hagenbräu,brewpub,Am Rhein 3,,,Worms,Rheinland-Pfalz,67547,Germany,+49 6241 921100,http://www.hagenbraeu.de,8.3769918,49.6322419
+b8732ad1-0459-4a93-8e71-84b499048004,Hasslocher Brauhof,closed,Rennbahnstraße 151,,,Haßloch,Rheinland-Pfalz,67454,Germany,+49 6324 9114463,,8.2736087,49.3486088
 6ed3c594-4136-4a59-8bcd-aebb40fe31a1,Hof Schauferts,brewpub,Schaufertshof,,,Schönborn,Rheinland-Pfalz,56370,Germany,+49 6486 6208,http://www.schauferts.de,7.978594999999999,50.297119
-f3f2c3f0-a54c-4c72-bc61-93d8a0416253,Hofstätter-Scheune-Bräu,closed,33 Ortsstraße,,,Wilgartswiesen,Rheinland-Pfalz,76848,Germany,+49 6397 360,http://www.zurscheune.de,7.858876199999998,49.2789763
-cbf311c9-810c-497a-91d5-8d9ffb716d38,Jäger Bräu,brewpub,18 Staatsstraße,,,Edenkoben,Rheinland-Pfalz,67480,Germany,+49 6323 937641,http://www.jägerbräu.de,8.140009899999999,49.2830429
-7e9357ff-d1d6-419f-8e7b-38a814eacd5d,Kirner,brewpub,2 Kallenfelser Straße,,,Kirn,Rheinland-Pfalz,55606,Germany,+49 6752 1340,http://www.kirner.de,7.457421099999999,49.7887716
-6dde99bc-67da-4674-8fe3-ae513e5433ce,Koblenzer,brewpub,10 An der Königsbach,,,Koblenz,Rheinland-Pfalz,56075,Germany,,http://www.koblenzer-brauerei.de,7.5867422,50.3233019
-767be5e2-9fb4-4a8f-9457-496d1ec56922,Kraft-Bräu,brewpub,135 Olewiger Straße,,,Trier,Rheinland-Pfalz,54295,Germany,+49 651 36060,http://www.blesius-garten.de,6.659902799999999,49.74323760000001
-2289fc38-47ac-4ed5-b0fb-9c72d48a0b7c,Kuchems Brauhaus,brewpub,44 Schlossstraße,,,Pirmasens,Rheinland-Pfalz,66953,Germany,+49 6331 213894,http://www.kuchems-brauhaus.de,7.6054792,49.2004801
-ac7584c0-30a9-4850-a7e3-e26fae6770f7,Kuehn Kunz Rosen,brewpub,15 Weisenauer Straße,,,Mainz,Rheinland-Pfalz,55131,Germany,+49 6131 2116101,http://www.kuehnkunzrosen.de,8.2859641,49.99166040000001
-f596f5d3-4de7-4ab1-8403-e96fd6b8765c,Lahnsteiner,brewpub,1 Sandgasse,,,Lahnstein,Rheinland-Pfalz,56112,Germany,+49 2621 91740,http://www.lahnsteiner-brauerei.de,7.6079135,50.2990881
-9db4ce1b-8f01-424f-89c9-839c8d3f9825,Mahls Kleines Brauhaus,brewpub,16 Koblenzer Straße,,,Bacharach,Rheinland-Pfalz,55422,Germany,+49 6743 919179,http://www.rheintheater.de/html/bacchusbrau.html,7.768564100000001,50.0621514
-35e716a9-0d28-4f01-8d30-50bc99f05171,Mannebacher Brauhaus,brewpub,1 Hauptstraße,,,Mannebach,Rheinland-Pfalz,54441,Germany,+49 6581 99277,http://www.mannebacher.de,6.5085221,49.63354220000001
-9ad97617-1313-45d7-85aa-04f60b064e6e,Marienstatter Brauhaus,brewpub,1 Kloster,,,Streithausen,Rheinland-Pfalz,57629,Germany,+49 2662 9535300,http://www.abtei-marienstatt.de,7.799746499999999,50.6849861
-8091e6cf-a10d-48e0-b63d-e660297662ae,Maximilians Brauwiesen,brewpub,25 Didierstraße,,,Lahnstein,Rheinland-Pfalz,56112,Germany,+49 2621 926060,http://www.maximilians-brauwiesen.de,7.5927046,50.3209846
-a3b7f870-6dc6-45ad-8a62-78d678d0ead2,Mayer Bräu,brewpub,8 Schillerstraße,,,Ludwigshafen am Rhein,Rheinland-Pfalz,67071,Germany,+49 621 675083,http://www.mayerbraeu.de,8.3752328,49.4913831
-72b537f5-04be-4717-a5fe-151afed14f87,Merk's Scheunenbrauerei,closed,24 Hauptstraße,,,Otterbach,Rheinland-Pfalz,67731,Germany,,http://www.scheunenbrauerei.de,7.737792000000001,49.485161
-d66d2274-fb29-4864-82e6-1c89f9786e39,Munruffer Bierfabrik,brewpub,46 Hauptstraße,,,Mogendorf,Rheinland-Pfalz,56424,Germany,+49 1512 4071862,http://www.munruffer-bierfabrik.de,7.761430099999999,50.49482920000001
-49932d37-7c33-4c04-9b6f-ec6a167df8b4,Ottersheimer Bärenbräu,brewpub,35A Waldstraße,,,Ottersheim bei Landau,Rheinland-Pfalz,76879,Germany,+49 6348 7595,http://www.ottersheimer-baerenbraeu.de,8.22919,49.193964
-557d8bcd-6bf0-448a-8475-511eadbd7314,Park,brewpub,4 Zweibrücker Straße,,,Pirmasens,Rheinland-Pfalz,66953,Germany,+49 6331 8050,http://www.parkbrauerei.de,7.60427,49.20568
-22555e04-b794-426c-8c84-890103dcc097,Petrusbräu,brewpub,21 Windmühlenstraße,,,Trier,Rheinland-Pfalz,54290,Germany,+49 174 3239378,http://www.triererpetrusbraeu.de,6.6343035,49.7561967
-f864ec13-f060-4d91-83d7-74f0eda9d364,Pleiner Biermanufaktur,brewpub,3 Zum Waldschlößchen,,,Plein,Rheinland-Pfalz,54518,Germany,+49 6571 1740021,http://www.pleiner-biermanufaktur.de,6.8807578,50.032382
-1ae857e7-3dd2-4850-921e-34f1a08650de,Rheinhessen Bräu,brewpub,7 Reiterweg,,,Mainz,Rheinland-Pfalz,55129,Germany,+49 6136 763642,http://www.rheinhessen-braeu.de,8.2447682,49.9175301
-aaca73e7-11e0-419d-acd3-4f7cb62add88,Sander,brewpub,67 Weinsheimer Straße,,,Worms,Rheinland-Pfalz,67547,Germany,+49 6241 8545028,http://www.brauerei-sander.de,8.3429789,49.611809
-cc4f1fe5-f07a-4f7e-8049-c37ab5525929,Sickingen Bräu,micro,1 Burgweg,,,Landstuhl,Rheinland-Pfalz,66849,Germany,+49 6371 13460,http://www.sickingenbraeu.de,7.573582,49.40978699999999
-e0042e5f-805b-4118-b12b-a12d404f8961,Stadtbrauhaus Hermannbräu,closed,4 Stixwörthstraße,,,Hagenbach,Rheinland-Pfalz,76767,Germany,+49 7273 800765,http://www.stadtbrauhaus.de,8.258888899999999,49.00916669999999
-37d38c65-0849-4959-b8b2-bb14d62195fd,Stromberger Urbräu,brewpub,23b Deyertstraße,,,Schweppenhausen,Rheinland-Pfalz,55444,Germany,+49 1575 5315725,http://www.stromberger-urbraeu.de,7.7970333,49.9299264
-265d0844-0bee-4517-90f3-9eedbb839948,Stugge,brewpub,10 Zweibrücker Straße,,,Winterbach (Pfalz),Rheinland-Pfalz,66484,Germany,,http://www.stugge.de,7.469869699999999,49.3025013
-db6b78ee-d234-4c6d-98c5-c9f12c705399,Temmelser Braukeller 2018,brewpub,2 Kirchstraße,,,Temmels,Rheinland-Pfalz,54441,Germany,+49 1514 3203507,https://m.facebook.com/Temmelser/?locale2=de_DE,6.4625922,49.690649
-204ef187-4c38-4d0d-ae97-8dbbe845bc93,Unterhammer Bräu,brewpub,3 Unterhammer,,,Trippstadt,Rheinland-Pfalz,67705,Germany,+49 6306 701460,http://www.unterhammer.com,7.7398678,49.3609516
-493bbbf8-fe86-4649-9e2f-fa31bc31f53d,Vulkan,brewpub,2 Laacher-See-Straße,,,Mendig,Rheinland-Pfalz,56743,Germany,+49 2652 520330,http://www.vulkan-brauhaus.de,7.2823083,50.3775731
-a1763f8e-1838-4e17-afdc-003ecb7b97eb,Westerwald,brewpub,1 Am Hopfengarten,,,Hachenburg,Rheinland-Pfalz,57627,Germany,+49 2662 8080,http://www.hachenburger.de,7.8166273,50.6570489
-89cd4079-9d3c-4606-9208-f8a5fbe30fd7,Zils-Bräu,closed,1 Waldstraße,,,Naurath (Eifel),Rheinland-Pfalz,54340,Germany,+49 6508 91710,http://www.brauhaus-zils.de,6.7483765,49.880787
+f3f2c3f0-a54c-4c72-bc61-93d8a0416253,Hofstätter-Scheune-Bräu,closed,Ortsstraße 33,,,Wilgartswiesen,Rheinland-Pfalz,76848,Germany,+49 6397 360,http://www.zurscheune.de,7.858876199999998,49.2789763
+cbf311c9-810c-497a-91d5-8d9ffb716d38,Jäger Bräu,brewpub,Staatsstraße 18,,,Edenkoben,Rheinland-Pfalz,67480,Germany,+49 6323 937641,http://www.jägerbräu.de,8.140009899999999,49.2830429
+7e9357ff-d1d6-419f-8e7b-38a814eacd5d,Kirner,brewpub,Kallenfelser Straße 2,,,Kirn,Rheinland-Pfalz,55606,Germany,+49 6752 1340,http://www.kirner.de,7.457421099999999,49.7887716
+6dde99bc-67da-4674-8fe3-ae513e5433ce,Koblenzer,brewpub,An der Königsbach 10,,,Koblenz,Rheinland-Pfalz,56075,Germany,,http://www.koblenzer-brauerei.de,7.5867422,50.3233019
+767be5e2-9fb4-4a8f-9457-496d1ec56922,Kraft-Bräu,brewpub,Olewiger Straße 135,,,Trier,Rheinland-Pfalz,54295,Germany,+49 651 36060,http://www.blesius-garten.de,6.659902799999999,49.74323760000001
+2289fc38-47ac-4ed5-b0fb-9c72d48a0b7c,Kuchems Brauhaus,brewpub,Schlossstraße 44,,,Pirmasens,Rheinland-Pfalz,66953,Germany,+49 6331 213894,http://www.kuchems-brauhaus.de,7.6054792,49.2004801
+ac7584c0-30a9-4850-a7e3-e26fae6770f7,Kuehn Kunz Rosen,brewpub,Weisenauer Straße 15,,,Mainz,Rheinland-Pfalz,55131,Germany,+49 6131 2116101,http://www.kuehnkunzrosen.de,8.2859641,49.99166040000001
+f596f5d3-4de7-4ab1-8403-e96fd6b8765c,Lahnsteiner,brewpub,Sandgasse 1,,,Lahnstein,Rheinland-Pfalz,56112,Germany,+49 2621 91740,http://www.lahnsteiner-brauerei.de,7.6079135,50.2990881
+9db4ce1b-8f01-424f-89c9-839c8d3f9825,Mahls Kleines Brauhaus,brewpub,Koblenzer Straße 16,,,Bacharach,Rheinland-Pfalz,55422,Germany,+49 6743 919179,http://www.rheintheater.de/html/bacchusbrau.html,7.768564100000001,50.0621514
+35e716a9-0d28-4f01-8d30-50bc99f05171,Mannebacher Brauhaus,brewpub,Hauptstraße 1,,,Mannebach,Rheinland-Pfalz,54441,Germany,+49 6581 99277,http://www.mannebacher.de,6.5085221,49.63354220000001
+9ad97617-1313-45d7-85aa-04f60b064e6e,Marienstatter Brauhaus,brewpub,Kloster 1,,,Streithausen,Rheinland-Pfalz,57629,Germany,+49 2662 9535300,http://www.abtei-marienstatt.de,7.799746499999999,50.6849861
+8091e6cf-a10d-48e0-b63d-e660297662ae,Maximilians Brauwiesen,brewpub,Didierstraße 25,,,Lahnstein,Rheinland-Pfalz,56112,Germany,+49 2621 926060,http://www.maximilians-brauwiesen.de,7.5927046,50.3209846
+a3b7f870-6dc6-45ad-8a62-78d678d0ead2,Mayer Bräu,brewpub,Schillerstraße 8,,,Ludwigshafen am Rhein,Rheinland-Pfalz,67071,Germany,+49 621 675083,http://www.mayerbraeu.de,8.3752328,49.4913831
+72b537f5-04be-4717-a5fe-151afed14f87,Merk's Scheunenbrauerei,closed,Hauptstraße 24,,,Otterbach,Rheinland-Pfalz,67731,Germany,,http://www.scheunenbrauerei.de,7.737792000000001,49.485161
+d66d2274-fb29-4864-82e6-1c89f9786e39,Munruffer Bierfabrik,brewpub,Hauptstraße 46,,,Mogendorf,Rheinland-Pfalz,56424,Germany,+49 1512 4071862,http://www.munruffer-bierfabrik.de,7.761430099999999,50.49482920000001
+49932d37-7c33-4c04-9b6f-ec6a167df8b4,Ottersheimer Bärenbräu,brewpub,Waldstraße 35A,,,Ottersheim bei Landau,Rheinland-Pfalz,76879,Germany,+49 6348 7595,http://www.ottersheimer-baerenbraeu.de,8.22919,49.193964
+557d8bcd-6bf0-448a-8475-511eadbd7314,Park,brewpub,Zweibrücker Straße 4,,,Pirmasens,Rheinland-Pfalz,66953,Germany,+49 6331 8050,http://www.parkbrauerei.de,7.60427,49.20568
+22555e04-b794-426c-8c84-890103dcc097,Petrusbräu,brewpub,Windmühlenstraße 21,,,Trier,Rheinland-Pfalz,54290,Germany,+49 174 3239378,http://www.triererpetrusbraeu.de,6.6343035,49.7561967
+f864ec13-f060-4d91-83d7-74f0eda9d364,Pleiner Biermanufaktur,brewpub,Zum Waldschlößchen 3,,,Plein,Rheinland-Pfalz,54518,Germany,+49 6571 1740021,http://www.pleiner-biermanufaktur.de,6.8807578,50.032382
+1ae857e7-3dd2-4850-921e-34f1a08650de,Rheinhessen Bräu,brewpub,Reiterweg 7,,,Mainz,Rheinland-Pfalz,55129,Germany,+49 6136 763642,http://www.rheinhessen-braeu.de,8.2447682,49.9175301
+aaca73e7-11e0-419d-acd3-4f7cb62add88,Sander,brewpub,Weinsheimer Straße 67,,,Worms,Rheinland-Pfalz,67547,Germany,+49 6241 8545028,http://www.brauerei-sander.de,8.3429789,49.611809
+cc4f1fe5-f07a-4f7e-8049-c37ab5525929,Sickingen Bräu,micro,Burgweg 1,,,Landstuhl,Rheinland-Pfalz,66849,Germany,+49 6371 13460,http://www.sickingenbraeu.de,7.573582,49.40978699999999
+e0042e5f-805b-4118-b12b-a12d404f8961,Stadtbrauhaus Hermannbräu,closed,Stixwörthstraße 4,,,Hagenbach,Rheinland-Pfalz,76767,Germany,+49 7273 800765,http://www.stadtbrauhaus.de,8.258888899999999,49.00916669999999
+37d38c65-0849-4959-b8b2-bb14d62195fd,Stromberger Urbräu,brewpub,Deyertstraße 23b,,,Schweppenhausen,Rheinland-Pfalz,55444,Germany,+49 1575 5315725,http://www.stromberger-urbraeu.de,7.7970333,49.9299264
+265d0844-0bee-4517-90f3-9eedbb839948,Stugge,brewpub,Zweibrücker Straße 10,,,Winterbach (Pfalz),Rheinland-Pfalz,66484,Germany,,http://www.stugge.de,7.469869699999999,49.3025013
+db6b78ee-d234-4c6d-98c5-c9f12c705399,Temmelser Braukeller 2018,brewpub,Kirchstraße 2,,,Temmels,Rheinland-Pfalz,54441,Germany,+49 1514 3203507,https://m.facebook.com/Temmelser/?locale2=de_DE,6.4625922,49.690649
+204ef187-4c38-4d0d-ae97-8dbbe845bc93,Unterhammer Bräu,brewpub,Unterhammer 3,,,Trippstadt,Rheinland-Pfalz,67705,Germany,+49 6306 701460,http://www.unterhammer.com,7.7398678,49.3609516
+493bbbf8-fe86-4649-9e2f-fa31bc31f53d,Vulkan,brewpub,Laacher-See-Straße 2,,,Mendig,Rheinland-Pfalz,56743,Germany,+49 2652 520330,http://www.vulkan-brauhaus.de,7.2823083,50.3775731
+a1763f8e-1838-4e17-afdc-003ecb7b97eb,Westerwald,brewpub,Am Hopfengarten 1,,,Hachenburg,Rheinland-Pfalz,57627,Germany,+49 2662 8080,http://www.hachenburger.de,7.8166273,50.6570489
+89cd4079-9d3c-4606-9208-f8a5fbe30fd7,Zils-Bräu,closed,Waldstraße 1,,,Naurath (Eifel),Rheinland-Pfalz,54340,Germany,+49 6508 91710,http://www.brauhaus-zils.de,6.7483765,49.880787

--- a/data/germany/rheinland-pfalz.csv
+++ b/data/germany/rheinland-pfalz.csv
@@ -7,7 +7,7 @@ id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_co
 efbc4c79-d23e-4cc5-877f-e1c1922a7649,Bischoff,closed,6 An den Hopfengärten,,,Winnweiler,Rheinland-Pfalz,67722,Germany,+49 6302 9120,http://www.bischoff-bier.de,7.858153600000001,49.5720399
 aa1c1b26-722e-42d7-9d2d-74c0eca0a110,Bitburger,brewpub,3 Römermauer,,,Bitburg,Rheinland-Pfalz,54634,Germany,+49 6561 142497,http://www.bitburger.de,6.5223335,49.9744776
 81f66e31-e29e-423b-be6c-4270ac528313,BrauArt,brewpub,2-4 Angelgasse,,,Grünstadt,Rheinland-Pfalz,67269,Germany,+49 170 1697666,http://www.brau-art.com,8.15935,49.54849
-cd17edb8-b0d7-45af-b5f1-812737bcc315,Brauerei Schnorres,micro,Hauptstrasse 28,,,Mehlingen,Rheinland-Pfalz,67678,Germany,,http://www.schnorres.net,,
+cd17edb8-b0d7-45af-b5f1-812737bcc315,Brauerei Schnorres,micro,Hauptstraße 28,,,Mehlingen,Rheinland-Pfalz,67678,Germany,,http://www.schnorres.net,,
 92c70439-3435-4d7b-b3a2-ebe570015a1f,Brauhaus am Markt,brewpub,2 Stiftsplatz,,,Kaiserslautern,Rheinland-Pfalz,67655,Germany,+49 631 61944,http://www.brauhaus-am-markt.com,7.771735499999998,49.4447742
 fc2a2892-0ae7-418d-891c-8fbca075c821,Brauhaus am Turm,brewpub,1 Schlossstraße,,,Kirchheimbolanden,Rheinland-Pfalz,67292,Germany,+49 6352 3841,http://www.brauhaus-am-turm.de,8.0109962,49.6642482
 5822d6c5-e10d-4bb3-bcf7-d20893d5ec58,Brauhaus Ehrstein,brewpub,3 Im Handschuhteich,,,Hinterweidenthal,Rheinland-Pfalz,66999,Germany,+49 6396 1680000,http://www.brauhaus-ehrstein.de,7.749108399999999,49.1965741

--- a/data/germany/saarland.csv
+++ b/data/germany/saarland.csv
@@ -1,15 +1,15 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-c3c59882-de79-4ffe-9239-a08b9b49b53b,Bachs Braumanufaktur,brewpub,69 b Wellesweilerstraße,,,Neunkirchen,Saarland,66538,Germany,,http://www.bachs-braumanufaktur.de,7.191335,49.3518041
-c47d94e9-57df-44ad-a218-e3f285a39550,Bruch,brewpub,14 Saarbrücker Straße,,,Neunkirchen,Saarland,66538,Germany,,http://www.brauerei-bruch.de,7.1705762,49.34746879999999
-9647957d-4b7a-4f8e-821e-062d9c0b9833,Flammings Flammbräu,brewpub,63 Im Almet,,,Saarbrücken,Saarland,66119,Germany,+49 681 8579266,http://www.flammings-flammbraeu.de,6.994789399999999,49.20862959999999
-a2bdf151-9f3c-401d-804a-ffbf426dcf69,Grosswald,brewpub,130 Großwaldstraße,,,Heusweiler,Saarland,66265,Germany,+49 6806 6070,http://www.grosswald.de,6.947559999999999,49.37266
-0025ae6e-aef7-4de6-ac5f-304d74540dcd,Herz & Heimat,brewpub,5 Kahlenbergstraße,,,Sankt Ingbert,Saarland,66386,Germany,+49 177 6278680,http://www.herzundheimat.com,7.150965299999999,49.2764883
-e48eb13b-3509-40a8-ac30-8c2b4c0d8c61,Hochwälder Brauhaus,brewpub,190 Zum Stausee,,,Losheim am See,Saarland,66679,Germany,+49 6872 505772,http://www.hochwaelder-brauhaus.de,6.7412845,49.5194312
-d7d009b4-3e3e-4915-8baa-cd89c442215d,Homburger Brauhaus,brewpub,38d Talstraße,,,Homburg,Saarland,66424,Germany,+49 6841 2466,http://www.homburger-brauhaus.de,7.337546199999999,49.3213371
-a41677d5-6f1d-4557-8b13-b9d06bbac4f5,Karlsberg,brewpub,62 Karlsbergstraße,,,Homburg,Saarland,66424,Germany,+49 6841 1050,http://www.karlsberg.de,7.3453085,49.32446820000001
-eb45c496-e216-4533-871b-2db0bcc865b6,Körpricher Landbräu,closed,40 Bahnhofstraße,,,Nalbach,Saarland,66809,Germany,+49 6838 1447,http://www.landbrauerei.de,6.832735,49.38936400000001
-305cbfb2-ac1e-4f43-9b9b-f354b4943bdb,Mettlacher Abtei-Bräu,brewpub,32 Bahnhofstraße,,,Mettlach,Saarland,66693,Germany,+49 6864 93232,http://www.abtei-brauerei.de,6.5962272,49.4976947
-81405c0c-b872-49b5-95d8-31da1f4ecd18,Saarfürst Merziger Brauhaus,brewpub,6 Saarwiesenring,,,Merzig,Saarland,66663,Germany,+49 6861 791635,http://www.saarfuerst.de,6.6280015,49.443243
-c509c550-8730-4de6-9726-8c3fec3fd655,Schmelzer Brauhaus,brewpub,12 Am Erzweg,,,Schmelz,Saarland,66839,Germany,+49 6887 889109,http://www.schmelzer-brauhaus.de,6.8729327,49.4400479
-87b93747-6f37-4e3a-86bc-75f8a9328b0d,Stiefel Bräu,brewpub,2 Am Stiefel,,,Saarbrücken,Saarland,66111,Germany,+49 681 30984650,http://www.stiefelgastronomie.de/frameset_stiefelbraeu.htm,6.995145399999999,49.2329003
-17622d37-d142-4fd6-bdfc-dee5da7efbf5,Stumm's Brauhaus,brewpub,16 Saarbrücker Straße,,,Neunkirchen,Saarland,66538,Germany,+49 6821 179145,http://www.stumms-brauhaus.de,7.172285199999998,49.3476947
+c3c59882-de79-4ffe-9239-a08b9b49b53b,Bachs Braumanufaktur,brewpub,b Wellesweilerstraße 69,,,Neunkirchen,Saarland,66538,Germany,,http://www.bachs-braumanufaktur.de,7.191335,49.3518041
+c47d94e9-57df-44ad-a218-e3f285a39550,Bruch,brewpub,Saarbrücker Straße 14,,,Neunkirchen,Saarland,66538,Germany,,http://www.brauerei-bruch.de,7.1705762,49.34746879999999
+9647957d-4b7a-4f8e-821e-062d9c0b9833,Flammings Flammbräu,brewpub,Im Almet 63,,,Saarbrücken,Saarland,66119,Germany,+49 681 8579266,http://www.flammings-flammbraeu.de,6.994789399999999,49.20862959999999
+a2bdf151-9f3c-401d-804a-ffbf426dcf69,Grosswald,brewpub,Großwaldstraße 130,,,Heusweiler,Saarland,66265,Germany,+49 6806 6070,http://www.grosswald.de,6.947559999999999,49.37266
+0025ae6e-aef7-4de6-ac5f-304d74540dcd,Herz & Heimat,brewpub,Kahlenbergstraße 5,,,Sankt Ingbert,Saarland,66386,Germany,+49 177 6278680,http://www.herzundheimat.com,7.150965299999999,49.2764883
+e48eb13b-3509-40a8-ac30-8c2b4c0d8c61,Hochwälder Brauhaus,brewpub,Zum Stausee 190,,,Losheim am See,Saarland,66679,Germany,+49 6872 505772,http://www.hochwaelder-brauhaus.de,6.7412845,49.5194312
+d7d009b4-3e3e-4915-8baa-cd89c442215d,Homburger Brauhaus,brewpub,Talstraße 38d,,,Homburg,Saarland,66424,Germany,+49 6841 2466,http://www.homburger-brauhaus.de,7.337546199999999,49.3213371
+a41677d5-6f1d-4557-8b13-b9d06bbac4f5,Karlsberg,brewpub,Karlsbergstraße 62,,,Homburg,Saarland,66424,Germany,+49 6841 1050,http://www.karlsberg.de,7.3453085,49.32446820000001
+eb45c496-e216-4533-871b-2db0bcc865b6,Körpricher Landbräu,closed,Bahnhofstraße 40,,,Nalbach,Saarland,66809,Germany,+49 6838 1447,http://www.landbrauerei.de,6.832735,49.38936400000001
+305cbfb2-ac1e-4f43-9b9b-f354b4943bdb,Mettlacher Abtei-Bräu,brewpub,Bahnhofstraße 32,,,Mettlach,Saarland,66693,Germany,+49 6864 93232,http://www.abtei-brauerei.de,6.5962272,49.4976947
+81405c0c-b872-49b5-95d8-31da1f4ecd18,Saarfürst Merziger Brauhaus,brewpub,Saarwiesenring 6,,,Merzig,Saarland,66663,Germany,+49 6861 791635,http://www.saarfuerst.de,6.6280015,49.443243
+c509c550-8730-4de6-9726-8c3fec3fd655,Schmelzer Brauhaus,brewpub,Am Erzweg 12,,,Schmelz,Saarland,66839,Germany,+49 6887 889109,http://www.schmelzer-brauhaus.de,6.8729327,49.4400479
+87b93747-6f37-4e3a-86bc-75f8a9328b0d,Stiefel Bräu,brewpub,Am Stiefel 2,,,Saarbrücken,Saarland,66111,Germany,+49 681 30984650,http://www.stiefelgastronomie.de/frameset_stiefelbraeu.htm,6.995145399999999,49.2329003
+17622d37-d142-4fd6-bdfc-dee5da7efbf5,Stumm's Brauhaus,brewpub,Saarbrücker Straße 16,,,Neunkirchen,Saarland,66538,Germany,+49 6821 179145,http://www.stumms-brauhaus.de,7.172285199999998,49.3476947

--- a/data/germany/sachsen-anhalt.csv
+++ b/data/germany/sachsen-anhalt.csv
@@ -1,26 +1,26 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-8f2bb98b-273e-4dd1-8c47-aab114743994,Bitterfelder,brewpub,5 Hinter dem Bahnhof,,,Bitterfeld-Wolfen,Sachsen-Anhalt,06749,Germany,+49 3493 515990,http://www.bitterfelder-bier.de,12.3141718,51.6256401
-ecc50b17-1093-4d02-9dfd-9296f3ac524e,Böhlke,closed,5 Kamp,,,Hötensleben,Sachsen-Anhalt,39393,Germany,+49 39401 51491,,11.0220256,52.0701186
-81d73244-2daa-44dc-a0d3-4955b746794d,Brauhaus Wittenberg,brewpub,6 Markt,,,Wittenberg,Sachsen-Anhalt,06886,Germany,+49 3491 433130,http://www.brauhaus-wittenberg.de,12.6439,51.86597
-4bfa0fe0-e5d6-4440-a175-5076e8faedd2,Brauhaus zu Röglitz,closed,40d Röglitzer Hauptstraße,,,Schkopau,Sachsen-Anhalt,06258,Germany,+49 34605 21462,http://www.brauhaus-zu-roeglitz.de,12.1249217,51.39994429999999
-d207794a-899d-404b-872a-2c830aaa9890,Brewckau,brewpub,16 Schönebecker Straße,,,Magdeburg,Sachsen-Anhalt,39104,Germany,+49 391 40821949,http://www.facebook.com/Brewckau/,11.6387275,52.1092812
-bc3bf190-bc97-4fab-9407-6e2155d73602,Burgbräu,brewpub,1 Im Gewerbepark,,,Gommern,Sachsen-Anhalt,39245,Germany,+49 391 99032710,http://www.wasserburg-zu-gommern.com,11.8123521,52.08189369999999
-8b6f8a3b-95c9-4418-b7e6-147b5d572231,Colbitzer Heidebrauerei,brewpub,1 Brauereistraße,,,Colbitz,Sachsen-Anhalt,39326,Germany,+49 39207 880,http://www.colbitzer-heidebrauerei.de,11.6105642,52.3166129
-92786876-d7ee-4c48-8b5c-1b94be1946b4,Diamant Brauhaus,closed,127 Lübecker Straße,,,Magdeburg,Sachsen-Anhalt,39124,Germany,+49 391 5556254,http://diamant-brauhaus.de,11.6403856,52.15139139999999
-3a0678e1-bf58-40d6-82d4-570eedae18ff,Dorfkrug,brewpub,3 Hauptstraße,,,Oschersleben (Bode),Sachsen-Anhalt,39387,Germany,+49 3949 501535,http://neindorfer-krug.de/,11.1911303,52.0640691
-d8787517-6e8f-47b1-aa87-1eb16d7db19a,ElbBrauerei Frohse,micro,12 August-Bebel-Straße,,,Schollene,Sachsen-Anhalt,14715,Germany,+49 39389 969960,https://www.elbe-havel-brauerei.de/,12.2191686,52.6767616
-6c14b075-9235-4901-9967-1e1be44c2502,Hallesches Brauhaus,brewpub,2 Große Nikolaistraße,,,Halle (Saale),Sachsen-Anhalt,06108,Germany,+49 345 212570,http://www.brauhaushalle.de,11.9685041,51.4838299
-6013930b-4383-45ff-9e28-bc85d362d82e,Hasseröder,brewpub,1 Auerhahnring,,,Wernigerode,Sachsen-Anhalt,38855,Germany,+49 421 14621000,http://www.hasseroeder.de,10.7535147,51.8440479
-61c9224e-26a0-4c3f-9ea1-88f74af2c5ff,Heine Bräu,brewpub,20 Große Ringstraße,,,Halberstadt,Sachsen-Anhalt,38820,Germany,+49 3941 31800,http://www.hotel-heine.de,11.0744364,51.8967254
-f30c5e40-952b-474c-bf3f-2e4fca81df6e,Köthener Brauhaus,brewpub,1 Lachsfang,,,Köthen (Anhalt),Sachsen-Anhalt,06366,Germany,+49 3496 3099490,http://www.brauhauskoethen.de,11.9764046,51.752007
-fd45aa55-6b73-4c59-89df-5c03ec8ae2d3,Landsberger,brewpub,33 Bahnhofstraße,,,Landsberg,Sachsen-Anhalt,06188,Germany,+49 34602 40333,http://www.landsberger.de,12.1622736,51.5288927
-a1868876-1d78-41f5-96fd-e4c341d4530b,Lorenzhof,micro,13 Poststraße,,,Ausleben,Sachsen-Anhalt,39393,Germany,+49 173 3959971,http://www.facebook.com/Lorenzhof/,11.1180648,52.0985848
-9c4bac65-c291-4fa4-ad05-6f37fe3ce3ea,Lüdde,brewpub,14 Blasiistraße,,,Quedlinburg,Sachsen-Anhalt,06484,Germany,+49 3946 705206,http://www.hotel-brauhaus-luedde.de,11.138966,51.788458
-cd684ce0-24d6-4405-9b9c-9ae588fb8a69,Magdeburger Privatbrauerei,brewpub,16 Schönebecker Straße,,,Magdeburg,Sachsen-Anhalt,39104,Germany,+49 391 40821949,http://www.facebook.com/Magdeburger-Privatbrauerei-245943372909573/?ref=page_internal,11.6387275,52.1092812
-05b73694-bd1b-4330-a269-b6d1918479da,Ratskeller Naumburg,brewpub,1 Markt,,,Naumburg (Saale),Sachsen-Anhalt,06618,Germany,+49 3445 7793034,http://www.ratskeller-brauhaus.de,11.8094119,51.1525346
-f63145bd-ad70-4937-8cf0-f966493d1458,Rothenschirmbach Brauhaus am Landmarkt,closed,24 Gewerbegebiet Rothenschirmbach,,,Eisleben,Sachsen-Anhalt,06295,Germany,+49 34776 917593,http://www.landmarkt-rothenschirmbach.de,11.5432888,51.4527659
-95043e78-6dd5-4b3e-aee0-ba4c30366de6,Schulzens Hofbräu,brewpub,34 Lange Straße,,,Tangermünde,Sachsen-Anhalt,39590,Germany,+49 39322 44145,http://www.schulzens.info/,11.9752561,52.5432454
-3069e28a-07f6-4e11-bd1a-cd39aa75fb17,Spezialitätenbrauerei Eckart,brewpub,1 Brauereistraße,,,Colbitz,Sachsen-Anhalt,39326,Germany,+49 39207 880,http://www.brauerei-eckart.de,11.6105642,52.3166129
-b4e4b5ad-bc90-4707-8eeb-767cf931bb6d,Sudenburger Brauhaus,brewpub,94 Brenneckestraße,,,Magdeburg,Sachsen-Anhalt,39118,Germany,+49 391 620922410,http://www.sudenburger-brauhaus.de,11.5941462,52.1042715
-2a8cc2a2-aa58-4c51-be75-475db9cd73df,Unseburger Brauhaus,brewpub,16 Breite Straße,,,Bördeaue,Sachsen-Anhalt,39435,Germany,+49 39263 90420,http://www.unseburger-brauhaus.de,11.5131181,51.9318041
-4d68a980-6b91-46e7-bcfe-47ff49584680,Zum Alten Dessauer,brewpub,16 Lange Gasse,,,Dessau-Roßlau,Sachsen-Anhalt,06844,Germany,+49 340 2205909,http://www.alter-dessauer.de,12.2458972,51.835418
+8f2bb98b-273e-4dd1-8c47-aab114743994,Bitterfelder,brewpub,Hinter dem Bahnhof 5,,,Bitterfeld-Wolfen,Sachsen-Anhalt,06749,Germany,+49 3493 515990,http://www.bitterfelder-bier.de,12.3141718,51.6256401
+ecc50b17-1093-4d02-9dfd-9296f3ac524e,Böhlke,closed,Kamp 5,,,Hötensleben,Sachsen-Anhalt,39393,Germany,+49 39401 51491,,11.0220256,52.0701186
+81d73244-2daa-44dc-a0d3-4955b746794d,Brauhaus Wittenberg,brewpub,Markt 6,,,Wittenberg,Sachsen-Anhalt,06886,Germany,+49 3491 433130,http://www.brauhaus-wittenberg.de,12.6439,51.86597
+4bfa0fe0-e5d6-4440-a175-5076e8faedd2,Brauhaus zu Röglitz,closed,Röglitzer Hauptstraße 40d,,,Schkopau,Sachsen-Anhalt,06258,Germany,+49 34605 21462,http://www.brauhaus-zu-roeglitz.de,12.1249217,51.39994429999999
+d207794a-899d-404b-872a-2c830aaa9890,Brewckau,brewpub,Schönebecker Straße 16,,,Magdeburg,Sachsen-Anhalt,39104,Germany,+49 391 40821949,http://www.facebook.com/Brewckau/,11.6387275,52.1092812
+bc3bf190-bc97-4fab-9407-6e2155d73602,Burgbräu,brewpub,Im Gewerbepark 1,,,Gommern,Sachsen-Anhalt,39245,Germany,+49 391 99032710,http://www.wasserburg-zu-gommern.com,11.8123521,52.08189369999999
+8b6f8a3b-95c9-4418-b7e6-147b5d572231,Colbitzer Heidebrauerei,brewpub,Brauereistraße 1,,,Colbitz,Sachsen-Anhalt,39326,Germany,+49 39207 880,http://www.colbitzer-heidebrauerei.de,11.6105642,52.3166129
+92786876-d7ee-4c48-8b5c-1b94be1946b4,Diamant Brauhaus,closed,Lübecker Straße 127,,,Magdeburg,Sachsen-Anhalt,39124,Germany,+49 391 5556254,http://diamant-brauhaus.de,11.6403856,52.15139139999999
+3a0678e1-bf58-40d6-82d4-570eedae18ff,Dorfkrug,brewpub,Hauptstraße 3,,,Oschersleben (Bode),Sachsen-Anhalt,39387,Germany,+49 3949 501535,http://neindorfer-krug.de/,11.1911303,52.0640691
+d8787517-6e8f-47b1-aa87-1eb16d7db19a,ElbBrauerei Frohse,micro,August-Bebel-Straße 12,,,Schollene,Sachsen-Anhalt,14715,Germany,+49 39389 969960,https://www.elbe-havel-brauerei.de/,12.2191686,52.6767616
+6c14b075-9235-4901-9967-1e1be44c2502,Hallesches Brauhaus,brewpub,Große Nikolaistraße 2,,,Halle (Saale),Sachsen-Anhalt,06108,Germany,+49 345 212570,http://www.brauhaushalle.de,11.9685041,51.4838299
+6013930b-4383-45ff-9e28-bc85d362d82e,Hasseröder,brewpub,Auerhahnring 1,,,Wernigerode,Sachsen-Anhalt,38855,Germany,+49 421 14621000,http://www.hasseroeder.de,10.7535147,51.8440479
+61c9224e-26a0-4c3f-9ea1-88f74af2c5ff,Heine Bräu,brewpub,Große Ringstraße 20,,,Halberstadt,Sachsen-Anhalt,38820,Germany,+49 3941 31800,http://www.hotel-heine.de,11.0744364,51.8967254
+f30c5e40-952b-474c-bf3f-2e4fca81df6e,Köthener Brauhaus,brewpub,Lachsfang 1,,,Köthen (Anhalt),Sachsen-Anhalt,06366,Germany,+49 3496 3099490,http://www.brauhauskoethen.de,11.9764046,51.752007
+fd45aa55-6b73-4c59-89df-5c03ec8ae2d3,Landsberger,brewpub,Bahnhofstraße 33,,,Landsberg,Sachsen-Anhalt,06188,Germany,+49 34602 40333,http://www.landsberger.de,12.1622736,51.5288927
+a1868876-1d78-41f5-96fd-e4c341d4530b,Lorenzhof,micro,Poststraße 13,,,Ausleben,Sachsen-Anhalt,39393,Germany,+49 173 3959971,http://www.facebook.com/Lorenzhof/,11.1180648,52.0985848
+9c4bac65-c291-4fa4-ad05-6f37fe3ce3ea,Lüdde,brewpub,Blasiistraße 14,,,Quedlinburg,Sachsen-Anhalt,06484,Germany,+49 3946 705206,http://www.hotel-brauhaus-luedde.de,11.138966,51.788458
+cd684ce0-24d6-4405-9b9c-9ae588fb8a69,Magdeburger Privatbrauerei,brewpub,Schönebecker Straße 16,,,Magdeburg,Sachsen-Anhalt,39104,Germany,+49 391 40821949,http://www.facebook.com/Magdeburger-Privatbrauerei-245943372909573/?ref=page_internal,11.6387275,52.1092812
+05b73694-bd1b-4330-a269-b6d1918479da,Ratskeller Naumburg,brewpub,Markt 1,,,Naumburg (Saale),Sachsen-Anhalt,06618,Germany,+49 3445 7793034,http://www.ratskeller-brauhaus.de,11.8094119,51.1525346
+f63145bd-ad70-4937-8cf0-f966493d1458,Rothenschirmbach Brauhaus am Landmarkt,closed,Gewerbegebiet Rothenschirmbach 24,,,Eisleben,Sachsen-Anhalt,06295,Germany,+49 34776 917593,http://www.landmarkt-rothenschirmbach.de,11.5432888,51.4527659
+95043e78-6dd5-4b3e-aee0-ba4c30366de6,Schulzens Hofbräu,brewpub,Lange Straße 34,,,Tangermünde,Sachsen-Anhalt,39590,Germany,+49 39322 44145,http://www.schulzens.info/,11.9752561,52.5432454
+3069e28a-07f6-4e11-bd1a-cd39aa75fb17,Spezialitätenbrauerei Eckart,brewpub,Brauereistraße 1,,,Colbitz,Sachsen-Anhalt,39326,Germany,+49 39207 880,http://www.brauerei-eckart.de,11.6105642,52.3166129
+b4e4b5ad-bc90-4707-8eeb-767cf931bb6d,Sudenburger Brauhaus,brewpub,Brenneckestraße 94,,,Magdeburg,Sachsen-Anhalt,39118,Germany,+49 391 620922410,http://www.sudenburger-brauhaus.de,11.5941462,52.1042715
+2a8cc2a2-aa58-4c51-be75-475db9cd73df,Unseburger Brauhaus,brewpub,Breite Straße 16,,,Bördeaue,Sachsen-Anhalt,39435,Germany,+49 39263 90420,http://www.unseburger-brauhaus.de,11.5131181,51.9318041
+4d68a980-6b91-46e7-bcfe-47ff49584680,Zum Alten Dessauer,brewpub,Lange Gasse 16,,,Dessau-Roßlau,Sachsen-Anhalt,06844,Germany,+49 340 2205909,http://www.alter-dessauer.de,12.2458972,51.835418

--- a/data/germany/sachsen.csv
+++ b/data/germany/sachsen.csv
@@ -1,68 +1,68 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-444584ea-a619-4144-9b6a-b71b33ad2447,Alter Elbehof,brewpub,12 Werdau,,,Torgau,Sachsen,04860,Germany,+49 3421 904525,http://www.elbehof.eu,13.0336437,51.5527191
-2685a1c6-3058-4983-a713-0b3d79d2b75e,Bautzener Brauhaus,closed,7 Thomas-Mann-Straße,,,Bautzen,Sachsen,02625,Germany,+49 3591 491456,http://www.bautzener-brauhaus.de,14.4396638,51.1798022
-0b6ba94e-ab5c-4714-9a68-f92027cef3a3,Bergquell,brewpub,7 Weststraße,,,Löbau,Sachsen,02708,Germany,+49 3585 47470,http://www.bergquell-loebau.de,14.6596143,51.108704
-f007364e-036a-4d4f-abed-400788920817,Bergschlösschen,brewpub,25 Cunnersdorfer Straße,,,Dresden,Sachsen,01189,Germany,+49 351 40830,http://www.missionshof-lieske.de,13.707629,51.0159028
-48e2f92a-744b-4c7b-8b02-30a784d4da3e,Bierblume,closed,8 Neißstraße,,,Görlitz,Sachsen,02826,Germany,+49 3581 6673313,http://www.bierblume-goerlitz.de/,14.9928298,51.1572274
-86dc9da0-8c8a-4f8b-bf48-efa70cd5a978,Bierbrauhaus,closed,3 Großdöbschützer Straße,,,Obergurig,Sachsen,02692,Germany,+49 35938 57684,http://www.bierbrauhaus.de,14.4177034,51.1267916
-df527867-05b0-4b1c-b014-fe3eef2676ce,Bierfabrik Erzgebirge,brewpub,6 Bahnhofstraße,,,Pockau-Lengefeld,Sachsen,09514,Germany,+49 172 9598266,http://www.bierfabrik-erzgebirge.de,13.1923206,50.74187939999999
-d53f051e-de72-40a1-b75e-642429eb342a,Blechschmidt,brewpub,33 Straße der Jugend,,,Treuen,Sachsen,08233,Germany,+49 37468 2867,,12.31428,50.54056
-8de3de11-bd87-476d-9fd9-8c3bfa6bc3a7,Böhmisch Brauhaus,brewpub,9 Neueibauer Straße,,,Kottmar,Sachsen,02739,Germany,+49 3586 78140,http://www.boehmisch-brauhaus.de,14.6643599,50.97774889999999
-ead15508-e7b7-4e5e-8b08-ecf5cb721725,Brauhaus Napoleon,brewpub,233 Prager Straße,,,Leipzig,Sachsen,04289,Germany,+49 341 2467676,http://www.brauhaus-leipzig.com,12.4229895,51.306769
-3b713aa7-b03c-4931-a214-dccd8f2bf7bf,Brauhaus Pirna,brewpub,60b Basteistraße,,,Pirna,Sachsen,01796,Germany,+49 3501 464646,http://www.brauhaus-pirna.de,13.9429966,50.979966
-76688eae-2a3f-428c-bbec-ef20ec54808c,Brauhaus Radebeul,brewpub,8 Nach der Schiffsmühle,,,Radebeul,Sachsen,01445,Germany,+49 351 89516933,http://www.brauhaus-radebeul.de,13.5925459,51.1202543
-8f5d7f06-a66b-430d-8250-a95cd022c10c,Brauhaus Schmilka,brewpub,36 Schmilka,,,Bad Schandau,Sachsen,01814,Germany,,http://www.brauerei-schmilka.de,14.2319154,50.8921866
-1fa231e9-36e1-4330-a00c-b3e4abcf616d,Brauhaus Weltenbummler,closed,6 Sebastian-Kneipp-Straße,,,Bad Gottleuba-Berggießhübel,Sachsen,01816,Germany,,http://www.brauhaus-weltenbummler.de,13.9458144,50.873326
-1192010e-54ff-4ff1-9855-47062d8c6961,Brauhaus Zwickau,closed,12-20 Peter-Breuer-Straße,,,Zwickau,Sachsen,08056,Germany,+49 375 3032032,http://www.brauhaus-zwickau.de,12.4944446,50.7171153
-18ba9957-7aff-40ae-a4e9-69bb843a5dfd,Braumanufaktur Radebeul,brewpub,30 Straße des Friedens,,,Radebeul,Sachsen,01445,Germany,+49 1575 1369488,http://www.braumanufaktur-radebeul.de,13.6613536,51.1002708
-3c40b08e-3800-4435-87a5-da4596f4568e,Braun Mühle,brewpub,55 Dörnthal,,,Olbernhau,Sachsen,09526,Germany,+49 37360 6250,http://www.braun-muehle-doernthal.de,13.3336061,50.7344367
+444584ea-a619-4144-9b6a-b71b33ad2447,Alter Elbehof,brewpub,Werdau 12,,,Torgau,Sachsen,04860,Germany,+49 3421 904525,http://www.elbehof.eu,13.0336437,51.5527191
+2685a1c6-3058-4983-a713-0b3d79d2b75e,Bautzener Brauhaus,closed,Thomas-Mann-Straße 7,,,Bautzen,Sachsen,02625,Germany,+49 3591 491456,http://www.bautzener-brauhaus.de,14.4396638,51.1798022
+0b6ba94e-ab5c-4714-9a68-f92027cef3a3,Bergquell,brewpub,Weststraße 7,,,Löbau,Sachsen,02708,Germany,+49 3585 47470,http://www.bergquell-loebau.de,14.6596143,51.108704
+f007364e-036a-4d4f-abed-400788920817,Bergschlösschen,brewpub,Cunnersdorfer Straße 25,,,Dresden,Sachsen,01189,Germany,+49 351 40830,http://www.missionshof-lieske.de,13.707629,51.0159028
+48e2f92a-744b-4c7b-8b02-30a784d4da3e,Bierblume,closed,Neißstraße 8,,,Görlitz,Sachsen,02826,Germany,+49 3581 6673313,http://www.bierblume-goerlitz.de/,14.9928298,51.1572274
+86dc9da0-8c8a-4f8b-bf48-efa70cd5a978,Bierbrauhaus,closed,Großdöbschützer Straße 3,,,Obergurig,Sachsen,02692,Germany,+49 35938 57684,http://www.bierbrauhaus.de,14.4177034,51.1267916
+df527867-05b0-4b1c-b014-fe3eef2676ce,Bierfabrik Erzgebirge,brewpub,Bahnhofstraße 6,,,Pockau-Lengefeld,Sachsen,09514,Germany,+49 172 9598266,http://www.bierfabrik-erzgebirge.de,13.1923206,50.74187939999999
+d53f051e-de72-40a1-b75e-642429eb342a,Blechschmidt,brewpub,Straße der Jugend 33,,,Treuen,Sachsen,08233,Germany,+49 37468 2867,,12.31428,50.54056
+8de3de11-bd87-476d-9fd9-8c3bfa6bc3a7,Böhmisch Brauhaus,brewpub,Neueibauer Straße 9,,,Kottmar,Sachsen,02739,Germany,+49 3586 78140,http://www.boehmisch-brauhaus.de,14.6643599,50.97774889999999
+ead15508-e7b7-4e5e-8b08-ecf5cb721725,Brauhaus Napoleon,brewpub,Prager Straße 233,,,Leipzig,Sachsen,04289,Germany,+49 341 2467676,http://www.brauhaus-leipzig.com,12.4229895,51.306769
+3b713aa7-b03c-4931-a214-dccd8f2bf7bf,Brauhaus Pirna,brewpub,Basteistraße 60b,,,Pirna,Sachsen,01796,Germany,+49 3501 464646,http://www.brauhaus-pirna.de,13.9429966,50.979966
+76688eae-2a3f-428c-bbec-ef20ec54808c,Brauhaus Radebeul,brewpub,Nach der Schiffsmühle 8,,,Radebeul,Sachsen,01445,Germany,+49 351 89516933,http://www.brauhaus-radebeul.de,13.5925459,51.1202543
+8f5d7f06-a66b-430d-8250-a95cd022c10c,Brauhaus Schmilka,brewpub,Schmilka 36,,,Bad Schandau,Sachsen,01814,Germany,,http://www.brauerei-schmilka.de,14.2319154,50.8921866
+1fa231e9-36e1-4330-a00c-b3e4abcf616d,Brauhaus Weltenbummler,closed,Sebastian-Kneipp-Straße 6,,,Bad Gottleuba-Berggießhübel,Sachsen,01816,Germany,,http://www.brauhaus-weltenbummler.de,13.9458144,50.873326
+1192010e-54ff-4ff1-9855-47062d8c6961,Brauhaus Zwickau,closed,Peter-Breuer-Straße 12-20,,,Zwickau,Sachsen,08056,Germany,+49 375 3032032,http://www.brauhaus-zwickau.de,12.4944446,50.7171153
+18ba9957-7aff-40ae-a4e9-69bb843a5dfd,Braumanufaktur Radebeul,brewpub,Straße des Friedens 30,,,Radebeul,Sachsen,01445,Germany,+49 1575 1369488,http://www.braumanufaktur-radebeul.de,13.6613536,51.1002708
+3c40b08e-3800-4435-87a5-da4596f4568e,Braun Mühle,brewpub,Dörnthal 55,,,Olbernhau,Sachsen,09526,Germany,+49 37360 6250,http://www.braun-muehle-doernthal.de,13.3336061,50.7344367
 06c893b6-2ec3-4f3f-a8dc-35a87ff4e40e,Braustolz,closed,Am Feldschlößchen,,,Chemnitz,Sachsen,09116,Germany,,http://www.braustolz.de,12.8856435,50.8230444
-6f842131-7f1f-40c0-93a4-bc11f93a2b9c,Cliff's Brauwerk,brewpub,17 Leibnizstraße,,,Leipzig,Sachsen,04105,Germany,+49 341 24972927,http://www.cliffs-brauwerk-leipzig.de,12.3637598,51.3449824
-844e3c33-dc12-4bc3-a7ae-f1a506f996b9,Eibauer,brewpub,9 Neueibauer Straße,,,Kottmar,Sachsen,02739,Germany,+49 3586 78140,http://www.eibauer.de,14.6643599,50.97774889999999
-db564006-6e51-4e02-b096-d6aed279117a,Einsiedler,brewpub,144 Einsiedler Hauptstraße,,,Chemnitz,Sachsen,09123,Germany,+49 37209 6610,http://www.einsiedler.de,12.9745768,50.7649684
-4dfa8b8e-9c01-402d-840c-4f979e9b8bd9,Erlbacher Brauhaus,brewpub,12 Klingenthaler Straße,,,Markneukirchen,Sachsen,08258,Germany,+49 37422 6384,http://www.brauhaus-erlbach.de,12.3773059,50.314346
-cd635902-69a1-45ee-aeee-6ea7909ad896,Feldschlößchen,brewpub,25 Cunnersdorfer Straße,,,Dresden,Sachsen,01189,Germany,+49 351 40830,http://www.feldschloesschen.de,13.707629,51.0159028
-805c9b9a-c9fc-47e6-a910-f4c78a7d9dae,Fiedler,brewpub,28 Hauptstraße,,,Scheibenberg,Sachsen,09481,Germany,+49 37349 8249,http://www.brauerei-fiedler.de,12.8985525,50.5368797
+6f842131-7f1f-40c0-93a4-bc11f93a2b9c,Cliff's Brauwerk,brewpub,Leibnizstraße 17,,,Leipzig,Sachsen,04105,Germany,+49 341 24972927,http://www.cliffs-brauwerk-leipzig.de,12.3637598,51.3449824
+844e3c33-dc12-4bc3-a7ae-f1a506f996b9,Eibauer,brewpub,Neueibauer Straße 9,,,Kottmar,Sachsen,02739,Germany,+49 3586 78140,http://www.eibauer.de,14.6643599,50.97774889999999
+db564006-6e51-4e02-b096-d6aed279117a,Einsiedler,brewpub,Einsiedler Hauptstraße 144,,,Chemnitz,Sachsen,09123,Germany,+49 37209 6610,http://www.einsiedler.de,12.9745768,50.7649684
+4dfa8b8e-9c01-402d-840c-4f979e9b8bd9,Erlbacher Brauhaus,brewpub,Klingenthaler Straße 12,,,Markneukirchen,Sachsen,08258,Germany,+49 37422 6384,http://www.brauhaus-erlbach.de,12.3773059,50.314346
+cd635902-69a1-45ee-aeee-6ea7909ad896,Feldschlößchen,brewpub,Cunnersdorfer Straße 25,,,Dresden,Sachsen,01189,Germany,+49 351 40830,http://www.feldschloesschen.de,13.707629,51.0159028
+805c9b9a-c9fc-47e6-a910-f4c78a7d9dae,Fiedler,brewpub,Hauptstraße 28,,,Scheibenberg,Sachsen,09481,Germany,+49 37349 8249,http://www.brauerei-fiedler.de,12.8985525,50.5368797
 9cf3c431-77fa-4e7d-844c-400efa949d1e,Freiberger,brewpub,Am Fürstenwald,,,Freiberg,Sachsen,09599,Germany,+49 3731 3630,http://www.freiberger-bier.de,13.322575,50.932104
-36a45755-af65-4cf3-a616-eac119026f57,Frenzel-Bräu,brewpub,21A Humboldtstraße,,,Bautzen,Sachsen,02625,Germany,+49 3591 5984401,http://www.frenzel-braeu.de,14.4197092,51.1712607
-2403e0b0-4cd0-48d3-90ea-a9ad53d23ca9,Genusbrauerei Krause / GR-LI-Bräu,brewpub,116 An der Landskronbrauerei,,,Görlitz,Sachsen,02826,Germany,+49 3581 4650,http://www.gr-li-braeu.de,14.98846,51.13994
-e708a031-9197-4710-9c9f-183fee2f8cd9,Glückauf,brewpub,176 Hauptstraße,,,Gersdorf,Sachsen,09355,Germany,+49 37203 9100,http://www.glueckaufbiere.de,12.7083,50.76184
-27bb814e-1295-479d-b0d5-e7b0e75bc58c,Gosebrauerei Bayerischer Bahnhof,brewpub,1 Bayrischer Platz,,,Leipzig,Sachsen,04107,Germany,+49 341 1245760,http://www.bayerischer-bahnhof.de,12.3814659,51.3288041
-dff5903d-ece5-45cf-9d84-47c108743897,Hammer-Bräu,brewpub,42 Bahnhofstraße,,,Riesa,Sachsen,01587,Germany,+49 3525 530930,http://www.hammerbraeu.de,13.2950269,51.3088546
-e3637ea0-e776-4bb9-bb41-1309758f4ebc,Hartmannsdorfer Brauhaus,brewpub,5 Chemnitzer Straße,,,Hartmannsdorf,Sachsen,09232,Germany,+49 3722 71910,http://www.mittweidaer-loewenbraeu.de,12.8031414,50.8862812
-f0eb9d25-c479-4a36-843b-4f7147370840,Hausbrauerei Jahn / Obergorbitzer Hausbräu,brewpub,67 Österreicher Straße,,,Dresden,Sachsen,01279,Germany,+49 351 48455580,http://www.hausbrauerei-jahn.de,13.8397617,51.0225448
-8dd4004f-e969-4008-ae94-0ca0ebbb740e,Hausbrauerei Laubegast,brewpub,67 Österreicher Straße,,,Dresden,Sachsen,01279,Germany,+49 351 48455580,http://www.hausbrauerei-laubegast.de,13.8397617,51.0225448
-7ab3e6bb-ec3e-4b70-808c-197879e77414,Hausbrauerei Roland Rosner,brewpub,1B Taubenheimer Straße,,,Sohland an der Spree,Sachsen,02689,Germany,+49 35936 41685,http://www.brauereisohland.de/,14.4409862,51.0530499
-a6635b8e-512a-4de8-9eed-8d9fbee6e613,Hausbrauerei Schiller,closed,19 Töpferstraße,,,Coswig,Sachsen,01640,Germany,+49 1640,http://www.bierscheune.com,13.5482133,51.1458451
-8cc2db49-d1ee-4c36-9763-91d36fa876f9,Kevin Brewery,brewpub,1 Seilerstraße,,,Zwickau,Sachsen,08056,Germany,+49 176 60902538,http://www.kevin-brewery.de,12.480278,50.7220522
-e85038b8-f50c-422d-b923-9ecb9363d073,Kräckerbräu,brewpub,16 Schloßstraße,,,Frohburg,Sachsen,04654,Germany,+49 34345 522727,http://www.kraeckerbier.de,12.6594601,51.1016923
-14b33f50-5575-4d96-bf47-e3804e221add,Krostitzer,brewpub,12 Brauereistraße,,,Krostitz,Sachsen,04509,Germany,+49 34295 7760,http://www.ur-krostitzer.de,12.4509185,51.464457
-04497c6e-c293-4744-ba9a-9a7bd7cc5c22,Kunos Braugasthaus,brewpub,8 Schulstraße,,,Breitenbrunn/Erzgebirge,Sachsen,08359,Germany,+49 3773 88050,http://www.hotel-alte-schleiferei.de,12.7117657,50.47255740000001
-74c06c33-689f-483a-bde5-1f02080f9f69,Landskron,brewpub,116 An der Landskronbrauerei,,,Görlitz,Sachsen,02826,Germany,+49 3581 4650,http://www.landskron.de,14.98846,51.13994
-1c319606-8103-4424-bbdd-0fb8970cc2a6,Lotterane / Ratskeller,brewpub,1 Lotterstraße,,,Leipzig,Sachsen,04109,Germany,+49 341 1234567,http://www.lotteraner.de,12.372847,51.336684
-60b6d804-0760-4886-9af2-234fdd6d3dee,Lotters Wirtschaft,brewpub,1 Altmarkt,,,Aue-Bad Schlema,Sachsen,08280,Germany,+49 3771 5920,http://www.hotel-blauerengel.de,12.7015039,50.5865261
-a644f809-699a-4b42-b640-1c4b10e3d993,Mauritius,brewpub,2 Talstraße,,,Zwickau,Sachsen,08066,Germany,+49 375 49490,http://www.mauritius-brauerei.de,12.50091,50.72535
-b54f8df2-395a-4f24-826c-8bd8f33d4a1d,Nerchauer Brauhaus,brewpub,1 Am Grünen Winkel,,,Grimma,Sachsen,04668,Germany,+49 34382 40574,http://www.nerchauer-brauhaus.de,12.7829388,51.274024
-a414fa8e-4fe5-4581-b09c-1e6b10106458,Neustädter Hausbrauerei,closed,37 Hoyerswerdaer Straße,,,Dresden,Sachsen,01099,Germany,,http://www.obergaerig.de,13.7518216,51.0625223
-a1370e53-c699-4647-9c48-67368f24a196,Nordmann's Bräu,brewpub,7 Warschauer Straße,,,Torgau,Sachsen,04860,Germany,+49 3421 73000,https://www.torgauer-brauhof.de/,12.9893603,51.5586375
-fbd39f91-7568-49e3-874b-2287428045d2,Ohne Bedenken,brewpub,5 Menckestraße,,,Leipzig,Sachsen,04155,Germany,+49 341 5662360,http://www.gosenschenke.de,12.3675988,51.3577221
-6b6d1b51-7682-4683-80d5-b24e27540424,Radeberger,brewpub,2 Dresdener Straße,,,Radeberg,Sachsen,01454,Germany,+49 3528 4540,http://www.radeberger.de,13.91405,51.11494
-ffd463e3-7b4b-405d-b5c8-01889cdb7564,Rechenberger,brewpub,3 An der Schanze,,,Rechenberg-Bienenmühle,Sachsen,09623,Germany,+49 37327 8800,http://www.rechenberger.com,13.5570543,50.736487
-e9ae3694-a705-45c0-a368-c6c92a413cdf,Reichenbrander,brewpub,478 Zwickauer Straße,,,Chemnitz,Sachsen,09117,Germany,+49 371 850214,http://www.brauerei-bergt.de,12.8350739,50.8143898
-c60040e0-0420-4feb-8431-8a961b602cda,Schwerter,brewpub,6 Ziegelstraße,,,Meißen,Sachsen,01662,Germany,+49 3521 731443,http://www.schwerter-brauerei.de,13.5154919,51.1577971
-eb3b419d-6147-4aa1-aa7a-065bec60f7a6,Specht,brewpub,17 Thomas-Mann-Straße,,,Ehrenfriedersdorf,Sachsen,09427,Germany,+49 37341 2229,http://www.privatbrauerei-specht.de,12.9650243,50.64258170000001
-33e271cf-a8f8-4af1-b2cb-451d1e8b0520,Stadtbrauerei Wittichenau,brewpub,33 Haschkestraße,,,Wittichenau,Sachsen,02997,Germany,+49 35725 7510,http://www.wittichenauer.de,14.24506,51.38354
-4524282f-f574-4912-9cd6-4657445587a6,Sternburg,brewpub,13 Mühlstraße,,,Leipzig,Sachsen,04317,Germany,+49 341 222230,http://www.sternburg-bier.de,12.4010099,51.33024529999999
-78d9f25e-02db-47f0-99bb-8b6f9010d270,Sternquell,brewpub,83 Dobenaustraße,,,Plauen,Sachsen,08523,Germany,+49 3741 2110,http://www.sternquell.de,12.1242607,50.4982041
-91ab781c-29ea-4779-be81-244e345bd50c,Stonewood Braumanufaktur,brewpub,73 Obere Dorfstraße,,,Claußnitz,Sachsen,09236,Germany,+49 37202 89043,http://www.stonewood-bier.de,12.899566,50.943435
-bee7f4d8-fa30-4b48-995e-2f1639c24ed7,Thomaskirche,brewpub,3-5 Thomaskirchhof,,,Leipzig,Sachsen,04109,Germany,+49 341 2126110,http://www.brauerei-thomaskirche.de,12.3737277,51.3392913
-69562a6d-9333-40b2-9944-9856d2aa8131,Trachennowe Braukunst,brewpub,1 Schönbrunnstraße,,,Dresden,Sachsen,01097,Germany,+49 351 7993774,http://www.trachennowe-braukunst.de,13.7469725,51.0693855
-eb320dd5-bec1-4c6e-b162-e8d97e53fd83,Turm Brauhaus,brewpub,2 Neumarkt,,,Chemnitz,Sachsen,09111,Germany,+49 371 9095095,http://www.turmbrauhaus.de,12.9205552,50.8333296
-c2e1141a-f9cf-4a6e-b07e-1ab5da7072fe,Waldschlösschen,brewpub,8B Am Brauhaus,,,Dresden,Sachsen,01099,Germany,+49 351 8042010,http://www.waldschloesschen.de,13.7780918,51.06793829999999
-1e4f48a1-6a96-4eea-a327-723fe3530308,Watzke,brewpub,1 Kötzschenbroder Straße,,,Dresden,Sachsen,01139,Germany,+49 351 852920,http://www.watzke.de,13.7158304,51.0775639
-fc942ca1-17dc-4e97-b366-223b87151d55,Weesensteiner Schlossbräu,closed,1 Am Schloßberg,,,Müglitztal,Sachsen,01809,Germany,+49 35027 42004,http://www.schlossbrauerei-weesenstein.de,13.8589685,50.9328735
-8a8f34e6-56b2-4352-b464-50c6d5403d77,Weniger Bräu,brewpub,25 Cunnersdorfer Straße,,,Dresden,Sachsen,01189,Germany,+49 351 40830,http://www.weniger-braeu.de,13.707629,51.0159028
-152a0a1a-925d-4a3a-ad28-1637ba061754,Wernesgrüner,brewpub,4 Bergstraße,,,Steinberg,Sachsen,08237,Germany,+49 37462 610,http://www.wernesgruener.de,12.4735612,50.5344657
-a4c4bc36-258a-4a85-baa1-e1e2b2a33048,Ybnstoker,brewpub,1 Muldenhammerstraße,,,Eibenstock,Sachsen,08309,Germany,+49 37752 879850,http://www.ybnstoker.de,12.5987227,50.4979176
-b0ab27e5-6ee2-42c5-b27a-78d215a3b3ee,Zur Ratte,brewpub,33 Wendelin-Hipler-Weg,,,Leipzig,Sachsen,04249,Germany,+49 341 97852360,http://www.zur-ratte.de,12.3014827,51.2690813
-68d22cdf-09fa-4257-9fe0-a5c4fe30fdf2,Zwönitz,brewpub,15 Grünhainer Straße,,,Zwönitz,Sachsen,08297,Germany,+49 37754 59904,http://www.brauerei-zwoenitz.de,12.8155514,50.6277281
+36a45755-af65-4cf3-a616-eac119026f57,Frenzel-Bräu,brewpub,Humboldtstraße 21A,,,Bautzen,Sachsen,02625,Germany,+49 3591 5984401,http://www.frenzel-braeu.de,14.4197092,51.1712607
+2403e0b0-4cd0-48d3-90ea-a9ad53d23ca9,Genusbrauerei Krause / GR-LI-Bräu,brewpub,An der Landskronbrauerei 116,,,Görlitz,Sachsen,02826,Germany,+49 3581 4650,http://www.gr-li-braeu.de,14.98846,51.13994
+e708a031-9197-4710-9c9f-183fee2f8cd9,Glückauf,brewpub,Hauptstraße 176,,,Gersdorf,Sachsen,09355,Germany,+49 37203 9100,http://www.glueckaufbiere.de,12.7083,50.76184
+27bb814e-1295-479d-b0d5-e7b0e75bc58c,Gosebrauerei Bayerischer Bahnhof,brewpub,Bayrischer Platz 1,,,Leipzig,Sachsen,04107,Germany,+49 341 1245760,http://www.bayerischer-bahnhof.de,12.3814659,51.3288041
+dff5903d-ece5-45cf-9d84-47c108743897,Hammer-Bräu,brewpub,Bahnhofstraße 42,,,Riesa,Sachsen,01587,Germany,+49 3525 530930,http://www.hammerbraeu.de,13.2950269,51.3088546
+e3637ea0-e776-4bb9-bb41-1309758f4ebc,Hartmannsdorfer Brauhaus,brewpub,Chemnitzer Straße 5,,,Hartmannsdorf,Sachsen,09232,Germany,+49 3722 71910,http://www.mittweidaer-loewenbraeu.de,12.8031414,50.8862812
+f0eb9d25-c479-4a36-843b-4f7147370840,Hausbrauerei Jahn / Obergorbitzer Hausbräu,brewpub,Österreicher Straße 67,,,Dresden,Sachsen,01279,Germany,+49 351 48455580,http://www.hausbrauerei-jahn.de,13.8397617,51.0225448
+8dd4004f-e969-4008-ae94-0ca0ebbb740e,Hausbrauerei Laubegast,brewpub,Österreicher Straße 67,,,Dresden,Sachsen,01279,Germany,+49 351 48455580,http://www.hausbrauerei-laubegast.de,13.8397617,51.0225448
+7ab3e6bb-ec3e-4b70-808c-197879e77414,Hausbrauerei Roland Rosner,brewpub,Taubenheimer Straße 1B,,,Sohland an der Spree,Sachsen,02689,Germany,+49 35936 41685,http://www.brauereisohland.de/,14.4409862,51.0530499
+a6635b8e-512a-4de8-9eed-8d9fbee6e613,Hausbrauerei Schiller,closed,Töpferstraße 19,,,Coswig,Sachsen,01640,Germany,+49 1640,http://www.bierscheune.com,13.5482133,51.1458451
+8cc2db49-d1ee-4c36-9763-91d36fa876f9,Kevin Brewery,brewpub,Seilerstraße 1,,,Zwickau,Sachsen,08056,Germany,+49 176 60902538,http://www.kevin-brewery.de,12.480278,50.7220522
+e85038b8-f50c-422d-b923-9ecb9363d073,Kräckerbräu,brewpub,Schloßstraße 16,,,Frohburg,Sachsen,04654,Germany,+49 34345 522727,http://www.kraeckerbier.de,12.6594601,51.1016923
+14b33f50-5575-4d96-bf47-e3804e221add,Krostitzer,brewpub,Brauereistraße 12,,,Krostitz,Sachsen,04509,Germany,+49 34295 7760,http://www.ur-krostitzer.de,12.4509185,51.464457
+04497c6e-c293-4744-ba9a-9a7bd7cc5c22,Kunos Braugasthaus,brewpub,Schulstraße 8,,,Breitenbrunn/Erzgebirge,Sachsen,08359,Germany,+49 3773 88050,http://www.hotel-alte-schleiferei.de,12.7117657,50.47255740000001
+74c06c33-689f-483a-bde5-1f02080f9f69,Landskron,brewpub,An der Landskronbrauerei 116,,,Görlitz,Sachsen,02826,Germany,+49 3581 4650,http://www.landskron.de,14.98846,51.13994
+1c319606-8103-4424-bbdd-0fb8970cc2a6,Lotterane / Ratskeller,brewpub,Lotterstraße 1,,,Leipzig,Sachsen,04109,Germany,+49 341 1234567,http://www.lotteraner.de,12.372847,51.336684
+60b6d804-0760-4886-9af2-234fdd6d3dee,Lotters Wirtschaft,brewpub,Altmarkt 1,,,Aue-Bad Schlema,Sachsen,08280,Germany,+49 3771 5920,http://www.hotel-blauerengel.de,12.7015039,50.5865261
+a644f809-699a-4b42-b640-1c4b10e3d993,Mauritius,brewpub,Talstraße 2,,,Zwickau,Sachsen,08066,Germany,+49 375 49490,http://www.mauritius-brauerei.de,12.50091,50.72535
+b54f8df2-395a-4f24-826c-8bd8f33d4a1d,Nerchauer Brauhaus,brewpub,Am Grünen Winkel 1,,,Grimma,Sachsen,04668,Germany,+49 34382 40574,http://www.nerchauer-brauhaus.de,12.7829388,51.274024
+a414fa8e-4fe5-4581-b09c-1e6b10106458,Neustädter Hausbrauerei,closed,Hoyerswerdaer Straße 37,,,Dresden,Sachsen,01099,Germany,,http://www.obergaerig.de,13.7518216,51.0625223
+a1370e53-c699-4647-9c48-67368f24a196,Nordmann's Bräu,brewpub,Warschauer Straße 7,,,Torgau,Sachsen,04860,Germany,+49 3421 73000,https://www.torgauer-brauhof.de/,12.9893603,51.5586375
+fbd39f91-7568-49e3-874b-2287428045d2,Ohne Bedenken,brewpub,Menckestraße 5,,,Leipzig,Sachsen,04155,Germany,+49 341 5662360,http://www.gosenschenke.de,12.3675988,51.3577221
+6b6d1b51-7682-4683-80d5-b24e27540424,Radeberger,brewpub,Dresdener Straße 2,,,Radeberg,Sachsen,01454,Germany,+49 3528 4540,http://www.radeberger.de,13.91405,51.11494
+ffd463e3-7b4b-405d-b5c8-01889cdb7564,Rechenberger,brewpub,An der Schanze 3,,,Rechenberg-Bienenmühle,Sachsen,09623,Germany,+49 37327 8800,http://www.rechenberger.com,13.5570543,50.736487
+e9ae3694-a705-45c0-a368-c6c92a413cdf,Reichenbrander,brewpub,Zwickauer Straße 478,,,Chemnitz,Sachsen,09117,Germany,+49 371 850214,http://www.brauerei-bergt.de,12.8350739,50.8143898
+c60040e0-0420-4feb-8431-8a961b602cda,Schwerter,brewpub,Ziegelstraße 6,,,Meißen,Sachsen,01662,Germany,+49 3521 731443,http://www.schwerter-brauerei.de,13.5154919,51.1577971
+eb3b419d-6147-4aa1-aa7a-065bec60f7a6,Specht,brewpub,Thomas-Mann-Straße 17,,,Ehrenfriedersdorf,Sachsen,09427,Germany,+49 37341 2229,http://www.privatbrauerei-specht.de,12.9650243,50.64258170000001
+33e271cf-a8f8-4af1-b2cb-451d1e8b0520,Stadtbrauerei Wittichenau,brewpub,Haschkestraße 33,,,Wittichenau,Sachsen,02997,Germany,+49 35725 7510,http://www.wittichenauer.de,14.24506,51.38354
+4524282f-f574-4912-9cd6-4657445587a6,Sternburg,brewpub,Mühlstraße 13,,,Leipzig,Sachsen,04317,Germany,+49 341 222230,http://www.sternburg-bier.de,12.4010099,51.33024529999999
+78d9f25e-02db-47f0-99bb-8b6f9010d270,Sternquell,brewpub,Dobenaustraße 83,,,Plauen,Sachsen,08523,Germany,+49 3741 2110,http://www.sternquell.de,12.1242607,50.4982041
+91ab781c-29ea-4779-be81-244e345bd50c,Stonewood Braumanufaktur,brewpub,Obere Dorfstraße 73,,,Claußnitz,Sachsen,09236,Germany,+49 37202 89043,http://www.stonewood-bier.de,12.899566,50.943435
+bee7f4d8-fa30-4b48-995e-2f1639c24ed7,Thomaskirche,brewpub,Thomaskirchhof 3-5,,,Leipzig,Sachsen,04109,Germany,+49 341 2126110,http://www.brauerei-thomaskirche.de,12.3737277,51.3392913
+69562a6d-9333-40b2-9944-9856d2aa8131,Trachennowe Braukunst,brewpub,Schönbrunnstraße 1,,,Dresden,Sachsen,01097,Germany,+49 351 7993774,http://www.trachennowe-braukunst.de,13.7469725,51.0693855
+eb320dd5-bec1-4c6e-b162-e8d97e53fd83,Turm Brauhaus,brewpub,Neumarkt 2,,,Chemnitz,Sachsen,09111,Germany,+49 371 9095095,http://www.turmbrauhaus.de,12.9205552,50.8333296
+c2e1141a-f9cf-4a6e-b07e-1ab5da7072fe,Waldschlösschen,brewpub,Am Brauhaus 8B,,,Dresden,Sachsen,01099,Germany,+49 351 8042010,http://www.waldschloesschen.de,13.7780918,51.06793829999999
+1e4f48a1-6a96-4eea-a327-723fe3530308,Watzke,brewpub,Kötzschenbroder Straße 1,,,Dresden,Sachsen,01139,Germany,+49 351 852920,http://www.watzke.de,13.7158304,51.0775639
+fc942ca1-17dc-4e97-b366-223b87151d55,Weesensteiner Schlossbräu,closed,Am Schloßberg 1,,,Müglitztal,Sachsen,01809,Germany,+49 35027 42004,http://www.schlossbrauerei-weesenstein.de,13.8589685,50.9328735
+8a8f34e6-56b2-4352-b464-50c6d5403d77,Weniger Bräu,brewpub,Cunnersdorfer Straße 25,,,Dresden,Sachsen,01189,Germany,+49 351 40830,http://www.weniger-braeu.de,13.707629,51.0159028
+152a0a1a-925d-4a3a-ad28-1637ba061754,Wernesgrüner,brewpub,Bergstraße 4,,,Steinberg,Sachsen,08237,Germany,+49 37462 610,http://www.wernesgruener.de,12.4735612,50.5344657
+a4c4bc36-258a-4a85-baa1-e1e2b2a33048,Ybnstoker,brewpub,Muldenhammerstraße 1,,,Eibenstock,Sachsen,08309,Germany,+49 37752 879850,http://www.ybnstoker.de,12.5987227,50.4979176
+b0ab27e5-6ee2-42c5-b27a-78d215a3b3ee,Zur Ratte,brewpub,Wendelin-Hipler-Weg 33,,,Leipzig,Sachsen,04249,Germany,+49 341 97852360,http://www.zur-ratte.de,12.3014827,51.2690813
+68d22cdf-09fa-4257-9fe0-a5c4fe30fdf2,Zwönitz,brewpub,Grünhainer Straße 15,,,Zwönitz,Sachsen,08297,Germany,+49 37754 59904,http://www.brauerei-zwoenitz.de,12.8155514,50.6277281

--- a/data/germany/schleswig-holstein.csv
+++ b/data/germany/schleswig-holstein.csv
@@ -10,7 +10,7 @@ bbcc1a73-772f-43dd-bb19-c148aface715,Das Kleine Brauhaus,brewpub,36 Alfstraße,,
 e55c818a-3774-4e9d-b8fa-0343b3d66c41,Ebbüller Brauhaus,brewpub,2 Ebbüller Weg,,,Emmelsbüll-Horsbüll,Schleswig-Holstein,25924,Germany,+49 4665 2323296,http://www.ebbueller.de,8.6860193,54.8097886
 8e29c731-d133-4d18-89cc-75d392d0311d,Fährhaus Bräu,brewpub,48 Hafenstraße,,,Burg (Dithmarschen),Schleswig-Holstein,25712,Germany,+49 4825 2417,http://www.burger-faehrhaus.de,9.2777747,53.98431110000001
 195c8caa-95d8-4fd3-b090-880af6788b8d,Flensburger,brewpub,12 Munketoft,,,Flensburg,Schleswig-Holstein,24937,Germany,+49 461 8630,http://www.flens.de,9.435710199999999,54.7789689
-31633fac-c442-4384-8fab-b9dd7f6b378d,Getränke Stapelfeldt,micro,Ratzeburger-Str. 31,,,Mölln,Schleswig-Holstein,23879,Germany,,http://www.getraenke-stapelfeldt.de,10.6919122,53.6349107
+31633fac-c442-4384-8fab-b9dd7f6b378d,Getränke Stapelfeldt,micro,Ratzeburger-Straße 31,,,Mölln,Schleswig-Holstein,23879,Germany,,http://www.getraenke-stapelfeldt.de,10.6919122,53.6349107
 fbb9fdfa-9897-4736-b80f-13dd7f0772e1,Grönwohlder,brewpub,1 Drahtmühle,,,Grönwohld,Schleswig-Holstein,22956,Germany,+49 1522 2387085,http://www.groenwohlder.de,10.4000244,53.64030349999999
 93cc7d1d-af61-4804-9087-00f61cace2a6,Hansens,brewpub,16 Schiffbrücke,,,Flensburg,Schleswig-Holstein,24939,Germany,+49 461 22210,http://www.hansens-brauerei.de,9.4334247,54.7909319
 a0726c0a-b7fd-4bed-b0a2-5db0797e076a,Hopfenleibe,brewpub,60 Rathausallee,,,Norderstedt,Schleswig-Holstein,22846,Germany,+49 40 30987243,http://www.hopfenliebe.de,9.9938006,53.7075188

--- a/data/germany/schleswig-holstein.csv
+++ b/data/germany/schleswig-holstein.csv
@@ -1,29 +1,29 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-911ba23d-87ac-4446-bd08-3bc36e9c18e1,Asgaard,brewpub,27 Königstraße,,,Schleswig,Schleswig-Holstein,24837,Germany,+49 4621 488213,http://www.asgaard.de,9.5618837,54.51441459999999
-abdeb784-805b-412e-92c0-8080b0125650,Brauberger,brewpub,36 Alfstraße,,,Lübeck,Schleswig-Holstein,23552,Germany,+49 451 71444,http://www.brauberger.com,10.6809594,53.8683004
-f7a27918-c59c-421d-91fd-2f2a7834df6d,Brauerei Taarstedt,brewpub,12 Schörderup,,,Stoltebüll,Schleswig-Holstein,24409,Germany,+49 160 5458702,http://www.brauerei-taarstedt.de,9.850406699999999,54.69805419999999
-e573ecc3-fdd9-42cc-abca-55354664cd72,Brauhaus Eutin,brewpub,11 Markt,,,Eutin,Schleswig-Holstein,23701,Germany,+49 4521 766777,http://www.brauhaus-eutin.de,10.6167935,54.1367339
-67f57213-ba7b-44c0-bafc-58351ec54036,Braukeller Gotthilf,brewpub,5 Am Schwarzen Berg,,,Bornhöved,Schleswig-Holstein,24619,Germany,+49 4323 6172,http://www.braukeller-gotthilf.de,10.2484171,54.0762164
-a720caae-898f-4a23-a3dc-1fed32b24dd3,Czerny's Küstenbrauerei,brewpub,20 Deichweg,,,Kiel,Schleswig-Holstein,24159,Germany,+49 431 97990985,http://www.czernys-kuestenbrauerei.de,10.18591,54.39265
-bbcc1a73-772f-43dd-bb19-c148aface715,Das Kleine Brauhaus,brewpub,36 Alfstraße,,,Lübeck,Schleswig-Holstein,23552,Germany,+49 451 71444,http://www.schwarzenbeker-brauhaus.de,10.6809594,53.8683004
-736dd4c4-bb0b-4407-b703-a74735dc8631,Dithmarscher,brewpub,18 Österstraße,,,Marne,Schleswig-Holstein,25709,Germany,+49 4851 9620,http://www.dithmarscher.de,9.012427700000002,53.95383289999999
-e55c818a-3774-4e9d-b8fa-0343b3d66c41,Ebbüller Brauhaus,brewpub,2 Ebbüller Weg,,,Emmelsbüll-Horsbüll,Schleswig-Holstein,25924,Germany,+49 4665 2323296,http://www.ebbueller.de,8.6860193,54.8097886
-8e29c731-d133-4d18-89cc-75d392d0311d,Fährhaus Bräu,brewpub,48 Hafenstraße,,,Burg (Dithmarschen),Schleswig-Holstein,25712,Germany,+49 4825 2417,http://www.burger-faehrhaus.de,9.2777747,53.98431110000001
-195c8caa-95d8-4fd3-b090-880af6788b8d,Flensburger,brewpub,12 Munketoft,,,Flensburg,Schleswig-Holstein,24937,Germany,+49 461 8630,http://www.flens.de,9.435710199999999,54.7789689
+911ba23d-87ac-4446-bd08-3bc36e9c18e1,Asgaard,brewpub,Königstraße 27,,,Schleswig,Schleswig-Holstein,24837,Germany,+49 4621 488213,http://www.asgaard.de,9.5618837,54.51441459999999
+abdeb784-805b-412e-92c0-8080b0125650,Brauberger,brewpub,Alfstraße 36,,,Lübeck,Schleswig-Holstein,23552,Germany,+49 451 71444,http://www.brauberger.com,10.6809594,53.8683004
+f7a27918-c59c-421d-91fd-2f2a7834df6d,Brauerei Taarstedt,brewpub,Schörderup 12,,,Stoltebüll,Schleswig-Holstein,24409,Germany,+49 160 5458702,http://www.brauerei-taarstedt.de,9.850406699999999,54.69805419999999
+e573ecc3-fdd9-42cc-abca-55354664cd72,Brauhaus Eutin,brewpub,Markt 11,,,Eutin,Schleswig-Holstein,23701,Germany,+49 4521 766777,http://www.brauhaus-eutin.de,10.6167935,54.1367339
+67f57213-ba7b-44c0-bafc-58351ec54036,Braukeller Gotthilf,brewpub,Am Schwarzen Berg 5,,,Bornhöved,Schleswig-Holstein,24619,Germany,+49 4323 6172,http://www.braukeller-gotthilf.de,10.2484171,54.0762164
+a720caae-898f-4a23-a3dc-1fed32b24dd3,Czerny's Küstenbrauerei,brewpub,Deichweg 20,,,Kiel,Schleswig-Holstein,24159,Germany,+49 431 97990985,http://www.czernys-kuestenbrauerei.de,10.18591,54.39265
+bbcc1a73-772f-43dd-bb19-c148aface715,Das Kleine Brauhaus,brewpub,Alfstraße 36,,,Lübeck,Schleswig-Holstein,23552,Germany,+49 451 71444,http://www.schwarzenbeker-brauhaus.de,10.6809594,53.8683004
+736dd4c4-bb0b-4407-b703-a74735dc8631,Dithmarscher,brewpub,Österstraße 18,,,Marne,Schleswig-Holstein,25709,Germany,+49 4851 9620,http://www.dithmarscher.de,9.012427700000002,53.95383289999999
+e55c818a-3774-4e9d-b8fa-0343b3d66c41,Ebbüller Brauhaus,brewpub,Ebbüller Weg 2,,,Emmelsbüll-Horsbüll,Schleswig-Holstein,25924,Germany,+49 4665 2323296,http://www.ebbueller.de,8.6860193,54.8097886
+8e29c731-d133-4d18-89cc-75d392d0311d,Fährhaus Bräu,brewpub,Hafenstraße 48,,,Burg (Dithmarschen),Schleswig-Holstein,25712,Germany,+49 4825 2417,http://www.burger-faehrhaus.de,9.2777747,53.98431110000001
+195c8caa-95d8-4fd3-b090-880af6788b8d,Flensburger,brewpub,Munketoft 12,,,Flensburg,Schleswig-Holstein,24937,Germany,+49 461 8630,http://www.flens.de,9.435710199999999,54.7789689
 31633fac-c442-4384-8fab-b9dd7f6b378d,Getränke Stapelfeldt,micro,Ratzeburger-Straße 31,,,Mölln,Schleswig-Holstein,23879,Germany,,http://www.getraenke-stapelfeldt.de,10.6919122,53.6349107
-fbb9fdfa-9897-4736-b80f-13dd7f0772e1,Grönwohlder,brewpub,1 Drahtmühle,,,Grönwohld,Schleswig-Holstein,22956,Germany,+49 1522 2387085,http://www.groenwohlder.de,10.4000244,53.64030349999999
-93cc7d1d-af61-4804-9087-00f61cace2a6,Hansens,brewpub,16 Schiffbrücke,,,Flensburg,Schleswig-Holstein,24939,Germany,+49 461 22210,http://www.hansens-brauerei.de,9.4334247,54.7909319
-a0726c0a-b7fd-4bed-b0a2-5db0797e076a,Hopfenleibe,brewpub,60 Rathausallee,,,Norderstedt,Schleswig-Holstein,22846,Germany,+49 40 30987243,http://www.hopfenliebe.de,9.9938006,53.7075188
-2709b55c-1e10-4f90-82b8-255aa29aaab4,Husums Brauhaus,brewpub,60-68 Neustadt,,,Husum,Schleswig-Holstein,25813,Germany,+49 4841 89660,http://www.husums-brauhaus.de,9.046839,54.478962
-6035e0cc-1fea-4384-a08a-21b54378dbd5,Kieler,brewpub,9 Alter Markt,,,Kiel,Schleswig-Holstein,24103,Germany,+49 431 906290,http://www.kieler-brauerei.de,10.139087,54.323513
-b4721ac2-e28d-454e-b600-7d053d70f84d,Kirschenholz,brewpub,4 Hauptstraße,,,Schillsdorf,Schleswig-Holstein,24637,Germany,+49 4394 309,http://www.kirschenholz.de,10.1262578,54.11361309999999
-bc52d91f-490a-4613-972f-842849a6c2bc,Klapperbräu,brewpub,13 Gehrn,,,Wacken,Schleswig-Holstein,25596,Germany,+49 4827 9969806,http://www.klapperbraeu.de,9.3859411,54.0206716
-b09080f2-482e-4560-a98d-3be2e9ee4517,Klüver's Brauhaus,brewpub,2-4 Schiffbrücke,,,Neustadt in Holstein,Schleswig-Holstein,23730,Germany,+49 4561 714811,http://www.kluevers-brauhaus.de,10.8113547,54.10559800000001
-d42186a6-e2f9-4f1b-bcf5-3c709a5a207e,Milster,brewpub,12 Munketoft,,,Flensburg,Schleswig-Holstein,24937,Germany,+49 461 8630,https://www.flens.de/?utm_source=gmb&utm_medium=profil&utm_campaign=branding,9.435710199999999,54.7789689
-a65a6d72-0a80-4904-8a03-7e481f1d9f81,Ricklinger Landbrauerei,brewpub,1 Grüner Weg,,,Rickling,Schleswig-Holstein,24635,Germany,+49 4328 1314,http://www.ricklinger-landbrauerei.de,10.1672125,54.0130345
-e71aa48e-3551-4a90-b6cf-e2a0af019519,Sylter Hopfen,brewpub,21 Brauereiweg,,,Flensburg,Schleswig-Holstein,24939,Germany,+49 461 90019967,http://www.sylter-hopfen.de,9.4275755,54.8029058
-56f86505-8c64-480e-a893-a0714c996b57,The Brewing Pack,brewpub,44 Zur Bleiche,,,Flensburg,Schleswig-Holstein,24941,Germany,+49 461 99583599,http://www.brewingpack.com,9.4287397,54.7716149
-89ff94de-c3bd-4356-a683-2f323ff8b6a2,Wacken Brauerei,brewpub,13 Gehrn,,,Wacken,Schleswig-Holstein,25596,Germany,+49 4827 9969806,http://www.wacken.beer,9.3859411,54.0206716
-920fc89a-f91c-43ad-953a-461ee9691977,Watt Bier,brewpub,2a Hafenstraße,,,List auf Sylt,Schleswig-Holstein,25992,Germany,,http://www.watt-bier.de,8.430721799999999,55.0154751
-05952806-4db4-49be-bfbe-06e1e00aec84,Wittorfer,brewpub,12 Wrangelstraße,,,Neumünster,Schleswig-Holstein,24539,Germany,+49 1515 0004321,http://www.wittorfer-brauerei.de,9.9738664,54.0662422
-f3008118-0b13-41ad-91ea-f7e355dc671d,Zeugenbräu,closed,17 Schlehenstieg,,,Ahrensburg,Schleswig-Holstein,22926,Germany,,http://www.zeugenbraeu.de,10.2100522,53.6756677
+fbb9fdfa-9897-4736-b80f-13dd7f0772e1,Grönwohlder,brewpub,Drahtmühle 1,,,Grönwohld,Schleswig-Holstein,22956,Germany,+49 1522 2387085,http://www.groenwohlder.de,10.4000244,53.64030349999999
+93cc7d1d-af61-4804-9087-00f61cace2a6,Hansens,brewpub,Schiffbrücke 16,,,Flensburg,Schleswig-Holstein,24939,Germany,+49 461 22210,http://www.hansens-brauerei.de,9.4334247,54.7909319
+a0726c0a-b7fd-4bed-b0a2-5db0797e076a,Hopfenleibe,brewpub,Rathausallee 60,,,Norderstedt,Schleswig-Holstein,22846,Germany,+49 40 30987243,http://www.hopfenliebe.de,9.9938006,53.7075188
+2709b55c-1e10-4f90-82b8-255aa29aaab4,Husums Brauhaus,brewpub,Neustadt 60-68,,,Husum,Schleswig-Holstein,25813,Germany,+49 4841 89660,http://www.husums-brauhaus.de,9.046839,54.478962
+6035e0cc-1fea-4384-a08a-21b54378dbd5,Kieler,brewpub,Alter Markt 9,,,Kiel,Schleswig-Holstein,24103,Germany,+49 431 906290,http://www.kieler-brauerei.de,10.139087,54.323513
+b4721ac2-e28d-454e-b600-7d053d70f84d,Kirschenholz,brewpub,Hauptstraße 4,,,Schillsdorf,Schleswig-Holstein,24637,Germany,+49 4394 309,http://www.kirschenholz.de,10.1262578,54.11361309999999
+bc52d91f-490a-4613-972f-842849a6c2bc,Klapperbräu,brewpub,Gehrn 13,,,Wacken,Schleswig-Holstein,25596,Germany,+49 4827 9969806,http://www.klapperbraeu.de,9.3859411,54.0206716
+b09080f2-482e-4560-a98d-3be2e9ee4517,Klüver's Brauhaus,brewpub,Schiffbrücke 2-4,,,Neustadt in Holstein,Schleswig-Holstein,23730,Germany,+49 4561 714811,http://www.kluevers-brauhaus.de,10.8113547,54.10559800000001
+d42186a6-e2f9-4f1b-bcf5-3c709a5a207e,Milster,brewpub,Munketoft 12,,,Flensburg,Schleswig-Holstein,24937,Germany,+49 461 8630,https://www.flens.de/?utm_source=gmb&utm_medium=profil&utm_campaign=branding,9.435710199999999,54.7789689
+a65a6d72-0a80-4904-8a03-7e481f1d9f81,Ricklinger Landbrauerei,brewpub,Grüner Weg 1,,,Rickling,Schleswig-Holstein,24635,Germany,+49 4328 1314,http://www.ricklinger-landbrauerei.de,10.1672125,54.0130345
+e71aa48e-3551-4a90-b6cf-e2a0af019519,Sylter Hopfen,brewpub,Brauereiweg 21,,,Flensburg,Schleswig-Holstein,24939,Germany,+49 461 90019967,http://www.sylter-hopfen.de,9.4275755,54.8029058
+56f86505-8c64-480e-a893-a0714c996b57,The Brewing Pack,brewpub,Zur Bleiche 44,,,Flensburg,Schleswig-Holstein,24941,Germany,+49 461 99583599,http://www.brewingpack.com,9.4287397,54.7716149
+89ff94de-c3bd-4356-a683-2f323ff8b6a2,Wacken Brauerei,brewpub,Gehrn 13,,,Wacken,Schleswig-Holstein,25596,Germany,+49 4827 9969806,http://www.wacken.beer,9.3859411,54.0206716
+920fc89a-f91c-43ad-953a-461ee9691977,Watt Bier,brewpub,Hafenstraße 2a,,,List auf Sylt,Schleswig-Holstein,25992,Germany,,http://www.watt-bier.de,8.430721799999999,55.0154751
+05952806-4db4-49be-bfbe-06e1e00aec84,Wittorfer,brewpub,Wrangelstraße 12,,,Neumünster,Schleswig-Holstein,24539,Germany,+49 1515 0004321,http://www.wittorfer-brauerei.de,9.9738664,54.0662422
+f3008118-0b13-41ad-91ea-f7e355dc671d,Zeugenbräu,closed,Schlehenstieg 17,,,Ahrensburg,Schleswig-Holstein,22926,Germany,,http://www.zeugenbraeu.de,10.2100522,53.6756677

--- a/data/germany/thuringen.csv
+++ b/data/germany/thuringen.csv
@@ -1,38 +1,38 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
-783328ef-b388-445a-bb53-9b66c6f132f8,Altenburger,brewpub,20 Brauereistraße,,,Altenburg,Thüringen,04600,Germany,+49 3447 31290,http://www.brauerei-altenburg.de,12.4368298,51.0006734
-9e16fd00-e490-47d0-a8ad-046a954bec87,Ankerbräu,brewpub,6A Steinbächlein,,,Steinach,Thüringen,96523,Germany,+49 171 6294017,http://www.ankerla.de,11.1549309,50.4329505
-1fc7b88c-bafb-4e5f-8c34-e8de2522b1e7,Brauhaus zum Löwen,brewpub,2-4 Felchtaer Straße,,,Mühlhausen/Thüringen,Thüringen,99974,Germany,+49 3601 4710,http://www.brauhaus-zum-loewen.de,10.4574616,51.2075459
-bba27afa-5e9b-4c5c-92d4-5ae0d8d1038b,Braukeller Erfurt,brewpub,5 Fischmarkt,,,Erfurt,Thüringen,99084,Germany,+49 361 21846054,http://www.braukeller-erfurt.de,11.0282588,50.97747409999999
-2fbc0b69-05da-4996-9856-43e610da5210,Braumanufaktur Schmalkalden,brewpub,8 Weidebrunner Gasse,,,Schmalkalden,Thüringen,98574,Germany,,http://www.braumanufaktur-schmalkalden.de,10.45262,50.72356
-eacf4733-9043-4640-9462-17cb9cd15181,Brauner Hirsch,brewpub,16 Sophienhof,,,Harztor,Thüringen,99768,Germany,+49 36331 48144,http://www.braunerhirsch-sophienhof.de,10.7909324,51.63462149999999
-d8419492-6b11-4300-8bf0-5c6d57fc3f25,Brauverein Buchfart,brewpub,1 Weimarische Straße,,,Buchfart,Thüringen,99438,Germany,+49 3643 495935,http://www.buchfarter-muehle.de,11.3326392,50.921529
-81201e0b-e5e4-40c5-8773-bfb4a8719dc9,Ehringsdorfer,brewpub,13 Hainweg,,,Weimar,Thüringen,99425,Germany,+49 3643 8760,http://www.ehringsdorfer.de,11.3499,50.95808
-699fa600-57e9-41bf-b902-05f9ff67068c,Gessner,brewpub,27 Am Lindenbach,,,Sonneberg,Thüringen,96515,Germany,+49 3675 40790,http://www.privatbrauerei-gessner.de,11.20887,50.34494
-9ffa71b6-5111-49fb-8b41-21ebcdc2ff8a,Gotha,brewpub,2 Dirk-Kollmar-Straße,,,Gotha,Thüringen,99867,Germany,+49 3621 22900,http://www.oettinger-bier.de,10.6824204,50.9360985
-ed284df8-f628-41da-a7db-3e38a848daff,Günther's Gutes Bier,brewpub,7 Steinweg,,,Gera,Thüringen,07545,Germany,+49 176 34448232,http://www.facebook.com/GuenthersGutes/,12.0851059,50.8779994
-b574e687-03c2-4556-b879-f9e7f25b157c,Heimathafen,brewpub,20 Zum Güterbahnhof,,,Erfurt,Thüringen,99085,Germany,+49 361 74435041,http://www.heimathafen-bier.de,11.0494661,50.974714
-db792fe3-0def-46d2-9954-76f57436122d,Hennebergisches Museum,micro,35 Anger,,,Kloster Veßra,Thüringen,98660,Germany,+49 36873 69030,http://www.museumklostervessra.de,10.6431255,50.4918221
-84312213-f6fa-473e-bc45-bbb8f42a00a8,Köstritzer,brewpub,16 Heinrich-Schütz-Straße,,,Bad Köstritz,Thüringen,07586,Germany,+49 36605 2000,http://www.koestritzer.de,12.01464,50.93072
-ef95a099-4d7d-4cc0-95dc-ba4865396c59,Kulturbrauhaus,brewpub,1 Hirschberger Straße,,,Bad Lobenstein,Thüringen,07356,Germany,+49 36651 2141,http://www.brauhaus-lobenstein.de,11.643648,50.4515138
-5cf729c6-6ea9-4ac7-bffc-6c4b30c3f6ce,Lemnitzbräu,brewpub,24 Markt,,,Bad Lobenstein,Thüringen,07356,Germany,+49 36651 2114,http://www.destillerie-erlebnisbrauerei.de,11.63945,50.44752
-b961aa70-219d-4815-930f-a1db32d0b0fe,Marktmühle,brewpub,18 Bahnhofstraße,,,Vogtei,Thüringen,99986,Germany,+49 3601 8882100,http://www.brauereigasthof-marktmühle.de,10.4219332,51.16364799999999
-6ccd6af6-8d26-492f-b52b-0db46493a3de,Metzler,brewpub,1 An der Klinge,,,Dingsleben,Thüringen,98646,Germany,+49 36873 2840,http://www.dingslebenerbrauerei.de,10.59548,50.4313
-1abcd1b4-07c3-4e05-88f9-f65e9230e3cb,Michels Eichsfelder Braumanufaktur,brewpub,10 Oberdorf,,,Dingelstädt,Thüringen,37351,Germany,+49 36076 418042,http://www.michels-bier.de,10.4398227,51.3274072
-3b8b9431-9554-40f7-a2c9-00e735ad426a,Museums-Brauerei Schmitt,brewpub,2 Schulgasse,,,Stadtilm,Thüringen,99326,Germany,+49 3629 802556,http://www.brauerei-schmitt.de,11.0581291,50.7245182
-e08686a6-96b9-4f69-acb0-3b45fa16c404,Neunspringe,brewpub,4 Neunspringer Straße,,,Leinefelde-Worbis,Thüringen,37339,Germany,+49 36074 9790,http://www.brauerei-neunspringe.de,10.3523076,51.42608300000001
-646eaf41-fe37-4aff-9496-c3e868964cda,Papiermühle,brewpub,102 Erfurter Straße,,,Jena,Thüringen,07743,Germany,+49 3641 45980,http://www.jenaer-bier.de,11.5578462,50.93758949999999
-82465136-1c7c-476e-82d7-1f392a2c676a,Rhönbrauerei Dittmar,brewpub,6 Fuldaer Straße,,,Kaltennordheim,Thüringen,36452,Germany,+49 36966 83490,http://www.rhoenbrauerei.de,10.1569864,50.6241352
-8f0eca83-c49e-4152-9df9-4334ac296068,Rosenbrauerei,brewpub,41 Dr.-Wilhelm-Külz-Straße,,,Pößneck,Thüringen,07381,Germany,+49 3647 41090,http://www.rosenbrauerei.de,11.5828962,50.6913299
-f7aae985-ca7a-4c7a-a6b5-3ddb09bc2092,Saalfelder,brewpub,55 Pößnecker Straße,,,Saalfeld/Saale,Thüringen,07318,Germany,+49 3671 67360,http://www.brauhaus-saalfeld.de,11.3776382,50.6549562
-3686b933-1e03-44d4-b29f-b4df1f9edbcd,Schackobräu,brewpub,14 Bachstraße,,,Friedrichroda,Thüringen,99894,Germany,+49 3623 304259,http://www.brauhaus-friedrichroda.de,10.5656406,50.8552654
-ecdcf4e1-b729-49f2-8954-c857e814780f,Schloßbrauerei Schwarzbach,brewpub,1 Zur Schleuse,,,Auengrund,Thüringen,98673,Germany,+49 36878 2760,http://www.schlossbrauerei-schwarzbach.de,10.8286712,50.4839865
-7d781bd8-4b8f-40b6-b5d8-98985cd8bea1,Schmiedeknecht,brewpub,4 Geschwister-Scholl-Straße,,,Großbreitenbach,Thüringen,98701,Germany,+49 36738 42357,http://www.brauerei-schmiedeknecht.de,11.0499395,50.6288721
-e688b96c-1205-4414-94d5-80bcd14b5fad,Talschänke,brewpub,1 Am Jenzig,,,Jena,Thüringen,07749,Germany,+49 3641 2263343,http://www.talschaenke-woellnitz.de,11.6102502,50.9363074
-4245b36c-5757-4e18-bdb5-3daa40d516d3,Valentino Brauhaus,closed,7 Brühl,,,Gotha,Thüringen,99867,Germany,+49 3621 226441,http://www.valentino-brauhaus.de,10.700063,50.9497278
-de4b23e5-b5c0-435f-a7f7-d77f0d923f52,Vereinsbrauerei Apolda,brewpub,14 Topfmarkt,,,Apolda,Thüringen,99510,Germany,+49 3644 84840,http://www.vereinsbrauerei-apolda.de,11.5123124,51.0220616
-7847128b-3e3c-45a8-b143-3707cd7f80c7,Vereinsbrauerei Greiz,brewpub,60 Lindenstraße,,,Greiz,Thüringen,07973,Germany,+49 3661 6100,http://www.greizer.de,12.2153314,50.6546455
-6a7ed98b-9f60-45cf-bcc1-5250aa16e724,Waldkasino,brewpub,2 Am Waldkasino,,,Erfurt,Thüringen,99096,Germany,+49 361 3456677,http://www.waldkasino.de,11.0244713,50.95644009999999
-8f371580-e021-4412-87c0-8a59c016255c,Watzdorfer,brewpub,14 Watzdorf,,,Bad Blankenburg,Thüringen,07422,Germany,+49 36741 6160,http://www.watzdorfer.de,11.23711,50.69162
-25e91cde-a3a9-4688-be8c-dad4abd96bc9,Weißenseer Ratsbräu,closed,26 Marktplatz,,,Weißensee,Thüringen,99631,Germany,+49 172 3672551,http://ratsbrauerei-weissensee.de,11.066058,51.2006637
-4d12ce58-4e3c-40f0-8542-b8b4d187e00b,Zaubierei,closed,239 Riethweg,,,Vachdorf,Thüringen,98617,Germany,,http://www.zaubierei.de,10.53141,50.52603999999999
-42a7d36e-7ecd-4cc4-a60d-9f8a8f8e9937,Zur Goldenen Henne,brewpub,17 Queckgasse,,,Grabfeld,Thüringen,98631,Germany,+49 171 5829751,http://www.brauerei-juechsen.de,10.4971834,50.4802512
+783328ef-b388-445a-bb53-9b66c6f132f8,Altenburger,brewpub,Brauereistraße 20,,,Altenburg,Thüringen,04600,Germany,+49 3447 31290,http://www.brauerei-altenburg.de,12.4368298,51.0006734
+9e16fd00-e490-47d0-a8ad-046a954bec87,Ankerbräu,brewpub,Steinbächlein 6A,,,Steinach,Thüringen,96523,Germany,+49 171 6294017,http://www.ankerla.de,11.1549309,50.4329505
+1fc7b88c-bafb-4e5f-8c34-e8de2522b1e7,Brauhaus zum Löwen,brewpub,Felchtaer Straße 2-4,,,Mühlhausen/Thüringen,Thüringen,99974,Germany,+49 3601 4710,http://www.brauhaus-zum-loewen.de,10.4574616,51.2075459
+bba27afa-5e9b-4c5c-92d4-5ae0d8d1038b,Braukeller Erfurt,brewpub,Fischmarkt 5,,,Erfurt,Thüringen,99084,Germany,+49 361 21846054,http://www.braukeller-erfurt.de,11.0282588,50.97747409999999
+2fbc0b69-05da-4996-9856-43e610da5210,Braumanufaktur Schmalkalden,brewpub,Weidebrunner Gasse 8,,,Schmalkalden,Thüringen,98574,Germany,,http://www.braumanufaktur-schmalkalden.de,10.45262,50.72356
+eacf4733-9043-4640-9462-17cb9cd15181,Brauner Hirsch,brewpub,Sophienhof 16,,,Harztor,Thüringen,99768,Germany,+49 36331 48144,http://www.braunerhirsch-sophienhof.de,10.7909324,51.63462149999999
+d8419492-6b11-4300-8bf0-5c6d57fc3f25,Brauverein Buchfart,brewpub,Weimarische Straße 1,,,Buchfart,Thüringen,99438,Germany,+49 3643 495935,http://www.buchfarter-muehle.de,11.3326392,50.921529
+81201e0b-e5e4-40c5-8773-bfb4a8719dc9,Ehringsdorfer,brewpub,Hainweg 13,,,Weimar,Thüringen,99425,Germany,+49 3643 8760,http://www.ehringsdorfer.de,11.3499,50.95808
+699fa600-57e9-41bf-b902-05f9ff67068c,Gessner,brewpub,Am Lindenbach 27,,,Sonneberg,Thüringen,96515,Germany,+49 3675 40790,http://www.privatbrauerei-gessner.de,11.20887,50.34494
+9ffa71b6-5111-49fb-8b41-21ebcdc2ff8a,Gotha,brewpub,Dirk-Kollmar-Straße 2,,,Gotha,Thüringen,99867,Germany,+49 3621 22900,http://www.oettinger-bier.de,10.6824204,50.9360985
+ed284df8-f628-41da-a7db-3e38a848daff,Günther's Gutes Bier,brewpub,Steinweg 7,,,Gera,Thüringen,07545,Germany,+49 176 34448232,http://www.facebook.com/GuenthersGutes/,12.0851059,50.8779994
+b574e687-03c2-4556-b879-f9e7f25b157c,Heimathafen,brewpub,Zum Güterbahnhof 20,,,Erfurt,Thüringen,99085,Germany,+49 361 74435041,http://www.heimathafen-bier.de,11.0494661,50.974714
+db792fe3-0def-46d2-9954-76f57436122d,Hennebergisches Museum,micro,Anger 35,,,Kloster Veßra,Thüringen,98660,Germany,+49 36873 69030,http://www.museumklostervessra.de,10.6431255,50.4918221
+84312213-f6fa-473e-bc45-bbb8f42a00a8,Köstritzer,brewpub,Heinrich-Schütz-Straße 16,,,Bad Köstritz,Thüringen,07586,Germany,+49 36605 2000,http://www.koestritzer.de,12.01464,50.93072
+ef95a099-4d7d-4cc0-95dc-ba4865396c59,Kulturbrauhaus,brewpub,Hirschberger Straße 1,,,Bad Lobenstein,Thüringen,07356,Germany,+49 36651 2141,http://www.brauhaus-lobenstein.de,11.643648,50.4515138
+5cf729c6-6ea9-4ac7-bffc-6c4b30c3f6ce,Lemnitzbräu,brewpub,Markt 24,,,Bad Lobenstein,Thüringen,07356,Germany,+49 36651 2114,http://www.destillerie-erlebnisbrauerei.de,11.63945,50.44752
+b961aa70-219d-4815-930f-a1db32d0b0fe,Marktmühle,brewpub,Bahnhofstraße 18,,,Vogtei,Thüringen,99986,Germany,+49 3601 8882100,http://www.brauereigasthof-marktmühle.de,10.4219332,51.16364799999999
+6ccd6af6-8d26-492f-b52b-0db46493a3de,Metzler,brewpub,An der Klinge 1,,,Dingsleben,Thüringen,98646,Germany,+49 36873 2840,http://www.dingslebenerbrauerei.de,10.59548,50.4313
+1abcd1b4-07c3-4e05-88f9-f65e9230e3cb,Michels Eichsfelder Braumanufaktur,brewpub,Oberdorf 10,,,Dingelstädt,Thüringen,37351,Germany,+49 36076 418042,http://www.michels-bier.de,10.4398227,51.3274072
+3b8b9431-9554-40f7-a2c9-00e735ad426a,Museums-Brauerei Schmitt,brewpub,Schulgasse 2,,,Stadtilm,Thüringen,99326,Germany,+49 3629 802556,http://www.brauerei-schmitt.de,11.0581291,50.7245182
+e08686a6-96b9-4f69-acb0-3b45fa16c404,Neunspringe,brewpub,Neunspringer Straße 4,,,Leinefelde-Worbis,Thüringen,37339,Germany,+49 36074 9790,http://www.brauerei-neunspringe.de,10.3523076,51.42608300000001
+646eaf41-fe37-4aff-9496-c3e868964cda,Papiermühle,brewpub,Erfurter Straße 102,,,Jena,Thüringen,07743,Germany,+49 3641 45980,http://www.jenaer-bier.de,11.5578462,50.93758949999999
+82465136-1c7c-476e-82d7-1f392a2c676a,Rhönbrauerei Dittmar,brewpub,Fuldaer Straße 6,,,Kaltennordheim,Thüringen,36452,Germany,+49 36966 83490,http://www.rhoenbrauerei.de,10.1569864,50.6241352
+8f0eca83-c49e-4152-9df9-4334ac296068,Rosenbrauerei,brewpub,Dr.-Wilhelm-Külz-Straße 41,,,Pößneck,Thüringen,07381,Germany,+49 3647 41090,http://www.rosenbrauerei.de,11.5828962,50.6913299
+f7aae985-ca7a-4c7a-a6b5-3ddb09bc2092,Saalfelder,brewpub,Pößnecker Straße 55,,,Saalfeld/Saale,Thüringen,07318,Germany,+49 3671 67360,http://www.brauhaus-saalfeld.de,11.3776382,50.6549562
+3686b933-1e03-44d4-b29f-b4df1f9edbcd,Schackobräu,brewpub,Bachstraße 14,,,Friedrichroda,Thüringen,99894,Germany,+49 3623 304259,http://www.brauhaus-friedrichroda.de,10.5656406,50.8552654
+ecdcf4e1-b729-49f2-8954-c857e814780f,Schloßbrauerei Schwarzbach,brewpub,Zur Schleuse 1,,,Auengrund,Thüringen,98673,Germany,+49 36878 2760,http://www.schlossbrauerei-schwarzbach.de,10.8286712,50.4839865
+7d781bd8-4b8f-40b6-b5d8-98985cd8bea1,Schmiedeknecht,brewpub,Geschwister-Scholl-Straße 4,,,Großbreitenbach,Thüringen,98701,Germany,+49 36738 42357,http://www.brauerei-schmiedeknecht.de,11.0499395,50.6288721
+e688b96c-1205-4414-94d5-80bcd14b5fad,Talschänke,brewpub,Am Jenzig 1,,,Jena,Thüringen,07749,Germany,+49 3641 2263343,http://www.talschaenke-woellnitz.de,11.6102502,50.9363074
+4245b36c-5757-4e18-bdb5-3daa40d516d3,Valentino Brauhaus,closed,Brühl 7,,,Gotha,Thüringen,99867,Germany,+49 3621 226441,http://www.valentino-brauhaus.de,10.700063,50.9497278
+de4b23e5-b5c0-435f-a7f7-d77f0d923f52,Vereinsbrauerei Apolda,brewpub,Topfmarkt 14,,,Apolda,Thüringen,99510,Germany,+49 3644 84840,http://www.vereinsbrauerei-apolda.de,11.5123124,51.0220616
+7847128b-3e3c-45a8-b143-3707cd7f80c7,Vereinsbrauerei Greiz,brewpub,Lindenstraße 60,,,Greiz,Thüringen,07973,Germany,+49 3661 6100,http://www.greizer.de,12.2153314,50.6546455
+6a7ed98b-9f60-45cf-bcc1-5250aa16e724,Waldkasino,brewpub,Am Waldkasino 2,,,Erfurt,Thüringen,99096,Germany,+49 361 3456677,http://www.waldkasino.de,11.0244713,50.95644009999999
+8f371580-e021-4412-87c0-8a59c016255c,Watzdorfer,brewpub,Watzdorf 14,,,Bad Blankenburg,Thüringen,07422,Germany,+49 36741 6160,http://www.watzdorfer.de,11.23711,50.69162
+25e91cde-a3a9-4688-be8c-dad4abd96bc9,Weißenseer Ratsbräu,closed,Marktplatz 26,,,Weißensee,Thüringen,99631,Germany,+49 172 3672551,http://ratsbrauerei-weissensee.de,11.066058,51.2006637
+4d12ce58-4e3c-40f0-8542-b8b4d187e00b,Zaubierei,closed,Riethweg 239,,,Vachdorf,Thüringen,98617,Germany,,http://www.zaubierei.de,10.53141,50.52603999999999
+42a7d36e-7ecd-4cc4-a60d-9f8a8f8e9937,Zur Goldenen Henne,brewpub,Queckgasse 17,,,Grabfeld,Thüringen,98631,Germany,+49 171 5829751,http://www.brauerei-juechsen.de,10.4971834,50.4802512


### PR DESCRIPTION
- Use the correct spelling "Straße"
- Move the house number to the end of the address