### PR TITLE
data: update Exhibit 'A' Brewing Co. for Framingham→Williamsburg move

### DIFF
--- a/breweries.csv
+++ b/breweries.csv
@@ -3792,7 +3792,7 @@ fe4a7fe6-9a1a-4e6b-8a7b-d4ddd6ad0efd,Evolution Craft Brewing Co. & Public House,
 68ecfe89-fccb-4419-ae21-5fa676e98542,Exchange Brewery,micro,7 Queen St,,,Niagara-on-the-Lake,Ontario,L0S 1J0,Canada,9056844440.0,http://exchangebrewery.com,,
 75a21a02-9de8-4c47-98ad-86b631186a15,Exeter Brewing Co,brewpub,156 Epping Rd,,,Exeter,New Hampshire,03833,United States,6036867253,https://www.exeterbrewing.co/,,
 9e2133f8-4aba-4b9b-830f-13f9c3626c44,Exferimentation Brewing Company,micro,7 N Saginaw St,,,Pontiac,Michigan,48342-2182,United States,2486481377,http://www.exferimentationbrewing.com,-83.292346,42.6369922
-cbc96b9c-6ff0-4172-8bbd-02f4a55ab5bc,Exhibit 'A' Brewing Co.,micro,81 Morton St,,,Framingham,Massachusetts,01702-7153,United States,,http://www.exhibit-A-brewing.com,-71.40187088,42.27880435
+cbc96b9c-6ff0-4172-8bbd-02f4a55ab5bc,Exhibit 'A' Brewing Co.,micro,4 Main St,,,Williamsburg,Massachusetts,01096,United States,,https://exhibitabrewing.com,-72.730506,42.392397
 7a156b9c-1010-4774-ab03-3f401a22089c,Exile Brewing,micro,1514 Walnut St,,,Des Moines,Iowa,50309-3420,United States,5158832337,http://www.exilebrewing.com,-93.63702159,41.5830167
 ad3eac47-5589-4d11-a8cf-f118895fe7f7,Exit 6 Brewery,micro,5055 Highway N Ste 112,,,Saint Charles,Missouri,63304-8031,United States,6362444343,http://www.exit6brewery.com,-90.639934,38.745126
 38b01e10-3aac-4226-b30f-bb568f0e41bc,Exit Strategy Brewing Company,brewpub,7700 Madison St,,,Forest Park,Illinois,60130-1404,United States,7086898771,http://www.exitstrategybrewing.com,-87.8108065,41.8795262

--- a/data/united-states/massachusetts.csv
+++ b/data/united-states/massachusetts.csv
@@ -60,7 +60,7 @@ e1e4d221-608a-4a65-9a55-4f142ffb57d8,Down the Road Brewery,micro,199 Ashland Str
 cfff9480-fc9e-4ac6-addc-f64fbb834fef,Drunken Rabbit Brewing,micro,749A New Ludlow Rd,,,South Hadley,Massachusetts,01020,United States,4137282739,http://www.rabbit.beer,-72.553245,42.217914
 be78f4a5-2c4a-426b-8aa6-3577b0bde2ad,Element Brewing Co,micro,16 Bridge St,,,Millers Falls,Massachusetts,01349-1336,United States,4138356340,http://www.elementbeer.com,-72.49516039,42.57950929
 3f8ad1a4-2cc8-4851-96f2-958f401ea4f0,Entitled Beer Company,proprietor,21 North St,,,Hingham,Massachusetts,02043-,United States,7817401035,http://www.entitledbrewing.com,-70.88618473,42.24360723
-cbc96b9c-6ff0-4172-8bbd-02f4a55ab5bc,Exhibit 'A' Brewing Co.,micro,81 Morton St,,,Framingham,Massachusetts,01702-7153,United States,,http://www.exhibit-A-brewing.com,-71.40187088,42.27880435
+cbc96b9c-6ff0-4172-8bbd-02f4a55ab5bc,Exhibit 'A' Brewing Co.,micro,4 Main St,,,Williamsburg,Massachusetts,01096,United States,,https://exhibitabrewing.com,-72.7305060,42.3923970
 b0c89b8a-6de3-4101-8a00-a7e8fbba8d7f,Fieldcrest Brewing Company,micro,2343 Boston Rd,,,Wilbraham,Massachusetts,01095,United States,4135963632,https://www.fieldcrestbrewing.com,-72.458583,42.150402
 c7fc7b32-5632-4336-88eb-1c30b02c9892,Fieldcrest Brewing Company,micro,11 E Main St,,,Ware,Massachusetts,01082,United States,4135107562,https://www.fieldcrestbrewing.com,-72.238636,42.259466
 942a943c-ddf3-4a7c-984b-2176a1ba8834,Flying Dreams Brewing Co.,closed,455B Park Ave,,,Worcester,Massachusetts,01610,United States,5089268251,http://www.flyingdreamsbrewing.com,-71.82618857,42.25419957


### PR DESCRIPTION
## Update: Exhibit 'A' Brewing Co. — relocation

Exhibit 'A' Brewing Co. has moved from Framingham, MA to a new space in Williamsburg, MA. Confirmed via the brewery's [official site](https://exhibitabrewing.com/) and [NBC Boston](https://www.nbcboston.com/news/local/award-winning-massachusetts-brewery-moving-to-new-location/3436065/).

Record `cbc96b9c-6ff0-4172-8bbd-02f4a55ab5bc` in `data/united-states/massachusetts.csv`.

| Field | Old | New |
|-------|-----|-----|
| address_1 | `81 Morton St` | `4 Main St` |
| city | `Framingham` | `Williamsburg` |
| postal_code | `01702-7153` | `01096` |
| longitude | `-71.40187088` | `-72.730506` |
| latitude | `42.27880435` | `42.392397` |
| website_url | `http://www.exhibit-A-brewing.com` | `https://exhibitabrewing.com` |

Coordinates from a Geocodio rooftop match (accuracy 1.00), confirmed to return Williamsburg, MA. `npm run validate` passes; `breweries.csv` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)