### PR TITLE
Add Brujos Brewing - Portland, OR

### DIFF
--- a/data/united-states/oregon.csv
+++ b/data/united-states/oregon.csv
@@ -54,6 +54,7 @@ cfac009a-caae-4462-beb3-1f603674e2a6,Brewery 26,micro,5829 SE Powell Blvd,,,Port
 433a8b85-87b2-4b73-87c9-c2c35570a544,Bricktowne Brewing Co,brewpub,111 E 8th St,,,Medford,Oregon,97501-7201,United States,5419732377,http://www.bricktownebeer.com,-122.8721525,42.32544541
 589c2190-6d97-4f2b-802d-2eaa6b282baf,Bridge 99 Brewery,micro,63063 Layton Ave,,,Bend,Oregon,97701-7087,United States,5412801690,,-121.2916707,44.09103738
 e635be49-6e8e-4697-a457-f8febe304d66,BridgePort Brewing Co,regional,1318 NW Northrup St,,,Portland,Oregon,97209-2808,United States,5032417179,http://www.bridgeportbrew.com,-122.6848601,45.53133335
+05282df2-6c22-431c-9b16-6de6007a314e,Brujos Brewing,micro,2377 NW Wilson St,,,Portland,Oregon,97217,United States,,https://www.brujosbrewing.com,-122.7001981,45.5377961
 3cb1a817-c050-4afc-af5e-40d83e9e2e84,Bunsenbrewer,brewpub,16506 362nd Dr,,,Sandy,Oregon,97055-9279,United States,5033083150,http://www.bunsenbrewer.com,-122.2904067,45.4042245
 43cc17d8-347f-4d72-9a2c-fdc75e562b77,Buoy Beer Company,micro,1 8th St,,,Astoria,Oregon,97103-4506,United States,5033254540,http://www.buoybeer.com,-123.835151,46.1913235
 94570768-e3ca-4d69-a292-35dea27a24c9,Burnside Brewing Co,micro,701 E Burnside St,,,Portland,Oregon,97214-1218,United States,5032083476,http://www.burnsidebrewco.com,-122.6584695,45.5233261


### PR DESCRIPTION
## Summary

Adds [Brujos Brewing](https://www.brujosbrewing.com) to the Oregon dataset. They're a microbrewery in Portland's Overlook neighborhood.

**Details:**
- Name: Brujos Brewing
- Type: micro
- Address: 2377 NW Wilson St, Portland, OR 97217
- Website: https://www.brujosbrewing.com
- Coordinates: 45.5377961, -122.7001981

## Verification

- Confirmed active via website
- Address geocoded via OpenStreetMap Nominatim
- Inserted in alphabetical order in `data/united-states/oregon.csv`