### PR TITLE
Add Original Beer Company (Paju, Gyeonggido, South Korea)

### DIFF
--- a/data/south-korea/gyeonggido.csv
+++ b/data/south-korea/gyeonggido.csv
@@ -8,3 +8,4 @@ cfa85b4b-30b6-4775-8e83-33339b8f877f,에잇피플브루어리(Eight People Brewe
 2056bc4b-2844-4128-a406-fca7a1dca89b,펜더멘탈 브루어리(Fundamental Brewing Co.),brewpub,"61, Maeyeong-ro 269beon-gil",Yeongtong-gu,,Suwon-si,Gyeonggido,16523,South Korea,050-71319-7808,https://www.instagram.com/fundamental_brewing_co/,127.0677246,37.25978047
 57a70f5c-a995-4be1-949c-99244450940f,플레이그라운드 브루어리(playground Brewery),brewpub,"246-13, Isanpo-gil",Ilsanseo-gu,,Goyang-si,Gyeonggido,10203,South Korea,031-912-2463,https://www.playgroundbrewery.com/,126.7020113,37.66779467
 6f317bdc-458e-466f-bd2a-9ab398d46631,헤이스탁 브루어리(Haystack Brewery),brewpub,"25, Pangyogongwon-ro 3-gil",Bundang-gu,,Seongnam-si,Gyeonggido,13477,South Korea,070-7631-1110,,127.0890607,37.39125615
+,오리지널비어컴퍼니(Original Beer Company),micro,"377, Hwangsobawi-gil",Wollong-myeon,,Paju-si,Gyeonggido,10945,South Korea,070-7726-2356,https://originalbeer.co.kr/,,


### PR DESCRIPTION
### Summary
Adds 오리지널비어컴퍼니 (Original Beer Company) as a single new micro brewery row for Paju-si, Gyeonggido, South Korea.

This is the Paju production brewery only. The Seoul (Samsung-dong / Gangnam) location on the company site is a retail/office flagship, not a second brewery, so it is intentionally omitted.

### Sources
- Company website (address, phone, URL): https://originalbeer.co.kr/
  - Footer: 파주 양조장 경기도 파주시 월롱면 황소바위길 377; TEL 070-7726-2356
- JobKorea (same Paju address; incorporation context 2019):
  - https://www.jobkorea.co.kr/recruit/co_read/c/obc01377
- Asia Brewers Network (founded 2019):
  - https://asiabrewersnetwork.com/news/koreas-original-beer-company-launches-its-first-canned-lagers
- Korea Herald (Paju launch):
  - https://www.koreaherald.com/article/2412316

### Field notes
- `id` left empty per OBDB new-row practice
- `postal_code` 10945 from road-name match for 황소바위길 377
- longitude/latitude left blank (no confident geocode)
- No awards fields invented

### Checklist
- [x] Confirmed not already in `gyeonggido.csv`
- [x] Header match / quoted `address_1`
- [x] One brewery only (no Seoul retail row)